### PR TITLE
Fix scrolling of component catalog

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -79,10 +79,11 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
     >
       <Box
         sx={{
-          height: '100%',
           display: 'flex',
           flexDirection: 'row',
-          position: 'fixed',
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
           background: 'white',
           borderRight: 1,
           borderColor: 'divider',


### PR DESCRIPTION
position: fixed sized the scrollcontainer to the viewport, which is too big