### PR TITLE
[core] Don't need large CircleCI env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
 
 defaults: &defaults
   working_directory: /tmp/mui-studio
+  resource_class: medium
   docker:
     - image: cimg/node:14.19
 # CircleCI has disabled the cache across forks for security reasons.


### PR DESCRIPTION
Look at the "Resources" tab on the build, it seems that 2 CPUs are enough for what we use. This would mean the same default as in the other repositories we have:

<img width="1078" alt="Screenshot 2022-03-22 at 11 31 02" src="https://user-images.githubusercontent.com/3165635/159462287-520743a0-d1ac-4681-afc9-0ff349d101f7.png">

https://app.circleci.com/pipelines/github/mui/mui-studio/670/workflows/fcf2c528-09fc-4d2d-9323-158dbf30e4f0/jobs/1329/resources

<img width="943" alt="Screenshot 2022-03-22 at 11 34 07" src="https://user-images.githubusercontent.com/3165635/159462830-098b7851-3b40-4169-8a43-27b70c7f4ea3.png">

I found this by chance trying to find a solution for https://mui-org.slack.com/archives/C02EAR1R8CC/p1647936628890269?thread_ts=1647853909.860129&cid=C02EAR1R8CC.