### PR TITLE
Remove too opinionated rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,31 @@ module.exports = {
       rules: {
         ...override.rules,
         'no-restricted-imports': ['off'],
+        'no-restricted-syntax': [
+          'error',
+          // From https://github.com/airbnb/javascript/blob/d8cb404da74c302506f91e5928f30cc75109e74d/packages/eslint-config-airbnb-base/rules/style.js#L333
+          {
+            selector: 'ForInStatement',
+            message:
+              'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+          },
+          // Too opinionated
+          // {
+          //   selector: 'ForOfStatement',
+          //   message:
+          //     'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
+          // },
+          {
+            selector: 'LabeledStatement',
+            message:
+              'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+          },
+          {
+            selector: 'WithStatement',
+            message:
+              '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+          },
+        ],
       },
     };
   }),

--- a/packages/toolpad-app/runtime/pageEditor/EditorSandbox.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/EditorSandbox.tsx
@@ -26,7 +26,6 @@ function renderToolpadComponent({
   argTypes,
 }: RenderToolpadComponentParams): React.ReactElement {
   const wrappedProps = { ...props };
-  // eslint-disable-next-line no-restricted-syntax
   for (const [propName, argType] of Object.entries(argTypes)) {
     if (argType?.typeDef.type === 'element') {
       if (argType.control?.type === 'slots') {

--- a/packages/toolpad-app/runtime/pageEditor/renderToolpadApp.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/renderToolpadApp.tsx
@@ -51,7 +51,6 @@ function instantiateComponent<P = {}>(def: ToolpadComponentDefinition): React.Co
 function instantiateComponents(defs: ToolpadComponentDefinitions): InstantiatedComponents {
   const result: InstantiatedComponents = {};
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const [id, def] of Object.entries(defs)) {
     if (def) {
       result[id] = {

--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -372,7 +372,6 @@ export function getChildNodes<N extends AppDomNode>(dom: AppDom, parent: N): Nod
       (node: AppDomNode) => node.parentId === parent.id,
     );
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const child of allNodeChildren) {
       const prop = child.parentProp || 'children';
       let existing = result[prop];
@@ -383,7 +382,6 @@ export function getChildNodes<N extends AppDomNode>(dom: AppDom, parent: N): Nod
       existing.push(child);
     }
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const childArray of Object.values(result)) {
       childArray?.sort((node1: AppDomNode, node2: AppDomNode) => {
         if (!node1.parentIndex || !node2.parentIndex) {

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -11,7 +11,6 @@ export interface EditorCanvasHostProps {
   // TODO: Remove these when we get rid of PageView
   // eslint-disable-next-line react/no-unused-prop-types
   editor?: boolean;
-  // eslint-disable-next-line react/no-unused-prop-types
   dom: appDom.AppDom;
 }
 

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -188,7 +188,6 @@ function findClosestSlot(slots: RenderedSlot[], x: number, y: number): SlotLocat
   let closestDistance = Infinity;
   let closestSlot: RenderedSlot | null = null;
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const namedSlot of slots) {
     let distance: number;
     if (namedSlot.type === 'single') {
@@ -438,7 +437,6 @@ function calculateNodeSlots(
 
   const result: NodeSlots = {};
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const [parentProp, slotState] of Object.entries(parentState.slots)) {
     if (slotState) {
       const namedChildren = children[parentProp] ?? [];

--- a/packages/toolpad-app/src/server/secrets.ts
+++ b/packages/toolpad-app/src/server/secrets.ts
@@ -46,7 +46,6 @@ export function encryptSecret(value: string): string {
 }
 
 export function decryptSecret(value: string): string {
-  // eslint-disable-next-line no-restricted-syntax
   for (const decryptionMethod of decryptionMethods) {
     try {
       return unboxSecret(decryptionMethod(value));


### PR DESCRIPTION
This was brought in by the airbnb preset. I'm happy to restrict old and deprecated syntax, but not new ES features that are only restricted to support archaic browsers without generator runtime.