### PR TITLE
Refactors for upcoming query+API merge

### DIFF
--- a/packages/toolpad-app/index.d.ts
+++ b/packages/toolpad-app/index.d.ts
@@ -1,1 +1,3 @@
+import 'react/next';
+
 export {};

--- a/packages/toolpad-app/runtime/pageEditor/EditorSandbox.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/EditorSandbox.tsx
@@ -30,7 +30,6 @@ export default function EditorCanvas({ dom: initialDom, ...props }: EditorCanvas
     // eslint-disable-next-line no-underscore-dangle
     window.__TOOLPAD_BRIDGE__ = {
       updateDom: (newDom) => {
-        // @ts-expect-error Need to upgrade @types/react
         React.startTransition(() => {
           setDom(newDom);
         });

--- a/packages/toolpad-app/src/components/AppEditor/BindingEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/BindingEditor.tsx
@@ -141,7 +141,7 @@ export interface BindingEditorProps<V> extends WithControlledProp<BindableAttrVa
    */
   server?: boolean;
   disabled?: boolean;
-  propType: PropValueType;
+  propType?: PropValueType;
   liveBinding?: LiveBinding;
 }
 
@@ -230,7 +230,7 @@ export function BindingEditor<V>({
             <Box sx={{ height: '100%', display: 'flex', flex: 1, flexDirection: 'column' }}>
               <Typography sx={{ mb: 2 }}>
                 Make the &quot;{label}&quot; property dynamic with a JavaScript expression. This
-                property expects a type: <code>{propType.type}</code>.
+                property expects a type: <code>{propType?.type || 'any'}</code>.
               </Typography>
 
               <JsExpressionBindingEditor<V>

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/NodeAttributeEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/NodeAttributeEditor.tsx
@@ -3,6 +3,7 @@ import { ArgTypeDefinition, BindableAttrValue } from '@mui/toolpad-core';
 import * as appDom from '../../../appDom';
 import { useDomApi } from '../../DomLoader';
 import BindableEditor from './BindableEditor';
+import { usePageEditorState } from './PageEditorProvider';
 
 export interface NodeAttributeEditorProps {
   node: appDom.AppDomNode;
@@ -28,10 +29,16 @@ export default function NodeAttributeEditor({
 
   const propValue: BindableAttrValue<unknown> | null = (node as any)[namespace]?.[name] ?? null;
 
+  const bindingId = `${node.id}${namespace ? `.${namespace}` : ''}.${name}`;
+  const { bindings, pageState } = usePageEditorState();
+  const liveBinding = bindings[bindingId];
+  const globalScope = pageState;
+
   return (
     <BindableEditor
-      propNamespace={namespace}
-      propName={name}
+      liveBinding={liveBinding}
+      globalScope={globalScope}
+      label={name}
       argType={argType}
       nodeId={node.id}
       value={propValue}

--- a/packages/toolpad-app/src/components/propertyControls/select.tsx
+++ b/packages/toolpad-app/src/components/propertyControls/select.tsx
@@ -2,14 +2,8 @@ import { FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from '@m
 import * as React from 'react';
 import type { EditorProps, PropControlDefinition } from '../../types';
 
-function SelectPropEditor({
-  propName,
-  label,
-  argType,
-  value,
-  onChange,
-  disabled,
-}: EditorProps<string>) {
+function SelectPropEditor({ label, argType, value, onChange, disabled }: EditorProps<string>) {
+  const id = React.useId();
   const items = argType.typeDef.type === 'string' ? argType.typeDef.enum ?? [] : [];
   const handleChange = React.useCallback(
     (event: SelectChangeEvent<string>) => {
@@ -19,9 +13,9 @@ function SelectPropEditor({
   );
   return (
     <FormControl fullWidth size="small">
-      <InputLabel id={`select-${propName}`}>{label}</InputLabel>
+      <InputLabel id={id}>{label}</InputLabel>
       <Select
-        labelId={`select-${propName}`}
+        labelId={id}
         size="small"
         label={label}
         value={value ?? ''}

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -12,7 +12,6 @@ import type { Rectangle } from './utils/geometry';
 
 export interface EditorProps<T> {
   nodeId: NodeId;
-  propName: string;
   label: string;
   argType: ArgTypeDefinition;
   disabled?: boolean;

--- a/packages/toolpad-core/src/useDataQuery.ts
+++ b/packages/toolpad-core/src/useDataQuery.ts
@@ -34,7 +34,6 @@ const EMPTY_ARRAY: any[] = [];
 const EMPTY_OBJECT: any = {};
 
 export function useDataQuery(
-  setResult: (newResult: UseDataQuery) => void,
   dataUrl: string,
   queryId: string | null,
   params: any,
@@ -42,7 +41,7 @@ export function useDataQuery(
     UseQueryOptions<any, unknown, unknown, any[]>,
     'refetchOnWindowFocus' | 'refetchOnReconnect' | 'refetchInterval'
   >,
-): void {
+): UseDataQuery {
   const {
     isLoading,
     isFetching,
@@ -70,7 +69,5 @@ export function useDataQuery(
     [isLoading, isFetching, error, data, rows, refetch],
   );
 
-  React.useEffect(() => {
-    setResult(result);
-  }, [setResult, result]);
+  return result;
 }


### PR DESCRIPTION
a few refactors to be released separately

* use React 18 `useId` for`Select` label id
* Remove setState parameter from `useDataQuery`
* shift a few things around in the `BindableEditor` for reusability