### PR TITLE
DOMloader error handler

### DIFF
--- a/packages/studio-app/src/components/StudioEditor/index.tsx
+++ b/packages/studio-app/src/components/StudioEditor/index.tsx
@@ -187,7 +187,11 @@ function EditorContent({ appId }: EditorContentProps) {
         </div>
       ) : (
         <Box flex={1} display="flex" alignItems="center" justifyContent="center">
-          <CircularProgress />
+          {domLoader.error ? (
+            <Alert severity="error">{domLoader.error}</Alert>
+          ) : (
+            <CircularProgress />
+          )}
         </Box>
       )}
       <CreateReleaseDialog


### PR DESCRIPTION
Make sure we show a message when dom loading fails (e.g. when the correct encryption keys are not provided, but some part of the DOM is encrypted)