### PR TITLE
Match plans to the situation in the field

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,7 @@ services:
     buildCommand: yarn --frozen-lockfile --prod=false && yarn release:build
     startCommand: yarn start
     healthCheckPath: /health-check
-    plan: free
+    plan: starter plus
     # previewPlan: free
     pullRequestPreviewsEnabled: true
     envVars:
@@ -22,7 +22,7 @@ services:
 databases:
   - name: toolpad-db
     ipAllowList: []
-    plan: free
+    plan: starter
     # previewPlan: free
 
 envVarGroups:


### PR DESCRIPTION
They seem to have been updated manually in the dashboard. The render.yml is not accepted because it tries to downgrade the databse plan. To avoid configuration drift in the future, it would probably be best if all changes to the stack happened exclusively through render.yml.