### PR TITLE
Few small UI tweaks

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -79,12 +79,12 @@ const OverlayRoot = styled('div')({
     display: 'none',
     position: 'absolute',
     alignItems: 'center',
-    right: 0,
+    right: -1,
     background: 'red',
     color: 'white',
     fontSize: 11,
-    padding: `2px 0 2px 8px`,
-    // TODO: figure out positioning of this selectionhint, it should
+    padding: `0 0 0 8px`,
+    // TODO: figure out positioning of this selectionhint, perhaps it should
     //   - prefer top right, above the component
     //   - if that appears out of bound of the editor, show it bottom or left
     zIndex: 1,

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -181,7 +181,8 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
 
 DataGridComponent.defaultProps = {
   selection: null,
-};
+  density: 'compact',
+} as ToolpadDataGridProps;
 
 export default createComponent(DataGridComponent, {
   errorProp: 'error',


### PR DESCRIPTION
- DataGrid default density to `'compact'`
- move selectionhint over 1 pixel to align with selection outline