### PR TITLE
Fix undo after save

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/CodeComponentEditor/index.tsx
@@ -80,10 +80,26 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
   const editorRef = React.useRef<monacoEditor.editor.IStandaloneCodeEditor>();
 
   const updateInputExtern = React.useCallback((newInput) => {
-    // Workaround for a problem in monaco editor
-    // See https://github.com/suren-atoyan/monaco-react/issues/365
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+
+    const model = editor.getModel();
+    if (!model) {
+      return;
+    }
+
+    // Used to restore cursor position
     const state = editorRef.current?.saveViewState();
-    editorRef.current?.setValue(newInput);
+
+    editor.executeEdits(null, [
+      {
+        range: model.getFullModelRange(),
+        text: newInput,
+      },
+    ]);
+
     if (state) {
       editorRef.current?.restoreViewState(state);
     }
@@ -201,7 +217,7 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
         <Box flex={1}>
           <Editor
             height="100%"
-            value={input}
+            defaultValue={input}
             onChange={(newValue) => setInput(newValue || '')}
             path="./component.tsx"
             language="typescript"

--- a/packages/toolpad-app/src/components/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/CodeComponentEditor/index.tsx
@@ -206,7 +206,7 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
   return (
     <Stack sx={{ height: '100%' }}>
       <Toolbar variant="dense" sx={{ mt: 2 }}>
-        <NodeNameEditor node={codeComponentNode} />
+        <NodeNameEditor node={codeComponentNode} sx={{ maxWidth: 300 }} />
       </Toolbar>
       <Toolbar variant="dense">
         <Button disabled={allChangesAreCommitted} onClick={handleSave}>

--- a/packages/toolpad-app/src/components/AppEditor/NodeNameEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/NodeNameEditor.tsx
@@ -1,13 +1,14 @@
-import { TextField } from '@mui/material';
+import { SxProps, TextField } from '@mui/material';
 import * as React from 'react';
 import * as appDom from '../../appDom';
 import { useDomApi } from '../DomLoader';
 
 interface NodeNameEditorProps {
   node: appDom.AppDomNode;
+  sx?: SxProps;
 }
 
-export default function NodeNameEditor({ node }: NodeNameEditorProps) {
+export default function NodeNameEditor({ node, sx }: NodeNameEditorProps) {
   const domApi = useDomApi();
 
   const [nameInput, setNameInput] = React.useState(node.name);
@@ -34,6 +35,7 @@ export default function NodeNameEditor({ node }: NodeNameEditorProps) {
 
   return (
     <TextField
+      sx={sx}
       fullWidth
       size="small"
       label="name"


### PR DESCRIPTION
Use an insert operation (`executeEdits`) to replace the content of the model instead of `setValue`. This preserves the undo stack.

Closes https://github.com/mui/mui-toolpad/issues/349 again