### PR TITLE
Add sx prop, create default page structure

### DIFF
--- a/packages/studio-app/src/components/StudioEditor/HierarchyExplorer/CreateStudioPageDialog.tsx
+++ b/packages/studio-app/src/components/StudioEditor/HierarchyExplorer/CreateStudioPageDialog.tsx
@@ -20,7 +20,7 @@ export interface CreateStudioPageDialogProps {
 export default function CreateStudioPageDialog({ onClose, ...props }: CreateStudioPageDialogProps) {
   const dom = useDom();
   const domApi = useDomApi();
-  const [title, setTitle] = React.useState('');
+  const [name, setName] = React.useState('');
   const navigate = useNavigate();
 
   return (
@@ -29,30 +29,44 @@ export default function CreateStudioPageDialog({ onClose, ...props }: CreateStud
         onSubmit={(e) => {
           e.preventDefault();
           const newNode = studioDom.createNode(dom, 'page', {
+            name,
             attributes: {
-              title: studioDom.createConst(title),
+              title: studioDom.createConst(name),
               urlQuery: studioDom.createConst({}),
             },
           });
           const appNode = studioDom.getApp(dom);
           domApi.addNode(newNode, appNode, 'pages');
+
+          const container = studioDom.createElement(dom, 'Container', {
+            sx: studioDom.createConst({ my: 2 }),
+          });
+          domApi.addNode(container, newNode, 'children');
+
+          const stack = studioDom.createElement(dom, 'Stack', {
+            gap: studioDom.createConst(2),
+            direction: studioDom.createConst('column'),
+            alignItems: studioDom.createConst('stretch'),
+          });
+          domApi.addNode(stack, container, 'children');
+
           onClose();
           navigate(`/editor/pages/${newNode.id}`);
         }}
       >
-        <DialogTitle>Create a new MUI Studio API</DialogTitle>
+        <DialogTitle>Create a new MUI Studio Page</DialogTitle>
         <DialogContent>
           <TextField
             sx={{ my: 1 }}
             autoFocus
             fullWidth
-            label="title"
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
+            label="name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
           />
         </DialogContent>
         <DialogActions>
-          <Button type="submit" disabled={!title}>
+          <Button type="submit" disabled={!name}>
             Create
           </Button>
         </DialogActions>

--- a/packages/studio-app/src/components/StudioEditor/PageEditor/UrlQueryEditor.tsx
+++ b/packages/studio-app/src/components/StudioEditor/PageEditor/UrlQueryEditor.tsx
@@ -29,7 +29,9 @@ export default function UrlQueryEditor({ pageNodeId }: UrlQueryEditorProps) {
 
   return (
     <React.Fragment>
-      <Button onClick={() => setDialogOpen(true)}>URL query</Button>
+      <Button color="inherit" onClick={() => setDialogOpen(true)}>
+        URL query
+      </Button>
       <Dialog fullWidth open={dialogOpen} onClose={() => setDialogOpen(false)}>
         <DialogTitle>Edit URL query</DialogTitle>
         <DialogContent>

--- a/packages/studio-app/src/renderPageCode.ts
+++ b/packages/studio-app/src/renderPageCode.ts
@@ -492,19 +492,12 @@ class Context implements RenderContext {
       {
         children: {
           typeDef: { type: 'element' },
-          control: { type: 'slots' },
+          control: { type: 'slot' },
         },
       },
     );
 
-    const Stack = this.addImport('@mui/material', 'Stack', 'Stack');
-
-    const rendered = `
-      <${Stack} direction="column" gap={2} m={2}>
-        ${this.renderJsxContent(resolvedChildren.children)}
-      </${Stack}>
-    `;
-
+    const rendered = this.renderJsExpression(resolvedChildren.children);
     const expr = this.wrapComponent(node, rendered);
     return this.renderJsExpression(expr);
   }

--- a/packages/studio-app/src/server/data.ts
+++ b/packages/studio-app/src/server/data.ts
@@ -16,17 +16,35 @@ const prisma = new PrismaClient();
 
 type Updates<O extends { id: string }> = Partial<O> & Pick<O, 'id'>;
 
-function createDefaultApp(): studioDom.StudioDom {
-  let dom = studioDom.createDom();
+function createDefaultPage(dom: studioDom.StudioDom, name: string): studioDom.StudioDom {
   const page = studioDom.createNode(dom, 'page', {
-    name: 'DefaultPage',
+    name,
     attributes: {
-      title: studioDom.createConst('Default'),
+      title: studioDom.createConst(name),
       urlQuery: studioDom.createConst({}),
     },
   });
   const app = studioDom.getApp(dom);
   dom = studioDom.addNode(dom, page, app, 'pages');
+
+  const container = studioDom.createElement(dom, 'Container', {
+    sx: studioDom.createConst({ my: 2 }),
+    direction: studioDom.createConst('column'),
+    alignItems: studioDom.createConst('stretch'),
+  });
+  dom = studioDom.addNode(dom, container, page, 'children');
+
+  const stack = studioDom.createElement(dom, 'Stack', {
+    gap: studioDom.createConst(2),
+  });
+  dom = studioDom.addNode(dom, stack, container, 'children');
+
+  return dom;
+}
+
+function createDefaultApp(): studioDom.StudioDom {
+  let dom = studioDom.createDom();
+  dom = createDefaultPage(dom, 'DefaultPage');
   return dom;
 }
 

--- a/packages/studio-app/src/studioComponents/Button.tsx
+++ b/packages/studio-app/src/studioComponents/Button.tsx
@@ -22,5 +22,8 @@ export default {
       typeDef: { type: 'string', enum: ['primary', 'secondary'] },
       defaultValue: 'primary',
     },
+    sx: {
+      typeDef: { type: 'object' },
+    },
   },
 } as StudioComponentDefinition;

--- a/packages/studio-app/src/studioComponents/Container.tsx
+++ b/packages/studio-app/src/studioComponents/Container.tsx
@@ -10,5 +10,8 @@ export default {
       typeDef: { type: 'element' },
       control: { type: 'slot' },
     },
+    sx: {
+      typeDef: { type: 'object' },
+    },
   },
 } as StudioComponentDefinition;

--- a/packages/studio-app/src/studioComponents/DataGrid.tsx
+++ b/packages/studio-app/src/studioComponents/DataGrid.tsx
@@ -21,5 +21,8 @@ export default {
     density: {
       typeDef: { type: 'string', enum: ['comfortable', 'compact', 'standard'] },
     },
+    sx: {
+      typeDef: { type: 'object' },
+    },
   },
 } as StudioComponentDefinition;

--- a/packages/studio-app/src/studioComponents/Paper.tsx
+++ b/packages/studio-app/src/studioComponents/Paper.tsx
@@ -14,5 +14,8 @@ export default {
       typeDef: { type: 'element' },
       control: { type: 'slot' },
     },
+    sx: {
+      typeDef: { type: 'object' },
+    },
   },
 } as StudioComponentDefinition;

