### PR TITLE
Don't debounce value when errors becoming undefined

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/BindingEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/BindingEditor.tsx
@@ -111,7 +111,8 @@ export function BindingEditor<V>({
   );
 
   const lastGoodPreview = useLatest(previewValue?.error ? undefined : previewValue);
-  const previewError = useDebounced(previewValue?.error, 500);
+  const previewErrorDebounced = useDebounced(previewValue?.error, 500);
+  const previewError = previewValue?.error && previewErrorDebounced;
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Ignore debounce when the error disappears (disappear immediately instead of waiting for debounce delay)
