### PR TITLE
Make the editor aware of component types that are live in the app

### DIFF
--- a/packages/toolpad-app/runtime/codeComponentEditor/CodeComponentSandbox.tsx
+++ b/packages/toolpad-app/runtime/codeComponentEditor/CodeComponentSandbox.tsx
@@ -81,11 +81,6 @@ export default function CodeComponentSandbox() {
     );
 
     import(importUrl).then((mod) => {
-      // eslint-disable-next-line no-underscore-dangle
-      if (window.__TOOLPAD_EDITOR_UPDATE_COMPONENT_CONFIG__) {
-        // eslint-disable-next-line no-underscore-dangle
-        window.__TOOLPAD_EDITOR_UPDATE_COMPONENT_CONFIG__(mod.config);
-      }
       setComponent(() => mod.default);
       seterrorBoundaryKey((key) => key + 1);
     });

--- a/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
@@ -111,7 +111,8 @@ function RenderedNode({ nodeId }: RenderedNodeProps) {
 
   const node = appDom.getNode(dom, nodeId, 'element');
   const { children = [] } = appDom.getChildNodes(dom, node);
-  const { Component, argTypes } = useElmToolpadComponent(node);
+  const { Component } = useElmToolpadComponent(node);
+  const { argTypes } = Component[TOOLPAD_COMPONENT];
 
   const liveBindings = useBindingsContext();
 
@@ -199,7 +200,8 @@ function useInitialControlledState(dom: appDom.AppDom, page: appDom.PageNode): C
     return Object.fromEntries(
       elements.flatMap((elm) => {
         if (appDom.isElement(elm)) {
-          const { argTypes, Component } = getElmComponent(components, elm);
+          const { Component } = getElmComponent(components, elm);
+          const { argTypes } = Component[TOOLPAD_COMPONENT];
           return [
             [
               elm.name,
@@ -298,7 +300,8 @@ function useLiveBindings(
     descendants.forEach((descendant) => {
       if (appDom.isElement(descendant)) {
         if (descendant.props) {
-          const { argTypes } = getElmComponent(components, descendant);
+          const { Component } = getElmComponent(components, descendant);
+          const { argTypes } = Component[TOOLPAD_COMPONENT];
           const elmBindables = resolveBindables(descendant.props, currentPageState, argTypes);
           Object.entries(elmBindables).forEach(([propName, bindable]) => {
             bindings[`${descendant.id}.props.${propName}`] = bindable;

--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -6,7 +6,6 @@ import {
   BindableAttrValues,
   ConstantAttrValues,
   SecretAttrValue,
-  ArgTypeDefinitions,
   PropValueType,
   PropValueTypes,
 } from '@mui/toolpad-core';
@@ -106,7 +105,6 @@ export interface CodeComponentNode extends AppDomNodeBase {
   readonly type: 'codeComponent';
   readonly attributes: {
     readonly code: ConstantAttrValue<string>;
-    readonly argTypes: ConstantAttrValue<ArgTypeDefinitions>;
   };
 }
 

--- a/packages/toolpad-app/src/components/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/CodeComponentEditor/index.tsx
@@ -3,7 +3,6 @@ import { Box, Button, Stack, styled, Toolbar, Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import Editor from '@monaco-editor/react';
 import type * as monacoEditor from 'monaco-editor';
-import { ArgTypeDefinitions, ComponentConfig } from '@mui/toolpad-core';
 import { transform } from 'sucrase';
 import { NodeId } from '../../../types';
 import * as appDom from '../../../appDom';
@@ -68,17 +67,10 @@ interface CodeComponentEditorContentProps {
   codeComponentNode: appDom.CodeComponentNode;
 }
 
-declare global {
-  interface Window {
-    __TOOLPAD_EDITOR_UPDATE_COMPONENT_CONFIG__?: React.Dispatch<React.SetStateAction<any>>;
-  }
-}
-
 function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorContentProps) {
   const domApi = useDomApi();
 
   const [input, setInput] = React.useState(codeComponentNode.attributes.code.value);
-  const [argTypes, setArgTypes] = React.useState<ArgTypeDefinitions>({});
 
   const frameRef = React.useRef<HTMLIFrameElement>(null);
 
@@ -94,21 +86,8 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
         'code',
         appDom.createConst(pretty),
       );
-      domApi.setNodeNamespacedProp(
-        codeComponentNode,
-        'attributes',
-        'argTypes',
-        appDom.createConst(argTypes),
-      );
     };
-  }, [domApi, codeComponentNode, input, argTypes]);
-
-  const handleConfigUpdate = React.useCallback(
-    (newConfig: ComponentConfig<unknown> | undefined) => {
-      setArgTypes(newConfig?.argTypes || {});
-    },
-    [],
-  );
+  }, [domApi, codeComponentNode, input]);
 
   const editorRef = React.useRef<monacoEditor.editor.IStandaloneCodeEditor>();
   const HandleEditorMount = React.useCallback(
@@ -160,16 +139,6 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
     },
     [],
   );
-
-  const setupFrameWindow = React.useCallback(() => {
-    if (frameRef.current?.contentWindow) {
-      // eslint-disable-next-line no-underscore-dangle
-      frameRef.current.contentWindow.__TOOLPAD_EDITOR_UPDATE_COMPONENT_CONFIG__ =
-        handleConfigUpdate;
-    }
-  }, [handleConfigUpdate]);
-
-  React.useEffect(() => setupFrameWindow(), [setupFrameWindow]);
 
   React.useEffect(() => {
     const frameWindow = frameRef.current?.contentWindow;

--- a/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -18,17 +18,13 @@ function createDefaultCodeComponent(name: string): string {
   const propTypeId = `${componentId}Props`;
   return format(`
     import * as React from 'react';
-    import type { ComponentConfig } from '@mui/toolpad-core';
+    import { createComponent } from '@mui/toolpad-core';
     
     export interface ${propTypeId} {
       msg: string;
     }
     
-    export const config: ComponentConfig<${propTypeId}> = {
-      argTypes: {}
-    }
-    
-    export default function ${componentId}({ msg }: ${propTypeId}) {
+    function ${componentId}({ msg }: ${propTypeId}) {
       return (
         <div>{msg}</div>
       );
@@ -37,6 +33,12 @@ function createDefaultCodeComponent(name: string): string {
     ${componentId}.defaultProps = {
       msg: "Hello world!",
     };
+
+    export default createComponent(${componentId}, {
+      argTypes: {
+        msg: { typeDef: { type: "string" } }
+      }
+    });
   `);
 }
 
@@ -70,7 +72,6 @@ export default function CreateStudioCodeComponentDialog({
             name,
             attributes: {
               code: appDom.createConst(createDefaultCodeComponent(name)),
-              argTypes: appDom.createConst({}),
             },
           });
           const appNode = appDom.getApp(dom);

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentEditor.tsx
@@ -1,6 +1,6 @@
 import { styled, Typography } from '@mui/material';
 import * as React from 'react';
-import { ArgTypeDefinition, ArgTypeDefinitions } from '@mui/toolpad-core';
+import { ArgTypeDefinition, ArgTypeDefinitions, ComponentConfig } from '@mui/toolpad-core';
 import { ExactEntriesOf } from '../../../utils/types';
 import * as appDom from '../../../appDom';
 import NodeAttributeEditor from './NodeAttributeEditor';
@@ -30,15 +30,13 @@ function shouldRenderControl(propTypeDef: ArgTypeDefinition) {
 
 interface ComponentPropsEditorProps<P> {
   node: appDom.ElementNode<P>;
+  componentConfig: ComponentConfig<P>;
 }
 
-function ComponentPropsEditor<P>({ node }: ComponentPropsEditorProps<P>) {
-  const dom = useDom();
-  const definition = useToolpadComponent(dom, node.attributes.component.value);
-
+function ComponentPropsEditor<P>({ componentConfig, node }: ComponentPropsEditorProps<P>) {
   return (
     <ComponentPropsEditorRoot>
-      {(Object.entries(definition.argTypes) as ExactEntriesOf<ArgTypeDefinitions<P>>).map(
+      {(Object.entries(componentConfig.argTypes) as ExactEntriesOf<ArgTypeDefinitions<P>>).map(
         ([propName, propTypeDef]) =>
           propTypeDef && shouldRenderControl(propTypeDef) ? (
             <div key={propName} className={classes.control}>
@@ -63,6 +61,7 @@ function SelectedNodeEditor({ node }: SelectedNodeEditorProps) {
   const dom = useDom();
   const { viewState } = usePageEditorState();
   const nodeError = viewState.nodes[node.id]?.error;
+  const componentConfig = viewState.nodes[node.id]?.componentConfig || { argTypes: {} };
 
   const component = useToolpadComponent(dom, node.attributes.component.value);
 
@@ -79,7 +78,7 @@ function SelectedNodeEditor({ node }: SelectedNodeEditorProps) {
           <Typography variant="subtitle1" sx={{ mt: 2 }}>
             Properties:
           </Typography>
-          <ComponentPropsEditor node={node} />
+          <ComponentPropsEditor componentConfig={componentConfig} node={node} />
         </React.Fragment>
       ) : null}
     </React.Fragment>

--- a/packages/toolpad-app/src/toolpadComponents/index.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/index.tsx
@@ -1,27 +1,11 @@
-import {
-  PageRow,
-  Stack,
-  Button,
-  Image,
-  DataGrid,
-  Container,
-  TextField,
-  Typography,
-  Select,
-  Paper,
-  CustomLayout,
-} from '@mui/toolpad-components';
-import { ArgTypeDefinitions, ToolpadComponent, TOOLPAD_COMPONENT } from '@mui/toolpad-core';
+import { ToolpadComponent } from '@mui/toolpad-core';
 import * as appDom from '../appDom';
 import { VersionOrPreview } from '../types';
 
 export interface ToolpadComponentDefinition {
   displayName: string;
-  argTypes: ArgTypeDefinitions;
   importedModule: string;
   importedName: string;
-  codeComponent?: boolean;
-  extraControls?: Partial<Record<string, { type: string }>>;
 }
 
 export type ToolpadComponentDefinitions = Record<string, ToolpadComponentDefinition | undefined>;
@@ -37,7 +21,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'PageRow',
       importedModule: '@mui/toolpad-components',
       importedName: 'PageRow',
-      ...PageRow[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -46,7 +29,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'Stack',
       importedModule: '@mui/toolpad-components',
       importedName: 'Stack',
-      ...Stack[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -55,7 +37,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'Button',
       importedModule: '@mui/toolpad-components',
       importedName: 'Button',
-      ...Button[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -64,7 +45,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'Image',
       importedModule: '@mui/toolpad-components',
       importedName: 'Image',
-      ...Image[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -73,7 +53,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'DataGrid',
       importedModule: '@mui/toolpad-components',
       importedName: 'DataGrid',
-      ...DataGrid[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -82,7 +61,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'Container',
       importedModule: '@mui/toolpad-components',
       importedName: 'Container',
-      ...Container[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -91,7 +69,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'TextField',
       importedModule: '@mui/toolpad-components',
       importedName: 'TextField',
-      ...TextField[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -100,7 +77,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'Typography',
       importedModule: '@mui/toolpad-components',
       importedName: 'Typography',
-      ...Typography[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -109,7 +85,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'Select',
       importedModule: '@mui/toolpad-components',
       importedName: 'Select',
-      ...Select[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -118,7 +93,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'Paper',
       importedModule: '@mui/toolpad-components',
       importedName: 'Paper',
-      ...Paper[TOOLPAD_COMPONENT],
     },
   ],
   [
@@ -127,7 +101,6 @@ const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
       displayName: 'CustomLayout',
       importedModule: '@mui/toolpad-components',
       importedName: 'CustomLayout',
-      ...CustomLayout[TOOLPAD_COMPONENT],
     },
   ],
 ]);
@@ -139,12 +112,10 @@ function createCodeComponent(
 ): ToolpadComponentDefinition {
   return {
     displayName: domNode.name,
-    argTypes: domNode.attributes.argTypes.value,
     importedModule: `/api/components/${encodeURIComponent(appId)}/${encodeURIComponent(
       version,
     )}/${encodeURIComponent(domNode.id)}`,
     importedName: 'default',
-    codeComponent: true,
   };
 }
 


### PR DESCRIPTION
...instead of requiring them to be statically defined. It's all contained within the components themselves now. 
* This removes a few hacks that were in place to support code components. Makes them a lot more stable.
* More powerful component definitions, they don't need to be strictly json serializable anymore. e.g. This will allow us to create more sensible argTypes around event handlers.
* Any component can now present itself as a toolpad component, it doesn't need to be statically defined anywhere, once it's imported in the app, the editor will just follow whatever is connectd as `argTypes`
* more straightforward definition using `createComponent`

Components are now defined using `createComponent`:

```tsx
import * as React from "react";
import { createComponent } from "@mui/toolpad-core";

export interface HelloProps {
  msg: string;
}

function Hello({ msg }: HelloProps) {
  return <div>{msg}</div>;
}

Hello.defaultProps = {
  msg: "Hello world!",
};

export default createComponent(Hello, {
  argTypes: {
    msg: { typeDef: { type: "string" } },
  },
});
```
this makes them more self-contained and easier to pass around. Typescript-wise this is easier as well as it will automatically infer the props type. The legacy method with `config` export still works but will be removed later.