--- a/packages/studio-app/src/studioComponents/Select.tsx
+++ b/packages/studio-app/src/studioComponents/Select.tsx
@@ -10,13 +10,13 @@ export default {
     const Select = ctx.addImport('@mui/material', 'Select', 'Select');
     const MenuItem = ctx.addImport('@mui/material', 'MenuItem', 'MenuItem');
 
-    const { label, options, ...props } = resolvedProps;
+    const { sx, label, options, ...props } = resolvedProps;
 
     // TODO: generate a unique id based on node name
     const labelId = 'my-select';
 
     return `
-      <${FormControl} size="small">
+      <${FormControl} size="small" ${ctx.renderProps({ sx })}>
         <${InputLabel} id="${labelId}">${ctx.renderJsxContent(label)}</${InputLabel}>
         <${Select} 
           labelId="${labelId}" 
@@ -59,6 +59,9 @@ export default {
       typeDef: { type: 'array' },
       control: { type: 'json', schema: URI_SELECT_OPTIONS },
       defaultValue: [],
+    },
+    sx: {
+      typeDef: { type: 'object' },
     },
   },
 } as StudioComponentDefinition;

--- a/packages/studio-app/src/studioComponents/Stack.tsx
+++ b/packages/studio-app/src/studioComponents/Stack.tsx
@@ -12,7 +12,6 @@ export default {
     },
     margin: {
       typeDef: { type: 'number' },
-      defaultValue: 1,
     },
     direction: {
       typeDef: {

--- a/packages/studio-app/src/studioComponents/TextField.tsx
+++ b/packages/studio-app/src/studioComponents/TextField.tsx
@@ -27,5 +27,8 @@ export default {
       defaultValue: '',
       defaultValueProp: 'defaultValue',
     },
+    sx: {
+      typeDef: { type: 'object' },
+    },
   },
 } as StudioComponentDefinition;

--- a/packages/studio-app/src/studioComponents/Typography.tsx
+++ b/packages/studio-app/src/studioComponents/Typography.tsx
@@ -16,5 +16,8 @@ export default {
         enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2'],
       },
     },
+    sx: {
+      typeDef: { type: 'object' },
+    },
   },
 } as StudioComponentDefinition;


### PR DESCRIPTION
- Make the page just a component that accepts one single child.
- What we previously rendered as the default page structure => initialize it as DOM when a page is created (`Container` with some margin and a vertical `Stack` inside). if the user wants something else they can delete this default structure. in the future we could think of creating page templates that initalize a page with some layout.
- add `sx` prop to all components (just a JSON editor for now, but we can build something custom on top of this)

This should make sure that when we move to a drag&drop UX that automatically creates stacks, we can do that in a backwards compatible way