### PR TITLE
Create new debouncer for dom saving

### DIFF
--- a/packages/toolpad-app/src/components/DomLoader.tsx
+++ b/packages/toolpad-app/src/components/DomLoader.tsx
@@ -5,8 +5,8 @@ import * as appDom from '../appDom';
 import { NodeId } from '../types';
 import { update } from '../utils/immutability';
 import client from '../api';
-import useDebounced from '../utils/useDebounced';
 import useShortcut from '../utils/useShortcut';
+import useDebouncedHandler from '../utils/useDebouncedHandler';
 
 export type DomAction =
   | {
@@ -318,14 +318,11 @@ export default function DomProvider({ appId, children }: DomContextProps) {
       });
   }, [appId, state.dom]);
 
-  const debouncedDom = useDebounced(state.dom, 1000);
-  const lastSavedDebouncedDom = React.useRef<appDom.AppDom | null>(null);
+  const debouncedhandleSave = useDebouncedHandler(handleSave, 1000);
+
   React.useEffect(() => {
-    if (debouncedDom !== lastSavedDebouncedDom.current) {
-      handleSave();
-      lastSavedDebouncedDom.current = debouncedDom;
-    }
-  }, [debouncedDom, handleSave]);
+    debouncedhandleSave();
+  }, [state.dom, debouncedhandleSave]);
 
   React.useEffect(() => {
     if (state.unsavedChanges <= 0) {

--- a/packages/toolpad-app/src/utils/useDebouncedHandler.ts
+++ b/packages/toolpad-app/src/utils/useDebouncedHandler.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+/**
+ * Creates a debounced version of the handler that is passed. The invocation of [fn] is
+ * delayed for [delay] milliseconds from the last invocation of the debounced function.
+ */
+export default function useDebouncedHandler<P extends any[]>(
+  fn: (...params: P) => void,
+  delay: number,
+): (...params: P) => void {
+  const fnRef = React.useRef(fn);
+  React.useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
+  const timeout = React.useRef<NodeJS.Timeout | null>(null);
+
+  React.useEffect(
+    () => () => {
+      if (timeout.current) {
+        // TODO: Should this be optional? Someone might want to run the function, even after unmount.
+        clearTimeout(timeout.current);
+        timeout.current = null;
+      }
+    },
+    [],
+  );
+
+  return React.useCallback(
+    (...params: P) => {
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+        timeout.current = null;
+      }
+
+      timeout.current = setTimeout(() => {
+        fnRef.current(...params);
+        timeout.current = null;
+      }, delay);
+    },
+    [delay],
+  );
+}


### PR DESCRIPTION
Both versions of debouncing are needed sometimes. One for delaying updates to state. One for debouncing function invocations. This adds the second version and replaces the dom autosaving algorithm to use this. It makes the logic more intuitive.
