### PR TITLE
Move component definition to the runtime

### DIFF
--- a/packages/toolpad-app/src/toolpadComponents/Button.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Button.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,25 +7,5 @@ export default {
   displayName: 'Button',
   importedModule: '@mui/toolpad-components',
   importedName: 'Button',
-  argTypes: {
-    children: {
-      name: 'content',
-      typeDef: { type: 'string' },
-    },
-    onClick: {
-      typeDef: { type: 'function' },
-    },
-    disabled: {
-      typeDef: { type: 'boolean' },
-    },
-    variant: {
-      typeDef: { type: 'string', enum: ['contained', 'outlined', 'text'] },
-    },
-    color: {
-      typeDef: { type: 'string', enum: ['primary', 'secondary'] },
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-  },
+  ...Button[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/Container.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Container.tsx
@@ -1,3 +1,5 @@
+import { Container } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,13 +7,5 @@ export default {
   displayName: 'Container',
   importedModule: '@mui/toolpad-components',
   importedName: 'Container',
-  argTypes: {
-    children: {
-      typeDef: { type: 'element' },
-      control: { type: 'slot' },
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-  },
+  ...Container[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/CustomLayout.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/CustomLayout.tsx
@@ -1,3 +1,5 @@
+import { CustomLayout } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,10 +7,5 @@ export default {
   displayName: 'CustomLayout',
   importedModule: '@mui/toolpad-components',
   importedName: 'CustomLayout',
-  argTypes: {
-    child3: {
-      typeDef: { type: 'element' },
-      control: { type: 'slot' },
-    },
-  },
+  ...CustomLayout[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/DataGrid.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/DataGrid.tsx
@@ -1,3 +1,5 @@
+import { DataGrid } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,27 +7,5 @@ export default {
   displayName: 'DataGrid',
   importedModule: '@mui/toolpad-components',
   importedName: 'DataGrid',
-  argTypes: {
-    rows: {
-      typeDef: { type: 'array', schema: '/schemas/DataGridRows.json' },
-    },
-    columns: {
-      typeDef: { type: 'array', schema: '/schemas/DataGridColumns.json' },
-      control: { type: 'GridColumns' },
-      memoize: true,
-    },
-    dataQuery: {
-      typeDef: { type: 'object', schema: '/schemas/DataQuery.json' },
-    },
-    density: {
-      typeDef: { type: 'string', enum: ['compact', 'standard', 'comfortable'] },
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-    selection: {
-      typeDef: { type: 'object' },
-      onChangeProp: 'onSelectionChange',
-    },
-  },
+  ...DataGrid[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/Image.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Image.tsx
@@ -1,3 +1,5 @@
+import { Image } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,15 +7,5 @@ export default {
   displayName: 'Image',
   importedModule: '@mui/toolpad-components',
   importedName: 'Image',
-  argTypes: {
-    src: {
-      typeDef: { type: 'string' },
-    },
-    alt: {
-      typeDef: { type: 'string' },
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-  },
+  ...Image[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/PageRow.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/PageRow.tsx
@@ -1,3 +1,5 @@
+import { PageRow } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,29 +7,5 @@ export default {
   displayName: 'PageRow',
   importedModule: '@mui/toolpad-components',
   importedName: 'PageRow',
-  argTypes: {
-    spacing: {
-      typeDef: { type: 'number' },
-    },
-    alignItems: {
-      typeDef: {
-        type: 'string',
-        enum: ['start', 'center', 'end', 'stretch', 'baseline'],
-      },
-      label: 'Vertical alignment',
-      control: { type: 'VerticalAlign' },
-    },
-    justifyContent: {
-      typeDef: {
-        type: 'string',
-        enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
-      },
-      label: 'Horizontal alignment',
-      control: { type: 'HorizontalAlign' },
-    },
-    children: {
-      typeDef: { type: 'element' },
-      control: { type: 'slots' },
-    },
-  },
+  ...PageRow[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/Paper.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Paper.tsx
@@ -1,3 +1,5 @@
+import { Paper } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,16 +7,5 @@ export default {
   displayName: 'Paper',
   importedModule: '@mui/toolpad-components',
   importedName: 'Paper',
-  argTypes: {
-    elevation: {
-      typeDef: { type: 'number', minimum: 0 },
-    },
-    children: {
-      typeDef: { type: 'element' },
-      control: { type: 'slot' },
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-  },
+  ...Paper[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/Select.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Select.tsx
@@ -1,3 +1,5 @@
+import { Select } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,34 +7,5 @@ export default {
   displayName: 'Select',
   importedModule: '@mui/toolpad-components',
   importedName: 'Select',
-  argTypes: {
-    label: {
-      typeDef: { type: 'string' },
-    },
-    disabled: {
-      typeDef: { type: 'boolean' },
-    },
-    variant: {
-      typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
-    },
-    size: {
-      typeDef: { type: 'string', enum: ['small', 'normal'] },
-    },
-    value: {
-      typeDef: { type: 'string' },
-      onChangeProp: 'onChange',
-      defaultValueProp: 'defaultValue',
-      onChangeHandler: {
-        params: ['event'],
-        valueGetter: 'event.target.value',
-      },
-    },
-    options: {
-      typeDef: { type: 'array', schema: '/schemas/SelectOptions.json' },
-      control: { type: 'json' },
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-  },
+  ...Select[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/Stack.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Stack.tsx
@@ -1,3 +1,5 @@
+import { Stack } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,37 +7,5 @@ export default {
   displayName: 'Stack',
   importedModule: '@mui/toolpad-components',
   importedName: 'Stack',
-  argTypes: {
-    gap: {
-      typeDef: { type: 'number' },
-    },
-    margin: {
-      typeDef: { type: 'number' },
-    },
-    direction: {
-      typeDef: {
-        type: 'string',
-        enum: ['row', 'row-reverse', 'column', 'column-reverse'],
-      },
-    },
-    alignItems: {
-      typeDef: {
-        type: 'string',
-        enum: ['start', 'center', 'end', 'stretch', 'baseline'],
-      },
-    },
-    justifyContent: {
-      typeDef: {
-        type: 'string',
-        enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
-      },
-    },
-    children: {
-      typeDef: { type: 'element' },
-      control: { type: 'slots' },
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-  },
+  ...Stack[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/TextField.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/TextField.tsx
@@ -1,3 +1,5 @@
+import { TextField } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,27 +7,5 @@ export default {
   displayName: 'TextField',
   importedModule: '@mui/toolpad-components',
   importedName: 'TextField',
-  argTypes: {
-    label: {
-      typeDef: { type: 'string' },
-    },
-    variant: {
-      typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
-    },
-    size: {
-      typeDef: { type: 'string', enum: ['small', 'normal'] },
-    },
-    value: {
-      typeDef: { type: 'string' },
-      onChangeProp: 'onChange',
-      onChangeHandler: {
-        params: ['event'],
-        valueGetter: 'event.target.value',
-      },
-      defaultValueProp: 'defaultValue',
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-  },
+  ...TextField[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-app/src/toolpadComponents/Typography.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/Typography.tsx
@@ -1,3 +1,5 @@
+import { Typography } from '@mui/toolpad-components';
+import { TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import { ToolpadComponentDefinition } from './componentDefinition';
 
 export default {
@@ -5,19 +7,5 @@ export default {
   displayName: 'Typography',
   importedModule: '@mui/toolpad-components',
   importedName: 'Typography',
-  argTypes: {
-    children: {
-      typeDef: { type: 'string' },
-      label: 'value',
-    },
-    variant: {
-      typeDef: {
-        type: 'string',
-        enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2'],
-      },
-    },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-  },
+  ...Typography[TOOLPAD_COMPONENT],
 } as ToolpadComponentDefinition;

--- a/packages/toolpad-components/src/Button.tsx
+++ b/packages/toolpad-components/src/Button.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@mui/material';
+import { Button, ButtonProps } from '@mui/material';
+import { ComponentConfig } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
 export default withDefaultProps(Button, {
@@ -6,3 +7,27 @@ export default withDefaultProps(Button, {
   variant: 'contained',
   color: 'primary',
 });
+
+export const config: ComponentConfig<ButtonProps> = {
+  argTypes: {
+    children: {
+      label: 'content',
+      typeDef: { type: 'string' },
+    },
+    onClick: {
+      typeDef: { type: 'function' },
+    },
+    disabled: {
+      typeDef: { type: 'boolean' },
+    },
+    variant: {
+      typeDef: { type: 'string', enum: ['contained', 'outlined', 'text'] },
+    },
+    color: {
+      typeDef: { type: 'string', enum: ['primary', 'secondary'] },
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+  },
+};

--- a/packages/toolpad-components/src/Button.tsx
+++ b/packages/toolpad-components/src/Button.tsx
@@ -1,33 +1,34 @@
-import { Button, ButtonProps } from '@mui/material';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { Button } from '@mui/material';
+import { createComponent } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
-export default withDefaultProps(Button, {
-  children: 'Button Text',
-  variant: 'contained',
-  color: 'primary',
-});
-
-export const config: ComponentConfig<ButtonProps> = {
-  argTypes: {
-    children: {
-      label: 'content',
-      typeDef: { type: 'string' },
-    },
-    onClick: {
-      typeDef: { type: 'function' },
-    },
-    disabled: {
-      typeDef: { type: 'boolean' },
-    },
-    variant: {
-      typeDef: { type: 'string', enum: ['contained', 'outlined', 'text'] },
-    },
-    color: {
-      typeDef: { type: 'string', enum: ['primary', 'secondary'] },
-    },
-    sx: {
-      typeDef: { type: 'object' },
+export default createComponent(
+  withDefaultProps(Button, {
+    children: 'Button Text',
+    variant: 'contained',
+    color: 'primary',
+  }),
+  {
+    argTypes: {
+      children: {
+        label: 'content',
+        typeDef: { type: 'string' },
+      },
+      onClick: {
+        typeDef: { type: 'function' },
+      },
+      disabled: {
+        typeDef: { type: 'boolean' },
+      },
+      variant: {
+        typeDef: { type: 'string', enum: ['contained', 'outlined', 'text'] },
+      },
+      color: {
+        typeDef: { type: 'string', enum: ['primary', 'secondary'] },
+      },
+      sx: {
+        typeDef: { type: 'object' },
+      },
     },
   },
-};
+);

--- a/packages/toolpad-components/src/Container.tsx
+++ b/packages/toolpad-components/src/Container.tsx
@@ -1,9 +1,8 @@
-import { Container, ContainerProps } from '@mui/material';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { Container } from '@mui/material';
+import { createComponent } from '@mui/toolpad-core';
+import withDefaultProps from './utils/addDefaultProps';
 
-export default Container;
-
-export const config: ComponentConfig<ContainerProps> = {
+export default createComponent(withDefaultProps(Container, {}), {
   argTypes: {
     children: {
       typeDef: { type: 'element' },
@@ -13,4 +12,4 @@ export const config: ComponentConfig<ContainerProps> = {
       typeDef: { type: 'object' },
     },
   },
-};
+});

--- a/packages/toolpad-components/src/Container.tsx
+++ b/packages/toolpad-components/src/Container.tsx
@@ -1,3 +1,16 @@
-import { Container } from '@mui/material';
+import { Container, ContainerProps } from '@mui/material';
+import { ComponentConfig } from '@mui/toolpad-core';
 
 export default Container;
+
+export const config: ComponentConfig<ContainerProps> = {
+  argTypes: {
+    children: {
+      typeDef: { type: 'element' },
+      control: { type: 'slot' },
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+  },
+};

--- a/packages/toolpad-components/src/CustomLayout.tsx
+++ b/packages/toolpad-components/src/CustomLayout.tsx
@@ -1,7 +1,7 @@
 // Just for demo purposes
 import * as React from 'react';
 import { Grid } from '@mui/material';
-import { Placeholder, ComponentConfig } from '@mui/toolpad-core';
+import { Placeholder, createComponent } from '@mui/toolpad-core';
 
 export interface CustomLayoutProps {
   child1?: React.ReactNode;
@@ -9,7 +9,7 @@ export interface CustomLayoutProps {
   child3?: React.ReactNode;
 }
 
-export default function CustomLayout({ child1, child2, child3 }: CustomLayoutProps) {
+function CustomLayout({ child1, child2, child3 }: CustomLayoutProps) {
   return (
     <Grid container>
       <Grid item>
@@ -25,11 +25,11 @@ export default function CustomLayout({ child1, child2, child3 }: CustomLayoutPro
 
 CustomLayout.defaultProps = {};
 
-export const config: ComponentConfig<CustomLayoutProps> = {
+export default createComponent(CustomLayout, {
   argTypes: {
     child3: {
       typeDef: { type: 'element' },
       control: { type: 'slot' },
     },
   },
-};
+});

--- a/packages/toolpad-components/src/CustomLayout.tsx
+++ b/packages/toolpad-components/src/CustomLayout.tsx
@@ -1,7 +1,7 @@
 // Just for demo purposes
 import * as React from 'react';
 import { Grid } from '@mui/material';
-import { Placeholder } from '@mui/toolpad-core';
+import { Placeholder, ComponentConfig } from '@mui/toolpad-core';
 
 export interface CustomLayoutProps {
   child1?: React.ReactNode;
@@ -24,3 +24,12 @@ export default function CustomLayout({ child1, child2, child3 }: CustomLayoutPro
 }
 
 CustomLayout.defaultProps = {};
+
+export const config: ComponentConfig<CustomLayoutProps> = {
+  argTypes: {
+    child3: {
+      typeDef: { type: 'element' },
+      control: { type: 'slot' },
+    },
+  },
+};

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -9,7 +9,7 @@ import {
   GridColumnOrderChangeParams,
 } from '@mui/x-data-grid-pro';
 import * as React from 'react';
-import { useNode, UseDataQuery, ComponentConfig } from '@mui/toolpad-core';
+import { useNode, UseDataQuery, createComponent } from '@mui/toolpad-core';
 import { debounce } from '@mui/material';
 
 function inferColumnType(value: unknown): string | undefined {
@@ -155,13 +155,11 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
   );
 });
 
-export default DataGridComponent;
-
 DataGridComponent.defaultProps = {
   selection: null,
 };
 
-export const config: ComponentConfig<ToolpadDataGridProps> = {
+export default createComponent(DataGridComponent, {
   argTypes: {
     rows: {
       typeDef: { type: 'array', schema: '/schemas/DataGridRows.json' },
@@ -185,4 +183,4 @@ export const config: ComponentConfig<ToolpadDataGridProps> = {
       onChangeProp: 'onSelectionChange',
     },
   },
-};
+});

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -9,7 +9,7 @@ import {
   GridColumnOrderChangeParams,
 } from '@mui/x-data-grid-pro';
 import * as React from 'react';
-import { useNode, UseDataQuery } from '@mui/toolpad-core';
+import { useNode, UseDataQuery, ComponentConfig } from '@mui/toolpad-core';
 import { debounce } from '@mui/material';
 
 function inferColumnType(value: unknown): string | undefined {
@@ -159,4 +159,30 @@ export default DataGridComponent;
 
 DataGridComponent.defaultProps = {
   selection: null,
+};
+
+export const config: ComponentConfig<ToolpadDataGridProps> = {
+  argTypes: {
+    rows: {
+      typeDef: { type: 'array', schema: '/schemas/DataGridRows.json' },
+    },
+    columns: {
+      typeDef: { type: 'array', schema: '/schemas/DataGridColumns.json' },
+      control: { type: 'GridColumns' },
+      memoize: true,
+    },
+    dataQuery: {
+      typeDef: { type: 'object', schema: '/schemas/DataQuery.json' },
+    },
+    density: {
+      typeDef: { type: 'string', enum: ['compact', 'standard', 'comfortable'] },
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+    selection: {
+      typeDef: { type: 'object' },
+      onChangeProp: 'onSelectionChange',
+    },
+  },
 };

--- a/packages/toolpad-components/src/Image.tsx
+++ b/packages/toolpad-components/src/Image.tsx
@@ -1,6 +1,6 @@
 import { Box, SxProps, Theme } from '@mui/material';
 import * as React from 'react';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { createComponent } from '@mui/toolpad-core';
 
 export interface ImageProps {
   src: string;
@@ -10,7 +10,7 @@ export interface ImageProps {
 
 const EMPTY_SRC_STYLES = { minWidth: 30, minHeight: 30, border: 'inset' };
 
-export default function Image({ sx, src, ...props }: ImageProps) {
+function Image({ sx, src, ...props }: ImageProps) {
   return <Box component="img" src={src} sx={src ? sx : EMPTY_SRC_STYLES} {...props} />;
 }
 
@@ -19,7 +19,7 @@ Image.defaultProps = {
   sx: { maxWidth: '100%' },
 };
 
-export const config: ComponentConfig<ImageProps> = {
+export default createComponent(Image, {
   argTypes: {
     src: {
       typeDef: { type: 'string' },
@@ -31,4 +31,4 @@ export const config: ComponentConfig<ImageProps> = {
       typeDef: { type: 'object' },
     },
   },
-};
+});

--- a/packages/toolpad-components/src/Image.tsx
+++ b/packages/toolpad-components/src/Image.tsx
@@ -1,5 +1,6 @@
 import { Box, SxProps, Theme } from '@mui/material';
 import * as React from 'react';
+import { ComponentConfig } from '@mui/toolpad-core';
 
 export interface ImageProps {
   src: string;
@@ -16,4 +17,18 @@ export default function Image({ sx, src, ...props }: ImageProps) {
 Image.defaultProps = {
   alt: '',
   sx: { maxWidth: '100%' },
+};
+
+export const config: ComponentConfig<ImageProps> = {
+  argTypes: {
+    src: {
+      typeDef: { type: 'string' },
+    },
+    alt: {
+      typeDef: { type: 'string' },
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+  },
 };

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Stack, StackProps } from '@mui/material';
+import { ComponentConfig } from '@mui/toolpad-core';
 
 export interface PageRowProps {
   spacing?: number;
@@ -23,4 +24,32 @@ PageRow.defaultProps = {
   spacing: 2,
   alignItems: 'start',
   justifyContent: 'start',
+};
+
+export const config: ComponentConfig<PageRowProps> = {
+  argTypes: {
+    spacing: {
+      typeDef: { type: 'number' },
+    },
+    alignItems: {
+      typeDef: {
+        type: 'string',
+        enum: ['start', 'center', 'end', 'stretch', 'baseline'],
+      },
+      label: 'Vertical alignment',
+      control: { type: 'VerticalAlign' },
+    },
+    justifyContent: {
+      typeDef: {
+        type: 'string',
+        enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
+      },
+      label: 'Horizontal alignment',
+      control: { type: 'HorizontalAlign' },
+    },
+    children: {
+      typeDef: { type: 'element' },
+      control: { type: 'slots' },
+    },
+  },
 };

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Stack, StackProps } from '@mui/material';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { createComponent } from '@mui/toolpad-core';
 
 export interface PageRowProps {
   spacing?: number;
@@ -9,7 +9,7 @@ export interface PageRowProps {
   justifyContent?: StackProps['justifyContent'];
 }
 
-export default function PageRow({ spacing, children, alignItems, justifyContent }: PageRowProps) {
+function PageRow({ spacing, children, alignItems, justifyContent }: PageRowProps) {
   return (
     <Stack
       direction="row"
@@ -26,7 +26,7 @@ PageRow.defaultProps = {
   justifyContent: 'start',
 };
 
-export const config: ComponentConfig<PageRowProps> = {
+export default createComponent(PageRow, {
   argTypes: {
     spacing: {
       typeDef: { type: 'number' },
@@ -52,4 +52,4 @@ export const config: ComponentConfig<PageRowProps> = {
       control: { type: 'slots' },
     },
   },
-};
+});

--- a/packages/toolpad-components/src/Paper.tsx
+++ b/packages/toolpad-components/src/Paper.tsx
@@ -1,4 +1,20 @@
-import { Paper } from '@mui/material';
+import { Paper, PaperProps } from '@mui/material';
+import { ComponentConfig } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
 export default withDefaultProps(Paper, { elevation: 1 });
+
+export const config: ComponentConfig<PaperProps> = {
+  argTypes: {
+    elevation: {
+      typeDef: { type: 'number', minimum: 0 },
+    },
+    children: {
+      typeDef: { type: 'element' },
+      control: { type: 'slot' },
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+  },
+};

--- a/packages/toolpad-components/src/Paper.tsx
+++ b/packages/toolpad-components/src/Paper.tsx
@@ -1,10 +1,8 @@
-import { Paper, PaperProps } from '@mui/material';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { Paper } from '@mui/material';
+import { createComponent } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
-export default withDefaultProps(Paper, { elevation: 1 });
-
-export const config: ComponentConfig<PaperProps> = {
+export default createComponent(withDefaultProps(Paper, { elevation: 1 }), {
   argTypes: {
     elevation: {
       typeDef: { type: 'number', minimum: 0 },
@@ -17,4 +15,4 @@ export const config: ComponentConfig<PaperProps> = {
       typeDef: { type: 'object' },
     },
   },
-};
+});

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -8,6 +8,7 @@ import {
   SelectProps as MuiSelectProps,
   MenuItem,
 } from '@mui/material';
+import { ComponentConfig } from '@mui/toolpad-core';
 
 export interface Selectoption {
   value: string;
@@ -48,4 +49,37 @@ Select.defaultProps = {
   // eslint-disable-next-line react/default-props-match-prop-types
   value: '',
   options: [],
+};
+
+export const config: ComponentConfig<SelectProps> = {
+  argTypes: {
+    label: {
+      typeDef: { type: 'string' },
+    },
+    disabled: {
+      typeDef: { type: 'boolean' },
+    },
+    variant: {
+      typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
+    },
+    size: {
+      typeDef: { type: 'string', enum: ['small', 'normal'] },
+    },
+    value: {
+      typeDef: { type: 'string' },
+      onChangeProp: 'onChange',
+      defaultValueProp: 'defaultValue',
+      onChangeHandler: {
+        params: ['event'],
+        valueGetter: 'event.target.value',
+      },
+    },
+    options: {
+      typeDef: { type: 'array', schema: '/schemas/SelectOptions.json' },
+      control: { type: 'json' },
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+  },
 };

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -8,7 +8,7 @@ import {
   SelectProps as MuiSelectProps,
   MenuItem,
 } from '@mui/material';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { createComponent } from '@mui/toolpad-core';
 
 export interface Selectoption {
   value: string;
@@ -19,7 +19,7 @@ export interface SelectProps extends MuiSelectProps {
   options: (string | Selectoption)[];
 }
 
-export default function Select({ sx, label, options, ...props }: SelectProps) {
+function Select({ sx, label, options, ...props }: SelectProps) {
   const labelId = React.useId();
   return (
     <FormControl size="small" sx={{ minWidth: 120, ...sx }}>
@@ -43,15 +43,15 @@ Select.defaultProps = {
   // eslint-disable-next-line react/default-props-match-prop-types
   label: '',
   // eslint-disable-next-line react/default-props-match-prop-types
-  variant: 'outlined',
+  variant: 'outlined' as const,
   // eslint-disable-next-line react/default-props-match-prop-types
-  size: 'small',
+  size: 'small' as const,
   // eslint-disable-next-line react/default-props-match-prop-types
   value: '',
   options: [],
 };
 
-export const config: ComponentConfig<SelectProps> = {
+export default createComponent(Select, {
   argTypes: {
     label: {
       typeDef: { type: 'string' },
@@ -82,4 +82,4 @@ export const config: ComponentConfig<SelectProps> = {
       typeDef: { type: 'object' },
     },
   },
-};
+});

--- a/packages/toolpad-components/src/Stack.tsx
+++ b/packages/toolpad-components/src/Stack.tsx
@@ -1,4 +1,5 @@
-import { Stack } from '@mui/material';
+import { Stack, StackProps } from '@mui/material';
+import { ComponentConfig } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
 export default withDefaultProps(Stack, {
@@ -7,3 +8,39 @@ export default withDefaultProps(Stack, {
   alignItems: 'start',
   justifyContent: 'start',
 });
+
+export const config: ComponentConfig<StackProps> = {
+  argTypes: {
+    gap: {
+      typeDef: { type: 'number' },
+    },
+    margin: {
+      typeDef: { type: 'number' },
+    },
+    direction: {
+      typeDef: {
+        type: 'string',
+        enum: ['row', 'row-reverse', 'column', 'column-reverse'],
+      },
+    },
+    alignItems: {
+      typeDef: {
+        type: 'string',
+        enum: ['start', 'center', 'end', 'stretch', 'baseline'],
+      },
+    },
+    justifyContent: {
+      typeDef: {
+        type: 'string',
+        enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
+      },
+    },
+    children: {
+      typeDef: { type: 'element' },
+      control: { type: 'slots' },
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+  },
+};

--- a/packages/toolpad-components/src/Stack.tsx
+++ b/packages/toolpad-components/src/Stack.tsx
@@ -1,46 +1,47 @@
-import { Stack, StackProps } from '@mui/material';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { Stack } from '@mui/material';
+import { createComponent } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
-export default withDefaultProps(Stack, {
-  gap: 2,
-  direction: 'row',
-  alignItems: 'start',
-  justifyContent: 'start',
-});
-
-export const config: ComponentConfig<StackProps> = {
-  argTypes: {
-    gap: {
-      typeDef: { type: 'number' },
-    },
-    margin: {
-      typeDef: { type: 'number' },
-    },
-    direction: {
-      typeDef: {
-        type: 'string',
-        enum: ['row', 'row-reverse', 'column', 'column-reverse'],
+export default createComponent(
+  withDefaultProps(Stack, {
+    gap: 2,
+    direction: 'row',
+    alignItems: 'start',
+    justifyContent: 'start',
+  }),
+  {
+    argTypes: {
+      gap: {
+        typeDef: { type: 'number' },
       },
-    },
-    alignItems: {
-      typeDef: {
-        type: 'string',
-        enum: ['start', 'center', 'end', 'stretch', 'baseline'],
+      margin: {
+        typeDef: { type: 'number' },
       },
-    },
-    justifyContent: {
-      typeDef: {
-        type: 'string',
-        enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
+      direction: {
+        typeDef: {
+          type: 'string',
+          enum: ['row', 'row-reverse', 'column', 'column-reverse'],
+        },
       },
-    },
-    children: {
-      typeDef: { type: 'element' },
-      control: { type: 'slots' },
-    },
-    sx: {
-      typeDef: { type: 'object' },
+      alignItems: {
+        typeDef: {
+          type: 'string',
+          enum: ['start', 'center', 'end', 'stretch', 'baseline'],
+        },
+      },
+      justifyContent: {
+        typeDef: {
+          type: 'string',
+          enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
+        },
+      },
+      children: {
+        typeDef: { type: 'element' },
+        control: { type: 'slots' },
+      },
+      sx: {
+        typeDef: { type: 'object' },
+      },
     },
   },
-};
+);

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -1,35 +1,36 @@
-import { TextField, TextFieldProps } from '@mui/material';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { TextField } from '@mui/material';
+import { createComponent } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
-export default withDefaultProps(TextField, {
-  variant: 'outlined',
-  size: 'small',
-  value: '',
-});
-
-export const config: ComponentConfig<TextFieldProps> = {
-  argTypes: {
-    label: {
-      typeDef: { type: 'string' },
-    },
-    variant: {
-      typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
-    },
-    size: {
-      typeDef: { type: 'string', enum: ['small', 'normal'] },
-    },
-    value: {
-      typeDef: { type: 'string' },
-      onChangeProp: 'onChange',
-      onChangeHandler: {
-        params: ['event'],
-        valueGetter: 'event.target.value',
+export default createComponent(
+  withDefaultProps(TextField, {
+    variant: 'outlined',
+    size: 'small',
+    value: '',
+  }),
+  {
+    argTypes: {
+      label: {
+        typeDef: { type: 'string' },
       },
-      defaultValueProp: 'defaultValue',
-    },
-    sx: {
-      typeDef: { type: 'object' },
+      variant: {
+        typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
+      },
+      size: {
+        typeDef: { type: 'string', enum: ['small', 'normal'] },
+      },
+      value: {
+        typeDef: { type: 'string' },
+        onChangeProp: 'onChange',
+        onChangeHandler: {
+          params: ['event'],
+          valueGetter: 'event.target.value',
+        },
+        defaultValueProp: 'defaultValue',
+      },
+      sx: {
+        typeDef: { type: 'object' },
+      },
     },
   },
-};
+);

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -1,4 +1,5 @@
-import { TextField } from '@mui/material';
+import { TextField, TextFieldProps } from '@mui/material';
+import { ComponentConfig } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
 export default withDefaultProps(TextField, {
@@ -6,3 +7,29 @@ export default withDefaultProps(TextField, {
   size: 'small',
   value: '',
 });
+
+export const config: ComponentConfig<TextFieldProps> = {
+  argTypes: {
+    label: {
+      typeDef: { type: 'string' },
+    },
+    variant: {
+      typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
+    },
+    size: {
+      typeDef: { type: 'string', enum: ['small', 'normal'] },
+    },
+    value: {
+      typeDef: { type: 'string' },
+      onChangeProp: 'onChange',
+      onChangeHandler: {
+        params: ['event'],
+        valueGetter: 'event.target.value',
+      },
+      defaultValueProp: 'defaultValue',
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+  },
+};

--- a/packages/toolpad-components/src/Typography.tsx
+++ b/packages/toolpad-components/src/Typography.tsx
@@ -1,6 +1,25 @@
-import { Typography } from '@mui/material';
+import { Typography, TypographyProps } from '@mui/material';
+import { ComponentConfig } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
 export default withDefaultProps(Typography, {
   children: 'Text',
 });
+
+export const config: ComponentConfig<TypographyProps> = {
+  argTypes: {
+    children: {
+      typeDef: { type: 'string' },
+      label: 'value',
+    },
+    variant: {
+      typeDef: {
+        type: 'string',
+        enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2'],
+      },
+    },
+    sx: {
+      typeDef: { type: 'object' },
+    },
+  },
+};

--- a/packages/toolpad-components/src/Typography.tsx
+++ b/packages/toolpad-components/src/Typography.tsx
@@ -1,25 +1,26 @@
-import { Typography, TypographyProps } from '@mui/material';
-import { ComponentConfig } from '@mui/toolpad-core';
+import { Typography } from '@mui/material';
+import { createComponent } from '@mui/toolpad-core';
 import withDefaultProps from './utils/addDefaultProps';
 
-export default withDefaultProps(Typography, {
-  children: 'Text',
-});
-
-export const config: ComponentConfig<TypographyProps> = {
-  argTypes: {
-    children: {
-      typeDef: { type: 'string' },
-      label: 'value',
-    },
-    variant: {
-      typeDef: {
-        type: 'string',
-        enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2'],
+export default createComponent(
+  withDefaultProps(Typography, {
+    children: 'Text',
+  }),
+  {
+    argTypes: {
+      children: {
+        typeDef: { type: 'string' },
+        label: 'value',
+      },
+      variant: {
+        typeDef: {
+          type: 'string',
+          enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2'],
+        },
+      },
+      sx: {
+        typeDef: { type: 'object' },
       },
     },
-    sx: {
-      typeDef: { type: 'object' },
-    },
   },
-};
+);

--- a/packages/toolpad-components/src/index.tsx
+++ b/packages/toolpad-components/src/index.tsx
@@ -1,32 +1,21 @@
 export { default as PageRow } from './PageRow.js';
-export * from './PageRow.js';
 
 export { default as Stack } from './Stack.js';
-export * from './Stack.js';
 
 export { default as Button } from './Button.js';
-export * from './Button.js';
 
 export { default as DataGrid } from './DataGrid.js';
-export * from './DataGrid.js';
 
 export { default as Container } from './Container.js';
-export * from './Container.js';
 
 export { default as TextField } from './TextField.js';
-export * from './TextField.js';
 
 export { default as Typography } from './Typography.js';
-export * from './Typography.js';
 
 export { default as Select } from './Select.js';
-export * from './Select.js';
 
 export { default as Paper } from './Paper.js';
-export * from './Paper.js';
 
 export { default as CustomLayout } from './CustomLayout.js';
-export * from './CustomLayout.js';
 
 export { default as Image } from './Image.js';
-export * from './Image.js';

--- a/packages/toolpad-core/src/constants.ts
+++ b/packages/toolpad-core/src/constants.ts
@@ -1,2 +1,3 @@
 export const RUNTIME_PROP_NODE_ID = '__toolpadNodeId';
 export const RUNTIME_PROP_SLOTS = '__toolpadSlots';
+export const TOOLPAD_COMPONENT = Symbol.for('ToolpadComponent');

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -140,9 +140,14 @@ export interface ComponentDefinition<P> {
   argTypes: ArgTypeDefinitions<P>;
 }
 
+export interface LiveBindingError {
+  message: string;
+  stack?: string;
+}
+
 export interface LiveBinding {
   value?: any;
-  error?: Error;
+  error?: LiveBindingError;
 }
 
 export type RuntimeEvent =

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -1,3 +1,6 @@
+import React from 'react';
+import { TOOLPAD_COMPONENT } from './constants';
+
 export type BindingAttrValueFormat = 'stringLiteral' | 'default';
 
 // TODO: Get rid of BoundExpressionAttrValue? Its function can be fulfilled by derivedState as well
@@ -168,6 +171,19 @@ export type RuntimeEvent =
 
 export interface ComponentConfig<P> {
   argTypes: ArgTypeDefinitions<P>;
+}
+
+export type ToolpadComponent<P> = React.ComponentType<P> & {
+  [TOOLPAD_COMPONENT]: ComponentConfig<P>;
+};
+
+export function createComponent<P>(
+  Component: React.ComponentType<P>,
+  config?: ComponentConfig<P>,
+): ToolpadComponent<P> {
+  return Object.assign(Component, {
+    [TOOLPAD_COMPONENT]: config || { argTypes: {} },
+  });
 }
 
 export type LiveBindings = Partial<Record<string, LiveBinding>>;


### PR DESCRIPTION
Brings Toolpad component definition to the React Component itself so we can read it in the runtime.