### PR TITLE
onChangeHandler can be a function now

### DIFF
--- a/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
+++ b/packages/toolpad-app/runtime/pageEditor/ToolpadApp.tsx
@@ -160,16 +160,9 @@ function RenderedNodeContent({ nodeId, childNodes, Component }: RenderedNodeCont
             return [];
           }
 
-          const valueGetter = argType.onChangeHandler
-            ? new Function(
-                ...argType.onChangeHandler.params,
-                `return ${argType.onChangeHandler.valueGetter}`,
-              )
-            : (value: any) => value;
-
           const handler = (param: any) => {
-            const value = valueGetter(param);
             const bindingId = `${nodeId}.props.${key}`;
+            const value = argType.onChangeHandler ? argType.onChangeHandler(param) : param;
             setControlledBinding(bindingId, { value });
           };
           return [[argType.onChangeProp, handler]];

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -70,10 +70,7 @@ export default createComponent(Select, {
     value: {
       typeDef: { type: 'string' },
       onChangeProp: 'onChange',
-      onChangeHandler: {
-        params: ['event'],
-        valueGetter: 'event.target.value',
-      },
+      onChangeHandler: (event: React.ChangeEvent<HTMLSelectElement>) => event.target.value,
     },
     options: {
       typeDef: { type: 'array', schema: '/schemas/SelectOptions.json' },

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -22,10 +22,7 @@ export default createComponent(
       value: {
         typeDef: { type: 'string' },
         onChangeProp: 'onChange',
-        onChangeHandler: {
-          params: ['event'],
-          valueGetter: 'event.target.value',
-        },
+        onChangeHandler: (event: React.ChangeEvent<HTMLInputElement>) => event.target.value,
       },
       sx: {
         typeDef: { type: 'object' },

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -45,11 +45,6 @@ export type BindableAttrValues<P> = {
 
 export type SlotType = 'single' | 'multiple';
 
-export interface OnChangeHandler {
-  params: string[];
-  valueGetter: string;
-}
-
 export interface ValueTypeBase {
   type: 'string' | 'boolean' | 'number' | 'object' | 'array' | 'element' | 'function';
 }
@@ -146,8 +141,10 @@ export interface ArgTypeDefinition {
   onChangeProp?: string;
   /**
    * Provides a way to manipulate the value from the onChange event before it is assigned to state.
+   * @param {...any} params params for the function assigned to [onChangeProp]
+   * @returns {any} a value for the controlled prop
    */
-  onChangeHandler?: OnChangeHandler;
+  onChangeHandler?: (...params: any[]) => unknown;
 }
 
 export type ArgTypeDefinitions<P = any> = {


### PR DESCRIPTION
Now that these configs live in the same JS runtime as the application they don't need to be JSON serializable anymore.