### PR TITLE
Allow disabling select component

### DIFF
--- a/packages/toolpad-app/src/toolpadComponents/Select.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Select.tsx
@@ -10,6 +10,9 @@ export default {
     label: {
       typeDef: { type: 'string' },
     },
+    disabled: {
+      typeDef: { type: 'boolean' },
+    },
     variant: {
       typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
     },


### PR DESCRIPTION
Want to disable the subbreed select in the dog app if there are no options (🤔  Maybe the component should do this automagically)