### PR TITLE
Default REST datasource

### DIFF
--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -159,7 +159,6 @@ export async function createApp(name: string): Promise<App> {
         status: appDom.createConst(null),
       },
     });
-    console.log(newNode);
     const newDom = await appDom.addNode(dom, newNode, appNode, 'connections');
     await saveDom(app.id, newDom);
 

--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -151,7 +151,17 @@ export async function createApp(name: string): Promise<App> {
     });
 
     const dom = appDom.createDom();
-    await saveDom(app.id, dom);
+    const appNode = appDom.getApp(dom);
+    const newNode = appDom.createNode(dom, 'connection', {
+      attributes: {
+        dataSource: appDom.createConst('rest'),
+        params: appDom.createSecret({ name: 'rest' }),
+        status: appDom.createConst(null),
+      },
+    });
+    console.log(newNode);
+    const newDom = await appDom.addNode(dom, newNode, appNode, 'connections');
+    await saveDom(app.id, newDom);
 
     return app;
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Fixes #364

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Earliest implementation of adding a default `rest` connection inside `createApp`.  

Perhaps it is better to add this logic inside the client after `createAppMutation.mutateAsync([name]);`,the issue there is that the `dom` doesn't exist yet and the `useDom()` hook isn't callable at that point.
