### PR TITLE
Quickjs browser side

### DIFF
--- a/packages/toolpad-app/next.config.js
+++ b/packages/toolpad-app/next.config.js
@@ -11,6 +11,15 @@ module.exports = {
       // See https://github.com/prisma/prisma/issues/6564#issuecomment-853028373
       config.externals.push('_http_common');
     }
+
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      // We need these because quickjs-emscripten doesn't export pure browser compatible modules yet
+      // https://github.com/justjake/quickjs-emscripten/issues/33
+      fs: false,
+      path: false,
+    };
+
     return config;
   },
 

--- a/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
@@ -30,9 +30,7 @@ import {
   InstantiatedComponents,
 } from '../../src/toolpadComponents/componentDefinition';
 import AppThemeProvider from './AppThemeProvider';
-import { evaluateBindable, fireEvent } from '../coreRuntime';
-import { QuickJsProvider, useQuickJs } from './quickJs';
-import { evalExpressionInContext } from '../../src/server/evalExpression';
+import { evaluateBindable, fireEvent, JsRuntimeProvider } from '../coreRuntime';
 
 export interface RenderToolpadComponentParams {
   Component: React.ComponentType;
@@ -311,13 +309,6 @@ function useLiveBindings(
 }
 
 function RenderedPage({ nodeId }: RenderedNodeProps) {
-  const quickJs = useQuickJs();
-  const ctx = quickJs.newContext();
-  try {
-    console.log(evalExpressionInContext(ctx, '1 + 1'));
-  } finally {
-    ctx.dispose();
-  }
   const renderToolpadComponent = React.useContext(RenderToolpadComponentContext);
   const dom = useDomContext();
   const location = useLocation();
@@ -449,7 +440,7 @@ export default function ToolpadApp({ basename, appId, version, dom, components }
   return (
     <ErrorBoundary FallbackComponent={AppError}>
       <React.Suspense fallback={<AppLoading />}>
-        <QuickJsProvider>
+        <JsRuntimeProvider>
           <ComponentsContextProvider value={components}>
             <AppContextProvider value={appContext}>
               <QueryClientProvider client={queryClient}>
@@ -483,7 +474,7 @@ export default function ToolpadApp({ basename, appId, version, dom, components }
               </QueryClientProvider>
             </AppContextProvider>
           </ComponentsContextProvider>
-        </QuickJsProvider>
+        </JsRuntimeProvider>
       </React.Suspense>
     </ErrorBoundary>
   );

--- a/packages/toolpad-app/runtime/pageEditor/quickJs.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/quickJs.tsx
@@ -1,0 +1,20 @@
+import { getQuickJS, QuickJSWASMModule } from 'quickjs-emscripten';
+import * as React from 'react';
+import { createProvidedContext } from '../../src/utils/react';
+
+const [useQuickJs, QuickJsContextProvider] = createProvidedContext<QuickJSWASMModule>('QuickJs');
+
+export interface QuickJsProviderProps {
+  children?: React.ReactNode;
+}
+
+export const QuickJsProvider = React.lazy(async () => {
+  const quickJs = await getQuickJS();
+  const Context = (props: QuickJsProviderProps) => (
+    <QuickJsContextProvider value={quickJs} {...props} />
+  );
+  Context.displayName = 'QuickJsProvider';
+  return { default: Context };
+});
+
+export { useQuickJs };

--- a/packages/toolpad-app/scripts/buildRuntime.ts
+++ b/packages/toolpad-app/scripts/buildRuntime.ts
@@ -28,7 +28,17 @@ async function main() {
 
     watch: args['--watch'],
 
+    define: {
+      // For quickjs-emscripten
+      process: '{"env":{}}',
+    },
+
     external: [
+      // For quickjs-emscripten
+      'fs',
+      'path',
+
+      // Modules we want to load independently, to share with custom components
       'es-module-shims',
       'react',
       'react-dom',

--- a/packages/toolpad-app/scripts/buildRuntime.ts
+++ b/packages/toolpad-app/scripts/buildRuntime.ts
@@ -28,18 +28,12 @@ async function main() {
 
     watch: args['--watch'],
 
-    define: {
-      // For quickjs-emscripten
-      process: '{"env":{}}',
-    },
-
     external: [
-      // For quickjs-emscripten
-      'fs',
-      'path',
+      // Some runtime requirements
+      'quickjs-emscripten',
+      'es-module-shims',
 
       // Modules we want to load independently, to share with custom components
-      'es-module-shims',
       'react',
       'react-dom',
       'react-query',

--- a/packages/toolpad-app/scripts/esinstall.ts
+++ b/packages/toolpad-app/scripts/esinstall.ts
@@ -33,10 +33,12 @@ async function main() {
       '@mui/material/colors',
       '@mui/lab',
       '@mui/icons-material/Error',
+      'quickjs-emscripten',
     ],
     {
       cwd: PROJECT_ROOT,
       dest: DEST,
+      polyfillNode: true,
       // logger: console,
       packageLookupFields: ['module', 'main'],
       env: {

--- a/packages/toolpad-app/src/components/AppEditor/BindingEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/BindingEditor.tsx
@@ -96,7 +96,8 @@ function JsExpressionPreviewServerContent({ input, globalScope }: JsExpressionPr
   }, [jsRuntime, input, globalScope]);
 
   const lastGoodPreview = useLatest(previewValue?.error ? undefined : previewValue);
-  const previewError = useDebounced(previewValue?.error, 500);
+  const previewErrorDebounced = useDebounced(previewValue?.error, 500);
+  const previewError = previewValue?.error && previewErrorDebounced;
 
   return (
     <React.Fragment>

--- a/packages/toolpad-app/src/server/evaluateBindable.ts
+++ b/packages/toolpad-app/src/server/evaluateBindable.ts
@@ -1,0 +1,28 @@
+import { ArgTypeDefinition, BindableAttrValue, LiveBinding } from '@mui/toolpad-core';
+import evalExpression, { Json } from './evalExpression';
+
+export default async function evaluateBindable<V>(
+  bindable: BindableAttrValue<V> | null,
+  globalScope: Record<string, Json>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  argType?: ArgTypeDefinition,
+): Promise<LiveBinding> {
+  const execExpression = async () => {
+    if (bindable?.type === 'jsExpression') {
+      return evalExpression(bindable?.value, globalScope);
+    }
+
+    if (bindable?.type === 'const') {
+      return bindable?.value;
+    }
+
+    return undefined;
+  };
+
+  try {
+    const value = await execExpression();
+    return { value };
+  } catch (err) {
+    return { error: err as Error };
+  }
+}

--- a/packages/toolpad-app/src/server/evaluateBindable.ts
+++ b/packages/toolpad-app/src/server/evaluateBindable.ts
@@ -1,15 +1,17 @@
 import { ArgTypeDefinition, BindableAttrValue, LiveBinding } from '@mui/toolpad-core';
-import evalExpression, { Json } from './evalExpression';
+import { QuickJSContext } from 'quickjs-emscripten';
+import { evalExpressionInContext, Json } from './evalExpression';
 
-export default async function evaluateBindable<V>(
+export default function evaluateBindable<V>(
+  ctx: QuickJSContext,
   bindable: BindableAttrValue<V> | null,
   globalScope: Record<string, Json>,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   argType?: ArgTypeDefinition,
-): Promise<LiveBinding> {
-  const execExpression = async () => {
+): LiveBinding {
+  const execExpression = () => {
     if (bindable?.type === 'jsExpression') {
-      return evalExpression(bindable?.value, globalScope);
+      return evalExpressionInContext(ctx, bindable?.value, globalScope);
     }
 
     if (bindable?.type === 'const') {
@@ -20,7 +22,7 @@ export default async function evaluateBindable<V>(
   };
 
   try {
-    const value = await execExpression();
+    const value = execExpression();
     return { value };
   } catch (err) {
     return { error: err as Error };

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -45,6 +45,7 @@ function QueryEditor({ value, onChange }: WithControlledProp<FetchQuery>) {
           disabled={value.url && value.url.type !== 'const'}
         />
         <BindingEditor
+          server
           value={value.url}
           onChange={(url) => onChange({ ...value, url: url || appDom.createConst('') })}
           propType={{ type: 'string' }}

--- a/packages/toolpad-components/tsconfig.json
+++ b/packages/toolpad-components/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "skipLibCheck": true
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/toolpad-core/package.json
+++ b/packages/toolpad-core/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@mui/x-data-grid-pro": "^5.7.0",
+    "quickjs-emscripten": "^0.20.0",
     "react": "^18.0.0",
     "react-query": "^3.34.19"
   },

--- a/packages/toolpad-core/src/jsRuntime.tsx
+++ b/packages/toolpad-core/src/jsRuntime.tsx
@@ -1,0 +1,35 @@
+import { getQuickJS, RuntimeOptions, QuickJSRuntime } from 'quickjs-emscripten';
+import * as React from 'react';
+
+const JsRuntimeContext = React.createContext<QuickJSRuntime | null>(null);
+
+export interface JsRuntimeProviderProps {
+  options?: RuntimeOptions;
+  children?: React.ReactNode;
+}
+
+export const JsRuntimeProvider = React.lazy(async () => {
+  const quickJs = await getQuickJS();
+  const Context = (props: JsRuntimeProviderProps) => {
+    const [runtime, setRuntime] = React.useState(() => quickJs.newRuntime(props.options));
+
+    // Make sure to clean dispose of runtime when it changes or unmounts
+    React.useEffect(() => () => runtime.dispose(), [runtime]);
+
+    React.useEffect(() => setRuntime(quickJs.newRuntime(props.options)), [props.options]);
+
+    return <JsRuntimeContext.Provider value={runtime} {...props} />;
+  };
+  Context.displayName = 'JsRuntimeProvider';
+  return { default: Context };
+});
+
+export function useJsRuntime(): QuickJSRuntime {
+  const runtime = React.useContext(JsRuntimeContext);
+
+  if (!runtime) {
+    throw new Error(`No JsRuntime contetx found`);
+  }
+
+  return runtime;
+}

--- a/packages/toolpad-core/src/jsRuntime.tsx
+++ b/packages/toolpad-core/src/jsRuntime.tsx
@@ -13,8 +13,14 @@ export const JsRuntimeProvider = React.lazy(async () => {
   const Context = (props: JsRuntimeProviderProps) => {
     const [runtime, setRuntime] = React.useState(() => quickJs.newRuntime(props.options));
 
-    // Make sure to clean dispose of runtime when it changes or unmounts
-    React.useEffect(() => () => runtime.dispose(), [runtime]);
+    // Make sure to dispose of runtime when it changes or unmounts
+    React.useEffect(() => {
+      return () => {
+        if (runtime.alive) {
+          runtime.dispose();
+        }
+      };
+    }, [runtime]);
 
     React.useEffect(() => setRuntime(quickJs.newRuntime(props.options)), [props.options]);
 

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -269,3 +269,5 @@ export function evaluateBindable<V>(
     return { error: err as Error };
   }
 }
+
+export * from './jsRuntime';

--- a/packages/toolpad-core/tsconfig.json
+++ b/packages/toolpad-core/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "skipLibCheck": true
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
In the binding editor, evaluate serverside bindings using the QuickJs runtime so that it behaves exactly the same as when it's run during the app runtime. This required setting quickjs up to run in the browser. We can build further on this to move away from the iframe method which is less secure