### PR TITLE
Change the binding button's icons to indicate what clicking the button does

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/BindingEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/BindingEditor.tsx
@@ -178,7 +178,7 @@ export function BindingEditor<V>({
       onClick={handleOpen}
       color={hasBinding ? 'primary' : 'inherit'}
     >
-      {hasBinding ? <LinkIcon fontSize="inherit" /> : <LinkOffIcon fontSize="inherit" />}
+      {hasBinding ? <LinkOffIcon fontSize="inherit" /> : <LinkIcon fontSize="inherit" />}
     </IconButton>
   );
 


### PR DESCRIPTION
> If you decide to use a single control to indicate both state and what will happen next, how should that control be labeled?
> [...]
> If there is no text label (presumably because the icon is clear enough), then the _icon should change depending on the state it moves the system to_.
> A classic example is the interplay between the Play and Pause icons seen in the YouTube example above and present in most video players.

https://www.nngroup.com/articles/state-switch-buttons/
