### PR TITLE
Fix race condition in iframe loading logic

### DIFF
--- a/packages/toolpad-app/runtime/pageEditor/EditorSandbox.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/EditorSandbox.tsx
@@ -14,6 +14,7 @@ export interface ToolpadBridge {
 
 declare global {
   interface Window {
+    __TOOLPAD_READY__?: boolean | (() => void);
     __TOOLPAD_BRIDGE__?: ToolpadBridge;
   }
 }
@@ -60,6 +61,14 @@ export default function EditorCanvas({ dom: initialDom, ...props }: EditorCanvas
     window.__TOOLPAD_BRIDGE__ = {
       updateDom: (newDom) => setDom(newDom),
     };
+    // eslint-disable-next-line no-underscore-dangle
+    if (typeof window.__TOOLPAD_READY__ === 'function') {
+      // eslint-disable-next-line no-underscore-dangle
+      window.__TOOLPAD_READY__();
+    } else {
+      // eslint-disable-next-line no-underscore-dangle
+      window.__TOOLPAD_READY__ = true;
+    }
     return () => {
       // eslint-disable-next-line no-underscore-dangle
       delete window.__TOOLPAD_BRIDGE__;

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -37,9 +37,25 @@ export default function EditorCanvasHost({
   const frameRef = React.useRef<HTMLIFrameElement>(null);
 
   React.useEffect(() => {
+    const frameWindow = frameRef.current?.contentWindow;
+    if (!frameWindow) {
+      return;
+    }
+
     const renderDom = appDom.createRenderTree(dom);
+
     // eslint-disable-next-line no-underscore-dangle
-    frameRef.current?.contentWindow?.__TOOLPAD_BRIDGE__?.updateDom(renderDom);
+    if (frameWindow.__TOOLPAD_READY__) {
+      // eslint-disable-next-line no-underscore-dangle
+      frameWindow.__TOOLPAD_BRIDGE__?.updateDom(renderDom);
+      // eslint-disable-next-line no-underscore-dangle
+    } else if (typeof frameWindow.__TOOLPAD_READY__ !== 'function') {
+      // eslint-disable-next-line no-underscore-dangle
+      frameWindow.__TOOLPAD_READY__ = () => {
+        // eslint-disable-next-line no-underscore-dangle
+        frameWindow.__TOOLPAD_BRIDGE__?.updateDom(renderDom);
+      };
+    }
   }, [dom]);
 
   return (


### PR DESCRIPTION
Fixes the bug: when the page editor is not already open, and you create a new page, the page isn't shown in the canvas, a reload is required
