### PR TITLE
replace lodash with lodash-es

### DIFF
--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -63,6 +63,7 @@
     "googleapis": "^97.0.0",
     "import-meta-resolve": "^1.1.1",
     "json-to-ts": "^1.7.0",
+    "lodash-es": "^4.17.21",
     "next": "^12.1.4",
     "path-to-regexp": "^6.2.0",
     "prettier": "^2.6.2",
@@ -86,7 +87,7 @@
   "devDependencies": {
     "@types/crypto-js": "^4.1.1",
     "@types/glob": "^7.2.0",
-    "@types/lodash": "^4.14.181",
+    "@types/lodash-es": "^4.17.6",
     "@types/react": "^17.0.43",
     "@types/react-inspector": "^4.0.2",
     "@types/serialize-javascript": "^5.0.2",

--- a/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
@@ -8,7 +8,7 @@ import {
   styled,
   AlertTitle,
 } from '@mui/material';
-import { omit, pick, without } from 'lodash';
+import { omit, pick, without } from 'lodash-es';
 import {
   BindableAttrValues,
   ArgTypeDefinitions,

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import throttle from 'lodash/throttle';
+import throttle from 'lodash-es/throttle';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { IconButton, styled } from '@mui/material';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,10 +2326,17 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.181":
-  version "4.14.181"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.181.tgz#d1d3740c379fda17ab175165ba04e2d03389385d"
-  integrity sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==
+"@types/lodash-es@^4.17.6":
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.6.tgz#c2ed4c8320ffa6f11b43eb89e9eaeec65966a0a0"
+  integrity sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
 
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -6935,6 +6942,11 @@ locate-path@^7.1.0:
   integrity sha512-HNx5uOnYeK4SxEoid5qnhRfprlJeGMzFRKPLCf/15N3/B4AiofNwC/yq7VBKdVk9dx7m+PiYCJOGg55JYTAqoQ==
   dependencies:
     p-locate "^6.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
All parts of the runtime support ESM modules, we can use `lodash-es` to improve performance