### PR TITLE
Add prettier:all command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "toolpad": "./dist/index.js"
   },
   "scripts": {
-    "prettier": "node scripts/prettier.js",
+    "prettier": "node ./scripts/prettier.js",
+    "prettier:all": "node ./scripts/prettier.js write",
     "deduplicate": "node scripts/deduplicate.js",
     "start": "cross-env FORCE_COLOR=1 packages/toolpad-cli/cli.js",
     "dev": "cross-env FORCE_COLOR=1 lerna run dev --stream --parallel --scope @mui/toolpad-core --scope @mui/toolpad-components --scope @mui/toolpad",


### PR DESCRIPTION
What's going on in https://github.com/mui/mui-toolpad/pull/305? the [build](https://app.circleci.com/pipelines/github/mui/mui-toolpad/1034/workflows/b9dbd1c1-3d64-4763-922f-84f33455fe2a/jobs/2465) fails because it's trying to run prettier on files that didn't change in the PR, and running `prettier:all` doesn't update those files. ~ @oliviertassinari By any chance have you ever seen that with the prettier command in the `mui/material-ui` repo?~ Ok, a change was merged in master in the meantime