### PR TITLE
Clean up schema + incremental versioning

### DIFF
--- a/packages/studio-app/pages/api/data/[appId]/release/[version]/[queryId].ts
+++ b/packages/studio-app/pages/api/data/[appId]/release/[version]/[queryId].ts
@@ -5,6 +5,6 @@ import { asArray } from '../../../../../../src/utils/collections';
 
 export default (async (req, res) => {
   const [appId] = asArray(req.query.appId);
-  const [release] = asArray(req.query.release);
-  await handleDataRequest(req, res, { appId, release });
+  const [version] = asArray(req.query.version);
+  await handleDataRequest(req, res, { appId, release: Number(version) });
 }) as NextApiHandler<StudioApiResult<any>>;

--- a/packages/studio-app/pages/api/deploy/[appId]/[pageId].ts
+++ b/packages/studio-app/pages/api/deploy/[appId]/[pageId].ts
@@ -16,7 +16,7 @@ export default (async (req, res) => {
 
   const [pageId] = asArray(req.query.pageId);
   const { code: html } = renderPageHtml({
-    entry: `/api/release/${appId}/${activeDeployment.version}/${pageId}/entry`,
+    entry: `/api/release/${appId}/${activeDeployment.release.version}/${pageId}/entry`,
     importMap: getImportMap(),
   });
   res.setHeader('content-type', 'text/html');

--- a/packages/studio-app/pages/api/release/[appId]/[version]/[pageId]/page.ts
+++ b/packages/studio-app/pages/api/release/[appId]/[version]/[pageId]/page.ts
@@ -10,7 +10,7 @@ export default (async (req, res) => {
   const [appId] = asArray(req.query.appId);
   const [version] = asArray(req.query.version);
   const [pageId] = asArray(req.query.pageId);
-  const dom = await loadReleaseDom(appId, version);
+  const dom = await loadReleaseDom(appId, Number(version));
 
   const { code: page } = renderPageCode(appId, dom, pageId as NodeId, {
     release: version,

--- a/packages/studio-app/pages/api/release/[appId]/[version]/[pageId]/theme.ts
+++ b/packages/studio-app/pages/api/release/[appId]/[version]/[pageId]/theme.ts
@@ -8,7 +8,7 @@ import { asArray } from '../../../../../../src/utils/collections';
 export default (async (req, res) => {
   const [appId] = asArray(req.query.appId);
   const [version] = asArray(req.query.version);
-  const dom = await loadReleaseDom(appId, version);
+  const dom = await loadReleaseDom(appId, Number(version));
 
   const { code: theme } = renderThemeCode(dom);
 

--- a/packages/studio-app/pages/api/release/[appId]/[version]/components/[componentFile].tsx
+++ b/packages/studio-app/pages/api/release/[appId]/[version]/components/[componentFile].tsx
@@ -13,7 +13,7 @@ export default (async (req, res) => {
 
   const { name: componentId } = path.parse(componentFile);
 
-  const dom = await loadReleaseDom(appId, version);
+  const dom = await loadReleaseDom(appId, Number(version));
 
   const codeComponent = studioDom.getMaybeNode(dom, componentId as NodeId, 'codeComponent');
 

--- a/packages/studio-app/pages/api/release/[appId]/[version]/derivedState/[derivedStateFile].tsx
+++ b/packages/studio-app/pages/api/release/[appId]/[version]/derivedState/[derivedStateFile].tsx
@@ -13,7 +13,7 @@ export default (async (req, res) => {
 
   const { name: stateId } = path.parse(derivedStateFile);
 
-  const dom = await loadReleaseDom(appId, version);
+  const dom = await loadReleaseDom(appId, Number(version));
 
   const derivedState = studioDom.getMaybeNode(dom, stateId as NodeId, 'derivedState');
 

--- a/packages/studio-app/pages/api/rpc.ts
+++ b/packages/studio-app/pages/api/rpc.ts
@@ -13,6 +13,7 @@ import {
   loadReleaseDom,
   createDeployment,
   findActiveDeployment,
+  findLastRelease,
 } from '../../src/server/data';
 import { hasOwnProperty } from '../../src/utils/collections';
 
@@ -102,6 +103,9 @@ const rpcServer = {
     }),
     loadDom: createMethod<typeof loadDom>((params) => {
       return loadDom(...params);
+    }),
+    findLastRelease: createMethod<typeof findLastRelease>((params) => {
+      return findLastRelease(...params);
     }),
   },
   mutation: {

--- a/packages/studio-app/pages/deploy/[appId]/index.tsx
+++ b/packages/studio-app/pages/deploy/[appId]/index.tsx
@@ -17,7 +17,7 @@ export function Preview({ appId }: PreviewProps) {
 
 interface DeploymentProps {
   appId: string;
-  version: string;
+  version: number;
 }
 
 function Deployment({ appId, version }: DeploymentProps) {
@@ -37,7 +37,7 @@ const Deploy: NextPage = () => {
   );
 
   return appId && activeDeployment ? (
-    <Deployment appId={appId} version={activeDeployment.version} />
+    <Deployment appId={appId} version={activeDeployment.release.version} />
   ) : (
     <Container sx={{ my: 5 }}>
       <Typography>

--- a/packages/studio-app/prisma/schema.prisma
+++ b/packages/studio-app/prisma/schema.prisma
@@ -29,9 +29,9 @@ model App {
   id   String @id @default(cuid())
   name String
 
-  nodes      DomNode[]    @relation("AppNodes")
-  releases   Release[]    @relation("AppReleases")
-  deployment Deployment[] @relation("AppDeployment")
+  nodes       DomNode[]    @relation("AppNodes")
+  releases    Release[]    @relation("AppReleases")
+  deployments Deployment[] @relation("AppDeployments")
 }
 
 model DomNode {
@@ -71,27 +71,23 @@ model DomNodeAttribute {
 }
 
 model Release {
-  id          Int          @id @default(autoincrement())
-  version     String       @unique
+  id          String       @id @default(cuid())
+  version     Int
   description String
   createdAt   DateTime     @default(now())
   snapshot    Bytes
   Deployment  Deployment[] @relation("Release")
-
-  app   App    @relation("AppReleases", fields: [appId], references: [id])
-  appId String
+  app         App          @relation("AppReleases", fields: [appId], references: [id])
+  appId       String
 
   @@unique([version, appId], name: "release_app_constraint")
 }
 
 model Deployment {
-  id        Int      @id @default(autoincrement())
+  id        String   @id @default(cuid())
   createdAt DateTime @default(now())
-  version   String
-  release   Release  @relation("Release", fields: [version], references: [version])
-
-  app   App    @relation("AppDeployment", fields: [appId], references: [id])
-  appId String
-
-  @@unique([id, appId], name: "deployment_app_constraint")
+  release   Release  @relation("Release", fields: [releaseId], references: [id])
+  releaseId String
+  app       App      @relation("AppDeployments", fields: [appId], references: [id])
+  appId     String
 }

--- a/packages/studio-app/src/components/DomLoader.tsx
+++ b/packages/studio-app/src/components/DomLoader.tsx
@@ -264,7 +264,6 @@ export interface DomContextProps {
 }
 
 export default function DomProvider({ appId, children }: DomContextProps) {
-  console.log(appId);
   const [state, dispatch] = React.useReducer(domLoaderReducer, {
     loading: false,
     saving: false,

--- a/packages/studio-app/src/components/Release.tsx
+++ b/packages/studio-app/src/components/Release.tsx
@@ -12,7 +12,7 @@ import StudioAppBar from './StudioAppBar';
 
 interface NavigateToReleaseActionProps {
   appId: string;
-  version?: string;
+  version?: number;
   pageNodeId: NodeId;
 }
 
@@ -30,7 +30,8 @@ function NavigateToReleaseAction({ appId, version, pageNodeId }: NavigateToRelea
 }
 
 export default function Release() {
-  const { version, appId } = useParams();
+  const { version: rawVersion, appId } = useParams();
+  const version = Number(rawVersion);
 
   if (!appId) {
     throw new Error(`Missing queryParam "appId"`);
@@ -69,7 +70,7 @@ export default function Release() {
     }
   }, [appId, activeDeploymentQuery, deployReleaseMutation, version]);
 
-  const isActiveDeployment = activeDeploymentQuery.data?.version === version;
+  const isActiveDeployment = activeDeploymentQuery.data?.release.version === version;
 
   const canDeploy =
     deployReleaseMutation.isIdle && activeDeploymentQuery.isSuccess && !isActiveDeployment;

--- a/packages/studio-app/src/components/Releases.tsx
+++ b/packages/studio-app/src/components/Releases.tsx
@@ -1,12 +1,25 @@
 import { Container, Typography } from '@mui/material';
 import { Box } from '@mui/system';
-import { DataGridPro, GridActionsCellItem, GridColumns, GridRowParams } from '@mui/x-data-grid-pro';
+import {
+  DataGridPro,
+  GridActionsCellItem,
+  GridColumns,
+  GridRowParams,
+  GridValueGetterParams,
+} from '@mui/x-data-grid-pro';
 import * as React from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import { useNavigate, useParams } from 'react-router-dom';
 import client from '../api';
 import StudioAppBar from './StudioAppBar';
+
+interface ReleaseRow {
+  createdAt: Date;
+  id: string;
+  version: number;
+  description: string;
+}
 
 export default function Releases() {
   const { appId } = useParams();
@@ -27,16 +40,16 @@ export default function Releases() {
   const deployReleaseMutation = client.useMutation('createDeployment');
 
   const handleDeleteClick = React.useCallback(
-    async (version: string) => {
+    async (version: number) => {
       // TODO: confirmation dialog here
-      await deleteReleaseMutation.mutateAsync([version]);
+      await deleteReleaseMutation.mutateAsync([appId, version]);
       refetch();
     },
-    [deleteReleaseMutation, refetch],
+    [appId, deleteReleaseMutation, refetch],
   );
 
   const handleDeployClick = React.useCallback(
-    async (version: string) => {
+    async (version: number) => {
       // TODO: confirmation dialog here
       await deployReleaseMutation.mutateAsync([appId, version]);
       refetch();
@@ -59,7 +72,7 @@ export default function Releases() {
         field: 'createdAt',
         headerName: 'Created',
         type: 'date',
-        valueGetter: (params) => new Date(params.value),
+        valueGetter: (params: GridValueGetterParams<string, Date>) => new Date(params.value),
       },
       {
         field: 'actions',
@@ -68,12 +81,12 @@ export default function Releases() {
           <GridActionsCellItem
             icon={<RocketLaunchIcon />}
             label="Deploy release"
-            onClick={() => handleDeployClick(params.row.version)}
+            onClick={() => handleDeployClick((params.row as ReleaseRow).version)}
           />,
           <GridActionsCellItem
             icon={<DeleteIcon />}
             label="Remove release"
-            onClick={() => handleDeleteClick(params.row.version)}
+            onClick={() => handleDeleteClick((params.row as ReleaseRow).version)}
           />,
         ],
       },

--- a/packages/studio-app/src/components/StudioEditor/index.tsx
+++ b/packages/studio-app/src/components/StudioEditor/index.tsx
@@ -82,9 +82,10 @@ interface CreateReleaseDialogProps {
 function CreateReleaseDialog({ appId, open, onClose }: CreateReleaseDialogProps) {
   const navigate = useNavigate();
 
+  const lastRelease = client.useQuery('findLastRelease', [appId]);
+
   const { handleSubmit, register, formState, reset } = useForm({
     defaultValues: {
-      version: '',
       description: '',
     },
   });
@@ -105,29 +106,30 @@ function CreateReleaseDialog({ appId, open, onClose }: CreateReleaseDialogProps)
       <DialogForm onSubmit={doSubmit}>
         <DialogTitle>Create new release</DialogTitle>
         <DialogContent>
-          <Stack spacing={1} my={1}>
-            <TextField
-              label="Version"
-              size="small"
-              fullWidth
-              {...register('version', { required: true, minLength: 1 })}
-              error={Boolean(formState.errors.version)}
-              helperText={formState.errors.version?.message}
-            />
-            <TextField
-              label="description"
-              size="small"
-              fullWidth
-              multiline
-              rows={5}
-              {...register('description')}
-              error={Boolean(formState.errors.description)}
-              helperText={formState.errors.description?.message}
-            />
-          </Stack>
+          {lastRelease.isSuccess ? (
+            <Stack spacing={1} my={1}>
+              <Typography>
+                New version: {lastRelease.data ? lastRelease.data.version + 1 : 1}
+              </Typography>
+              <TextField
+                label="description"
+                size="small"
+                fullWidth
+                multiline
+                rows={5}
+                {...register('description')}
+                error={Boolean(formState.errors.description)}
+                helperText={formState.errors.description?.message}
+              />
+            </Stack>
+          ) : null}
         </DialogContent>
         <DialogActions>
-          <LoadingButton loading={createReleaseMutation.isLoading} type="submit">
+          <LoadingButton
+            disabled={!lastRelease.isSuccess}
+            loading={createReleaseMutation.isLoading}
+            type="submit"
+          >
             Create
           </LoadingButton>
         </DialogActions>

--- a/packages/studio-app/src/server/handleDataRequest.ts
+++ b/packages/studio-app/src/server/handleDataRequest.ts
@@ -17,7 +17,7 @@ const cors = initMiddleware<any>(
 
 export interface HandleDataRequestParams {
   appId: string;
-  release: string | null;
+  release: number | null;
 }
 
 export default async (


### PR DESCRIPTION
Clean up db schema
- use cuid instead of autoincrement
- remove "version" from deployment, we can reference by id and use include to drill down the version umber
- use version numbers instead of strings and automatically increment instead of free choice