### PR TITLE
Allow function properties

### DIFF
--- a/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ButtonProps, Stack, CssBaseline } from '@mui/material';
 import { omit, pick, without } from 'lodash';
 import {
+  ArgTypeDefinition,
   ArgTypeDefinitions,
   evalCode,
   INITIAL_DATA_QUERY,
@@ -73,34 +74,44 @@ function useElmToolpadComponent(elm: appDom.ElementNode): InstantiatedComponent 
   return getElmComponent(components, elm);
 }
 
-function resolveBindable<V>(bindable: BindableAttrValue<V>, pageState: PageState): LiveBinding {
-  if (bindable?.type === 'jsExpression') {
-    try {
-      const value = evalCode(bindable?.value, pageState);
-      return { value };
-    } catch (err) {
-      console.error(`Oh no`, err);
-      return { error: err as Error };
+function resolveBindable<V>(
+  bindable: BindableAttrValue<V>,
+  pageState: PageState,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  argType?: ArgTypeDefinition,
+): LiveBinding {
+  const execExpression = () => {
+    if (bindable?.type === 'jsExpression') {
+      return evalCode(bindable?.value, pageState);
     }
-  }
 
-  if (bindable?.type === 'const') {
-    return { value: bindable?.value };
-  }
+    if (bindable?.type === 'const') {
+      return bindable?.value;
+    }
 
-  return { value: undefined };
+    return undefined;
+  };
+
+  try {
+    return { value: execExpression() };
+  } catch (err) {
+    console.error(`Oh no`, err);
+    return { error: err as Error };
+  }
 }
 
 function resolveBindables(
   bindables: BindableAttrValues<any>,
   pageState: PageState,
+  argTypes: ArgTypeDefinitions,
 ): Record<string, LiveBinding> {
   return Object.fromEntries(
     Object.entries(bindables).flatMap(([key, bindable]) => {
       if (!bindable) {
         return [];
       }
-      const liveBinding = resolveBindable(bindable, pageState);
+      const argType = argTypes[key];
+      const liveBinding = resolveBindable(bindable, pageState, argType);
       return bindable === undefined ? [] : [[key, liveBinding]];
     }),
   );
@@ -295,20 +306,22 @@ function useLiveBindings(
   page: appDom.PageNode,
   currentPageState: PageState,
 ): LiveBindings {
+  const components = useComponentsContext();
   return React.useMemo(() => {
     const descendants = appDom.getDescendants(dom, page);
     const bindings: LiveBindings = {};
     descendants.forEach((descendant) => {
       if (appDom.isElement(descendant)) {
         if (descendant.props) {
-          const elmBindables = resolveBindables(descendant.props, currentPageState);
+          const { argTypes } = getElmComponent(components, descendant);
+          const elmBindables = resolveBindables(descendant.props, currentPageState, argTypes);
           Object.entries(elmBindables).forEach(([propName, bindable]) => {
             bindings[`${descendant.id}.props.${propName}`] = bindable;
           });
         }
       } else if (appDom.isQueryState(descendant)) {
         if (descendant.params) {
-          const elmBindables = resolveBindables(descendant.params, currentPageState);
+          const elmBindables = resolveBindables(descendant.params, currentPageState, {});
           Object.entries(elmBindables).forEach(([propName, bindable]) => {
             bindings[`${descendant.id}.params.${propName}`] = bindable;
           });
@@ -316,7 +329,7 @@ function useLiveBindings(
       }
     });
     return bindings;
-  }, [currentPageState, dom, page]);
+  }, [currentPageState, dom, page, components]);
 }
 
 function RenderedPage({ nodeId }: RenderedNodeProps) {

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/BindableEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/BindableEditor.tsx
@@ -19,6 +19,8 @@ function getDefaultControl(typeDef: PropValueType): ArgControlSpec | null {
       return { type: 'json' };
     case 'array':
       return { type: 'json' };
+    case 'function':
+      return { type: 'function' };
     default:
       return null;
   }

--- a/packages/toolpad-app/src/components/JsonView.tsx
+++ b/packages/toolpad-app/src/components/JsonView.tsx
@@ -18,12 +18,23 @@ function shouldCollapse({ name }: CollapsedFieldProps) {
   return index > 5;
 }
 
+function stringifySrc(src: unknown): string {
+  const srcType = typeof src;
+  switch (srcType) {
+    case 'undefined':
+    case 'function':
+      return srcType;
+    default:
+      return JSON.stringify(src);
+  }
+}
+
 export default function JsonView({ src }: JsonViewProps) {
   return src && typeof src === 'object' ? (
     <React.Suspense fallback={<Box />}>
       <ReactJsonView name={false} src={src} shouldCollapse={shouldCollapse} />
     </React.Suspense>
   ) : (
-    <pre>{src === undefined ? 'undefined' : JSON.stringify(src)}</pre>
+    <pre>{stringifySrc(src)}</pre>
   );
 }

--- a/packages/toolpad-app/src/components/propertyControls/function.tsx
+++ b/packages/toolpad-app/src/components/propertyControls/function.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Typography } from '@mui/material';
+import { EditorProps, PropControlDefinition } from '../../types';
+
+function Editor({ label }: EditorProps<any>) {
+  // No editor, bindings only
+  return <Typography>{label}</Typography>;
+}
+
+const functionType: PropControlDefinition<string> = {
+  Editor,
+};
+
+export default functionType;

--- a/packages/toolpad-app/src/components/propertyControls/index.tsx
+++ b/packages/toolpad-app/src/components/propertyControls/index.tsx
@@ -5,6 +5,7 @@ import boolean from './boolean';
 import number from './number';
 import select from './select';
 import json from './json';
+import functionType from './function';
 import GridColumns from './GridColumns';
 import HorizontalAlign from './HorizontalAlign';
 import VerticalAlign from './VerticalAlign';
@@ -17,6 +18,7 @@ const propTypeControls: {
   number,
   select,
   json,
+  function: functionType,
   GridColumns,
   HorizontalAlign,
   VerticalAlign,

--- a/packages/toolpad-app/src/toolpadComponents/Button.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Button.tsx
@@ -11,7 +11,7 @@ export default {
       typeDef: { type: 'string' },
     },
     onClick: {
-      typeDef: { type: 'event' },
+      typeDef: { type: 'function' },
     },
     disabled: {
       typeDef: { type: 'boolean' },

--- a/packages/toolpad-app/src/toolpadComponents/Button.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Button.tsx
@@ -10,6 +10,9 @@ export default {
       name: 'content',
       typeDef: { type: 'string' },
     },
+    onClick: {
+      typeDef: { type: 'event' },
+    },
     disabled: {
       typeDef: { type: 'boolean' },
     },

--- a/packages/toolpad-core/src/index.tsx
+++ b/packages/toolpad-core/src/index.tsx
@@ -6,7 +6,7 @@ export interface OnChangeHandler {
 }
 
 export interface ValueTypeBase {
-  type: 'string' | 'boolean' | 'number' | 'object' | 'array' | 'element';
+  type: 'string' | 'boolean' | 'number' | 'object' | 'array' | 'element' | 'event';
 }
 
 export interface StringValueType extends ValueTypeBase {
@@ -38,6 +38,10 @@ export interface ElementValueType extends ValueTypeBase {
   type: 'element';
 }
 
+export interface EventValueType extends ValueTypeBase {
+  type: 'event';
+}
+
 export interface ArgControlSpec {
   type:
     | 'boolean' // checkbox
@@ -66,7 +70,7 @@ type PrimitiveValueType =
   | ObjectValueType
   | ArrayValueType;
 
-export type PropValueType = PrimitiveValueType | ElementValueType;
+export type PropValueType = PrimitiveValueType | ElementValueType | EventValueType;
 
 export type PropValueTypes<K extends string = string> = Partial<{
   [key in K]?: PropValueType;

--- a/packages/toolpad-core/src/index.tsx
+++ b/packages/toolpad-core/src/index.tsx
@@ -6,7 +6,7 @@ export interface OnChangeHandler {
 }
 
 export interface ValueTypeBase {
-  type: 'string' | 'boolean' | 'number' | 'object' | 'array' | 'element' | 'event';
+  type: 'string' | 'boolean' | 'number' | 'object' | 'array' | 'element' | 'function';
 }
 
 export interface StringValueType extends ValueTypeBase {
@@ -38,8 +38,8 @@ export interface ElementValueType extends ValueTypeBase {
   type: 'element';
 }
 
-export interface EventValueType extends ValueTypeBase {
-  type: 'event';
+export interface FunctionValueType extends ValueTypeBase {
+  type: 'function';
 }
 
 export interface ArgControlSpec {
@@ -70,7 +70,7 @@ type PrimitiveValueType =
   | ObjectValueType
   | ArrayValueType;
 
-export type PropValueType = PrimitiveValueType | ElementValueType | EventValueType;
+export type PropValueType = PrimitiveValueType | ElementValueType | FunctionValueType;
 
 export type PropValueTypes<K extends string = string> = Partial<{
   [key in K]?: PropValueType;

--- a/packages/toolpad-core/src/useDataQuery.ts
+++ b/packages/toolpad-core/src/useDataQuery.ts
@@ -17,6 +17,7 @@ export interface UseDataQuery {
   error: any;
   data: any;
   rows: GridRowsProp;
+  refetch: () => void;
 }
 
 export const INITIAL_DATA_QUERY: UseDataQuery = {
@@ -24,6 +25,7 @@ export const INITIAL_DATA_QUERY: UseDataQuery = {
   error: null,
   data: null,
   rows: [],
+  refetch: () => {},
 };
 
 const EMPTY_ARRAY: any[] = [];
@@ -39,6 +41,7 @@ export function useDataQuery(
     isLoading: loading,
     error,
     data: responseData = EMPTY_OBJECT,
+    refetch,
   } = useQuery([dataUrl, queryId, params], () => queryId && fetchData(dataUrl, queryId, params), {
     enabled: !!queryId,
   });
@@ -53,8 +56,9 @@ export function useDataQuery(
       error,
       data,
       rows,
+      refetch,
     }),
-    [loading, error, data, rows],
+    [loading, error, data, rows, refetch],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
Initial implementation to allow binding to functions. in this PR:
- allow binding to functions
- add property for Button onClick
- add refetch function to dataqueries

This PR allows setting up a button that refetches a dataquery