### PR TITLE
Disallow selecting a page node

### DIFF
--- a/packages/studio-app/src/components/StudioEditor/PageEditor/RenderPanel.tsx
+++ b/packages/studio-app/src/components/StudioEditor/PageEditor/RenderPanel.tsx
@@ -737,9 +737,14 @@ export default function RenderPanel({ className }: RenderPanelProps) {
       }
 
       const newSelectedNodeId = findNodeAt(pageNodes, nodesInfo, cursorPos.x, cursorPos.y);
-      api.select(newSelectedNodeId);
+      const newSelectedNode = newSelectedNodeId && studioDom.getMaybeNode(dom, newSelectedNodeId);
+      if (newSelectedNode && studioDom.isElement(newSelectedNode)) {
+        api.select(newSelectedNodeId);
+      } else {
+        api.select(null);
+      }
     },
-    [api, pageNodes, nodesInfo, getViewCoordinates],
+    [getViewCoordinates, pageNodes, nodesInfo, dom, api],
   );
 
   const handleDelete = React.useCallback(

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,6 @@
 # https://render.com/docs/preview-environments
 previewsEnabled: false
+previewsExpireAfterDays: 3
 
 services:
   - type: web


### PR DESCRIPTION
Fixes a crash when clicking on the top 10pixels in the canvas