### PR TITLE
The effect on unmount is unnecesary

### DIFF
--- a/packages/toolpad-app/src/utils/useDebounced.ts
+++ b/packages/toolpad-app/src/utils/useDebounced.ts
@@ -3,15 +3,10 @@ import * as React from 'react';
 export default function useDebounced<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = React.useState(value);
 
-  const timeoutRef = React.useRef<NodeJS.Timeout>();
-
   React.useEffect(() => {
     const timeoutId = setTimeout(() => setDebouncedValue(value), delay);
-    timeoutRef.current = timeoutId;
     return () => clearTimeout(timeoutId);
   }, [value, delay]);
-
-  React.useEffect(() => () => timeoutRef.current && clearTimeout(timeoutRef.current), []);
 
   return debouncedValue;
 }

--- a/packages/toolpad-app/src/utils/useThottled.ts
+++ b/packages/toolpad-app/src/utils/useThottled.ts
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+export default function useThrottled<T>(value: T, throttle: number): T {
+  const [throttledValue, setThrottledValue] = React.useState(value);
+  const lastUpdate = React.useRef(Date.now());
+
+  React.useEffect(() => {
+    const now = Date.now();
+    const elapsed = now - lastUpdate.current;
+
+    if (elapsed > throttle) {
+      lastUpdate.current = now;
+      setThrottledValue(value);
+      return () => {};
+    }
+
+    const delay = throttle - elapsed;
+    const timeoutId = setTimeout(() => setThrottledValue(value), delay);
+    return () => clearTimeout(timeoutId);
+  }, [value, throttle]);
+
+  return throttledValue;
+}

--- a/packages/toolpad-app/src/utils/useThottled.ts
+++ b/packages/toolpad-app/src/utils/useThottled.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export default function useThrottled<T>(value: T, throttle: number): T {
   const [throttledValue, setThrottledValue] = React.useState(value);
-  const lastUpdate = React.useRef(Date.now());
+  const lastUpdate = React.useRef(-Infinity);
 
   React.useEffect(() => {
     const now = Date.now();
@@ -19,5 +19,8 @@ export default function useThrottled<T>(value: T, throttle: number): T {
     return () => clearTimeout(timeoutId);
   }, [value, throttle]);
 
-  return throttledValue;
+  const now = Date.now();
+  const elapsed = now - lastUpdate.current;
+
+  return elapsed > throttle ? value : throttledValue;
 }

--- a/packages/toolpad-app/src/utils/useThottled.ts
+++ b/packages/toolpad-app/src/utils/useThottled.ts
@@ -4,20 +4,24 @@ export default function useThrottled<T>(value: T, throttle: number): T {
   const [throttledValue, setThrottledValue] = React.useState(value);
   const lastUpdate = React.useRef(-Infinity);
 
+  const updateThrottledValue = React.useCallback((newValue: T) => {
+    lastUpdate.current = Date.now();
+    setThrottledValue(newValue);
+  }, []);
+
   React.useEffect(() => {
     const now = Date.now();
     const elapsed = now - lastUpdate.current;
 
     if (elapsed > throttle) {
-      lastUpdate.current = now;
-      setThrottledValue(value);
+      updateThrottledValue(value);
       return () => {};
     }
 
     const delay = throttle - elapsed;
-    const timeoutId = setTimeout(() => setThrottledValue(value), delay);
+    const timeoutId = setTimeout(() => updateThrottledValue(value), delay);
     return () => clearTimeout(timeoutId);
-  }, [value, throttle]);
+  }, [value, throttle, updateThrottledValue]);
 
   const now = Date.now();
   const elapsed = now - lastUpdate.current;


### PR DESCRIPTION
 as clearTimeout already runs on the other effect's cleanup