### PR TITLE
Some releases page updates

### DIFF
--- a/packages/toolpad-app/src/components/Releases.tsx
+++ b/packages/toolpad-app/src/components/Releases.tsx
@@ -1,21 +1,12 @@
 import { Container, Typography, Box } from '@mui/material';
-import {
-  DataGridPro,
-  GridActionsCellItem,
-  GridColumns,
-  GridRowParams,
-  GridValueGetterParams,
-} from '@mui/x-data-grid-pro';
+import { DataGridPro, GridColumns } from '@mui/x-data-grid-pro';
 import * as React from 'react';
-import DeleteIcon from '@mui/icons-material/Delete';
-import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import { useNavigate, useParams } from 'react-router-dom';
 import client from '../api';
 import ToolpadAppShell from './ToolpadAppShell';
 
 interface ReleaseRow {
   createdAt: Date;
-  id: string;
   version: number;
   description: string;
 }
@@ -28,35 +19,12 @@ export default function Releases() {
   }
 
   const navigate = useNavigate();
-  const {
-    data: releases = [],
-    isLoading,
-    error,
-    refetch,
-  } = client.useQuery('getReleases', [appId]);
+  const { data: releases = [], isLoading, error } = client.useQuery('getReleases', [appId]);
 
-  const deleteReleaseMutation = client.useMutation('deleteRelease');
-  const deployReleaseMutation = client.useMutation('createDeployment');
+  const activeDeploymentQuery = client.useQuery('findActiveDeployment', [appId]);
+  const activeVersion = activeDeploymentQuery.data?.release.version;
 
-  const handleDeleteClick = React.useCallback(
-    async (version: number) => {
-      // TODO: confirmation dialog here
-      await deleteReleaseMutation.mutateAsync([appId, version]);
-      refetch();
-    },
-    [appId, deleteReleaseMutation, refetch],
-  );
-
-  const handleDeployClick = React.useCallback(
-    async (version: number) => {
-      // TODO: confirmation dialog here
-      await deployReleaseMutation.mutateAsync([appId, version]);
-      refetch();
-    },
-    [appId, deployReleaseMutation, refetch],
-  );
-
-  const columns = React.useMemo<GridColumns>(
+  const columns = React.useMemo<GridColumns<ReleaseRow>>(
     () => [
       {
         field: 'version',
@@ -68,30 +36,18 @@ export default function Releases() {
         flex: 1,
       },
       {
+        field: 'active',
+        headerName: 'Deployed',
+        type: 'boolean',
+        valueGetter: (params) => params.row.version === activeVersion,
+      },
+      {
         field: 'createdAt',
         headerName: 'Created',
         type: 'date',
-        valueGetter: (params: GridValueGetterParams<string, Date>) =>
-          params.value ? new Date(params.value) : undefined,
-      },
-      {
-        field: 'actions',
-        type: 'actions',
-        getActions: (params: GridRowParams) => [
-          <GridActionsCellItem
-            icon={<RocketLaunchIcon />}
-            label="Deploy release"
-            onClick={() => handleDeployClick((params.row as ReleaseRow).version)}
-          />,
-          <GridActionsCellItem
-            icon={<DeleteIcon />}
-            label="Remove release"
-            onClick={() => handleDeleteClick((params.row as ReleaseRow).version)}
-          />,
-        ],
       },
     ],
-    [handleDeleteClick, handleDeployClick],
+    [activeVersion],
   );
 
   return (
@@ -104,7 +60,7 @@ export default function Releases() {
             columns={columns}
             density="compact"
             getRowId={(row) => row.version}
-            loading={isLoading || deleteReleaseMutation.isLoading}
+            loading={isLoading}
             error={(error as any)?.message}
             onRowClick={({ row }) => navigate(`/app/${appId}/releases/${row.version}`)}
           />


### PR DESCRIPTION
Changing a few things on the releases page to have a better default UX to start building on top of

* Remove the "delete" button. Currently delete is completely removing the release from database, essentially freeing the version number to be reused. We shouldn't allow that, there may be people using the urls for this release and we should show a 404 indicating that the release doesn't exist anymore, instead of overwriting it with a new release. I'm opening https://github.com/mui/mui-toolpad/issues/433 to track that.
* Remove the deploy button, I'm replacing it with a deployment status indicator, open the release page to verify the details if you want to deploy.

closes https://github.com/mui/mui-toolpad/issues/427