### PR TITLE
Try moving to next gen cci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 defaults: &defaults
   working_directory: /tmp/mui-studio
   docker:
-    - image: cimg/node:14
+    - image: cimg/node:14.19
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.


### PR DESCRIPTION
Got this email warning about:

>GitHub has changed which keys are supported in SSH and removed unencrypted Git protocol. Please reference the [blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/) GitHub released regarding this change.
>
>As a result of GitHub's changes, any image that is used in a job from a project created between November 2, 2021 and January 13, 2022 needs to use a version of OpenSSH that is greater than or equal to version 7.2. CircleCI has updated all [Convenience images](https://circleci.com/docs/2.0/next-gen-migration-guide/) to use at least version 7.2 of OpenSSH with the exception of the legacy Convenience images that were deprecated on December 31, 2021.