### PR TITLE
Some more small UX improvements

### DIFF
--- a/packages/toolpad-app/src/components/JsonView.tsx
+++ b/packages/toolpad-app/src/components/JsonView.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import * as React from 'react';
+import { CollapsedFieldProps } from 'react-json-view';
 
 // react-json-view uses `document` in the top-level scope, so can't be used in SSR context
 const ReactJsonView = React.lazy(() => import('react-json-view'));
@@ -8,10 +9,19 @@ export interface JsonViewProps {
   src: unknown;
 }
 
+function shouldCollapse({ name }: CollapsedFieldProps) {
+  // Assume the parent is an array when the property name is numerical and only expand first 5 items
+  const index = Number(name);
+  if (Number.isNaN(index)) {
+    return false;
+  }
+  return index > 5;
+}
+
 export default function JsonView({ src }: JsonViewProps) {
   return src && typeof src === 'object' ? (
     <React.Suspense fallback={<Box />}>
-      <ReactJsonView name={false} src={src} />
+      <ReactJsonView name={false} src={src} shouldCollapse={shouldCollapse} />
     </React.Suspense>
   ) : (
     <pre>{JSON.stringify(src)}</pre>

--- a/packages/toolpad-app/src/toolpadComponents/DataGrid.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/DataGrid.tsx
@@ -19,7 +19,7 @@ export default {
       typeDef: { type: 'object', schema: URI_DATAQUERY as string },
     },
     density: {
-      typeDef: { type: 'string', enum: ['comfortable', 'compact', 'standard'] },
+      typeDef: { type: 'string', enum: ['compact', 'standard', 'comfortable'] },
     },
     sx: {
       typeDef: { type: 'object' },


### PR DESCRIPTION
* reorder datagrid density values from densest to least dense
* try reducing performance impact of `react-json-view` by limiting which elements are collapsed. We should rewrite this component with virtualization in mind
* ...