### PR TITLE
Add Suspense and error boundaries to Toolpad Apps

### DIFF
--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -71,6 +71,7 @@
     "react": "^18.0.0",
     "react-devtools-inline": "^4.24.3",
     "react-dom": "^18.0.0",
+    "react-error-boundary": "^3.1.4",
     "react-hook-form": "^7.29.0",
     "react-inspector": "^5.1.1",
     "react-query": "^3.34.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8392,6 +8392,13 @@ react-dom@^18.0.0:
     loose-envify "^1.1.0"
     scheduler "^0.21.0"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-hook-form@^7.29.0:
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.29.0.tgz#5e7e41a483b70731720966ed8be52163ea1fecf1"


### PR DESCRIPTION
Make sure we capture loading and error states at least at the application outer boundary