### PR TITLE
GridColumns editor: Use the live bindings for finding the actual rows value

### DIFF
--- a/packages/toolpad-app/src/components/propertyControls/GridColumns.tsx
+++ b/packages/toolpad-app/src/components/propertyControls/GridColumns.tsx
@@ -39,7 +39,7 @@ function GridColumnsPropEditor({
   onChange,
   disabled,
 }: EditorProps<GridColumns>) {
-  const { viewState } = usePageEditorState();
+  const { bindings } = usePageEditorState();
   const [editColumnsDialogOpen, setEditColumnsDialogOpen] = React.useState(false);
   const [editedIndex, setEditedIndex] = React.useState<number | null>(null);
 
@@ -59,7 +59,8 @@ function GridColumnsPropEditor({
     setMenuAnchorEl(null);
   };
 
-  const definedRows = viewState.nodes[nodeId]?.props.rows;
+  const rowsValue = bindings[`${nodeId}.props.rows`];
+  const definedRows: unknown = rowsValue?.value;
 
   const columnSuggestions = React.useMemo(() => {
     const inferred = inferColumns(Array.isArray(definedRows) ? definedRows : []);


### PR DESCRIPTION
@bharatkashyap Proposing this change, since https://github.com/mui/mui-toolpad/pull/357, everywhere else in the editor this is used to retrieve live values so this would standardize on a single method for that. It also contains more information (error/loading information) about the value.