### PR TITLE
Remove jsdocs rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ const baseline = require('@mui/monorepo/.eslintrc');
 
 module.exports = {
   ...baseline,
-  plugins: [...baseline.plugins, 'jsdoc'],
   /**
    * Sorted alphanumerically within each group. built-in and each plugin form
    * their own groups.
@@ -12,15 +11,6 @@ module.exports = {
     'import/prefer-default-export': ['off'],
     // TODO move rule into the main repo once it has upgraded
     '@typescript-eslint/return-await': ['off'],
-    // TODO move rule into main repo to allow deep @mui/monorepo imports
-    'no-restricted-imports': ['off'],
-    'jsdoc/require-param': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-param-type': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-param-name': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-param-description': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-returns': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-returns-type': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-returns-description': ['error', { contexts: ['TSFunctionType'] }],
     // TODO: resolve these, non critical for pathfinder prototype
     'no-alert': ['off'],
     'no-console': ['off'],

--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -27,7 +27,6 @@ function excludeFields<T, K extends (keyof T)[]>(
   excluded: K,
 ): Record<Exclude<keyof T, K[number]>, boolean> {
   const result = {} as Record<Exclude<keyof T, K[number]>, boolean>;
-  // eslint-disable-next-line no-restricted-syntax
   for (const key of Object.keys(fields)) {
     if (!excluded.includes(key as any)) {
       result[key as Exclude<keyof T, K[number]>] = true;


### PR DESCRIPTION
We're not relying on them right now and they're not working at the moment anyway.
They should use `FunctionDeclaration` in contexts instead of `TSFunctionType`. Not sure why these are configured for `TSFunctionType`, perhaps an older AST format that's not used anymore by `@typescript-eslint/parser`?
