### PR TITLE
Update viewstate when a descendant resizes

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -854,6 +854,7 @@ export default function RenderPanel({ className }: RenderPanelProps) {
       const resizeObserver = new ResizeObserver(handlePageUpdateThrottled);
 
       resizeObserver.observe(rootElm);
+      rootElm.querySelectorAll('*').forEach((elm) => resizeObserver.observe(elm));
 
       // eslint-disable-next-line no-underscore-dangle
       const queuedEvents = Array.isArray(editorWindow.__TOOLPAD_RUNTIME_EVENT__)


### PR DESCRIPTION
Image loaded and subsequently resizing doesn't trigger mutation observer. As well as reflows after scrollbar appears, or fonts are loaded, etc...
We can just observe the subtree for changes. If it turns out a performance problem we can always single out just the node elements.
