### PR TITLE
Disable Select while loading

### DIFF
--- a/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
@@ -117,7 +117,7 @@ function RenderedNodeContent({ nodeId, childNodes, Component }: RenderedNodeCont
     const loadingPropSourceSet = new Set(loadingPropSource);
     const hookResult: Record<string, any> = {};
 
-    // error state we will propagate tot he component
+    // error state we will propagate tot the component
     let error: Error | undefined;
     // loading state we will propagate to the component
     let loading: boolean = false;

--- a/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
@@ -117,7 +117,7 @@ function RenderedNodeContent({ nodeId, childNodes, Component }: RenderedNodeCont
     const loadingPropSourceSet = new Set(loadingPropSource);
     const hookResult: Record<string, any> = {};
 
-    // error state we will propagate tot the component
+    // error state we will propagate to the component
     let error: Error | undefined;
     // loading state we will propagate to the component
     let loading: boolean = false;

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -52,6 +52,8 @@ Select.defaultProps = {
 };
 
 export default createComponent(Select, {
+  loadingPropSource: ['value', 'options'],
+  loadingProp: 'disabled',
   argTypes: {
     label: {
       typeDef: { type: 'string' },


### PR DESCRIPTION
The `Select` component doesn't have loading state like the `AutoComplete` has. For now we can just disable it while data is loading