### PR TITLE
Allow setting defaults for controlled props

### DIFF
--- a/packages/studio-app/src/components/StudioEditor/PageFileEditor/BindingEditor.tsx
+++ b/packages/studio-app/src/components/StudioEditor/PageFileEditor/BindingEditor.tsx
@@ -186,6 +186,7 @@ function getInitialBindingType(
 }
 
 export interface BindingEditorProps<V> extends WithControlledProp<StudioBindable<V> | null> {
+  disabled?: boolean;
   bindingId: string;
   nodeId: NodeId;
   prop: string;
@@ -193,6 +194,7 @@ export interface BindingEditorProps<V> extends WithControlledProp<StudioBindable
 }
 
 export function BindingEditor<V>({
+  disabled,
   bindingId,
   nodeId,
   prop,
@@ -238,7 +240,12 @@ export function BindingEditor<V>({
 
   return (
     <React.Fragment>
-      <IconButton size="small" onClick={handleOpen} color={hasBinding ? 'primary' : 'inherit'}>
+      <IconButton
+        disabled={disabled}
+        size="small"
+        onClick={handleOpen}
+        color={hasBinding ? 'primary' : 'inherit'}
+      >
         {hasBinding ? <LinkIcon fontSize="inherit" /> : <LinkOffIcon fontSize="inherit" />}
       </IconButton>
       <Dialog onClose={handleClose} open={open} fullWidth scroll="body">

--- a/packages/studio-app/src/components/StudioEditor/PageFileEditor/ComponentPropEditor.tsx
+++ b/packages/studio-app/src/components/StudioEditor/PageFileEditor/ComponentPropEditor.tsx
@@ -45,6 +45,10 @@ export function BindableEditor<V>({
     [onChange],
   );
 
+  // NOTE: Doesn't make much sense to bind controlled props. In the future we might opt
+  // to make them bindable to other controlled props only
+  const isBindable = !argType.onChangeHandler;
+
   const controlSpec = argType.control ?? getDefaultControl(argType.typeDef);
   const control = controlSpec ? studioPropControls[controlSpec.type] : null;
 
@@ -87,6 +91,7 @@ export function BindableEditor<V>({
             propType={argType.typeDef}
             value={value}
             onChange={onChange}
+            disabled={!isBindable}
           />
         </React.Fragment>
       ) : (

--- a/packages/studio-app/src/renderPageCode.ts
+++ b/packages/studio-app/src/renderPageCode.ts
@@ -179,7 +179,7 @@ class Context implements RenderContext {
   ): ControlledStateHook {
     const nodeId = node.id;
     const nodeName = node.name;
-    const stateId = `${nodeId}.${propName}`;
+    const stateId = `${nodeId}.props.${propName}`;
 
     let stateHook = this.controlledStateHooks.get(stateId);
     if (!stateHook) {
@@ -201,12 +201,15 @@ class Context implements RenderContext {
       const setStateVarSuggestion = camelCase('set', nodeName, propName);
       const setStateVar = this.moduleScope.createUniqueBinding(setStateVarSuggestion);
 
+      const propValue = node.props[propName];
+      const defaultValue = propValue?.type === 'const' ? propValue.value : argType.defaultValue;
+
       stateHook = {
         nodeName,
         propName,
         stateVar,
         setStateVar,
-        defaultValue: argType.defaultValue,
+        defaultValue,
       };
       this.controlledStateHooks.set(stateId, stateHook);
     }
@@ -340,7 +343,7 @@ class Context implements RenderContext {
           return;
         }
 
-        const stateId = `${node.id}.${propName}`;
+        const stateId = `${node.id}.props.${propName}`;
         const hook = this.controlledStateHooks.get(stateId);
 
         if (!hook) {


### PR DESCRIPTION
* Disable databinding fro controlled props. This is an advanced databinding scenario that we probably shouldn't give priority right now. Only useful in the case you want to build something like a two way F to C convertor or something.
* Use user provided prop value as default value for controlled props