### PR TITLE
App Editor enhancements: column components

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -7,7 +7,7 @@ import * as appDom from '../../../appDom';
 import { useDom } from '../../DomLoader';
 import { usePageEditorApi } from './PageEditorProvider';
 import { useToolpadComponents } from '../toolpadComponents';
-import { PAGE_ROW_COMPONENT_ID } from '../../../utils/components';
+import { PAGE_ROW_COMPONENT_ID } from '../../../toolpadComponents';
 
 const WIDTH_COLLAPSED = 50;
 

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -92,23 +92,25 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
         <Collapse in={!!openStart} orientation="horizontal" timeout={200} sx={{ height: '100%' }}>
           <Box sx={{ width: 300, height: '100%', overflow: 'auto' }}>
             <Box display="grid" gridTemplateColumns="1fr" gap={1} padding={1}>
-              {Object.entries(toolpadComponents).map(([componentId, componentType]) => {
-                if (!componentType) {
-                  throw new Error(
-                    `Invariant: Component definition for "${componentId}" is undefined`,
+              {Object.entries(toolpadComponents)
+                .filter(([componentId]) => componentId !== 'PageRow')
+                .map(([componentId, componentType]) => {
+                  if (!componentType) {
+                    throw new Error(
+                      `Invariant: Component definition for "${componentId}" is undefined`,
+                    );
+                  }
+                  return (
+                    <ComponentCatalogItem
+                      key={componentId}
+                      draggable
+                      onDragStart={handleDragStart(componentId)}
+                    >
+                      <DragIndicatorIcon color="inherit" />
+                      {componentType.displayName}
+                    </ComponentCatalogItem>
                   );
-                }
-                return (
-                  <ComponentCatalogItem
-                    key={componentId}
-                    draggable
-                    onDragStart={handleDragStart(componentId)}
-                  >
-                    <DragIndicatorIcon color="inherit" />
-                    {componentType.displayName}
-                  </ComponentCatalogItem>
-                );
-              })}
+                })}
             </Box>
           </Box>
         </Collapse>

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -7,6 +7,7 @@ import * as appDom from '../../../appDom';
 import { useDom } from '../../DomLoader';
 import { usePageEditorApi } from './PageEditorProvider';
 import { useToolpadComponents } from '../toolpadComponents';
+import { PAGE_ROW_COMPONENT_ID } from '../../../utils/components';
 
 const WIDTH_COLLAPSED = 50;
 
@@ -93,7 +94,7 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
           <Box sx={{ width: 300, height: '100%', overflow: 'auto' }}>
             <Box display="grid" gridTemplateColumns="1fr" gap={1} padding={1}>
               {Object.entries(toolpadComponents)
-                .filter(([componentId]) => componentId !== 'PageRow')
+                .filter(([componentId]) => componentId !== PAGE_ROW_COMPONENT_ID)
                 .map(([componentId, componentType]) => {
                   if (!componentType) {
                     throw new Error(

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentEditor.tsx
@@ -10,7 +10,7 @@ import PageOptionsPanel from './PageOptionsPanel';
 import ErrorAlert from './ErrorAlert';
 import NodeNameEditor from '../NodeNameEditor';
 import { useToolpadComponent } from '../toolpadComponents';
-import { getElementNodeComponentId } from '../../../utils/components';
+import { getElementNodeComponentId } from '../../../toolpadComponents';
 
 const classes = {
   control: 'Toolpad_Control',

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentEditor.tsx
@@ -10,6 +10,7 @@ import PageOptionsPanel from './PageOptionsPanel';
 import ErrorAlert from './ErrorAlert';
 import NodeNameEditor from '../NodeNameEditor';
 import { useToolpadComponent } from '../toolpadComponents';
+import { getElementNodeComponentId } from '../../../utils/components';
 
 const classes = {
   control: 'Toolpad_Control',
@@ -63,7 +64,7 @@ function SelectedNodeEditor({ node }: SelectedNodeEditorProps) {
   const nodeError = viewState.nodes[node.id]?.error;
   const componentConfig = viewState.nodes[node.id]?.componentConfig || { argTypes: {} };
 
-  const component = useToolpadComponent(dom, node.attributes.component.value);
+  const component = useToolpadComponent(dom, getElementNodeComponentId(node));
 
   return (
     <Stack direction="column" gap={1}>

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -33,6 +33,7 @@ import { HTML_ID_APP_ROOT } from '../../../constants';
 import { useToolpadComponent } from '../toolpadComponents';
 
 const ROW_COMPONENT = 'PageRow';
+const COLUMN_COMPONENT = 'PageColumn';
 
 type SlotDirection = 'horizontal' | 'vertical';
 
@@ -580,9 +581,11 @@ export default function RenderPanel({ className }: RenderPanelProps) {
     }
 
     const component = draggedNode.attributes.component.value;
-    if (component === ROW_COMPONENT) {
-      return [appDom.getNode(dom, pageNodeId, 'page')];
-    }
+
+    const dropTargetComponent = component === ROW_COMPONENT ? COLUMN_COMPONENT : ROW_COMPONENT;
+    const dropTargetNodes = pageNodes.filter(
+      (node) => (node as appDom.ElementNode).attributes.component?.value === dropTargetComponent,
+    );
 
     /**
      * Return all nodes that are available for insertion.
@@ -592,8 +595,8 @@ export default function RenderPanel({ className }: RenderPanelProps) {
     const excludedNodes = selectedNode
       ? new Set<appDom.AppDomNode>([selectedNode, ...appDom.getDescendants(dom, selectedNode)])
       : new Set();
-    return pageNodes.filter((n) => !excludedNodes.has(n));
-  }, [dom, getCurrentlyDraggedNode, pageNodeId, pageNodes, selectedNode]);
+    return dropTargetNodes.filter((n) => !excludedNodes.has(n));
+  }, [dom, getCurrentlyDraggedNode, pageNodes, selectedNode]);
 
   const availableDropTargetIds = React.useMemo(
     () => new Set(availableDropTargets.map((n) => n.id)),

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -688,8 +688,8 @@ export default function RenderPanel({ className }: RenderPanelProps) {
 
           const isOnlyRowElement =
             dragParent &&
-            (dragParent as appDom.ElementNode).attributes.component?.value ===
-              PAGE_ROW_COMPONENT_ID &&
+            appDom.isElement(dragParent) &&
+            dragParent.attributes.component.value === PAGE_ROW_COMPONENT_ID &&
             appDom.getChildNodes(dom, dragParent).children.length === 1;
 
           domApi.moveNode(
@@ -771,8 +771,9 @@ export default function RenderPanel({ className }: RenderPanelProps) {
 
       const isOnlyRowElement =
         parent &&
-        (parent as appDom.ElementNode).attributes.component?.value === PAGE_ROW_COMPONENT_ID &&
-        appDom.getChildNodes(dom, parent as appDom.ElementNode).children.length === 1;
+        appDom.isElement(parent) &&
+        parent.attributes.component.value === PAGE_ROW_COMPONENT_ID &&
+        appDom.getChildNodes(dom, parent).children.length === 1;
 
       domApi.removeNode(toRemove.id);
 

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -32,10 +32,12 @@ import EditorOverlay from './EditorOverlay';
 import { HTML_ID_APP_ROOT } from '../../../constants';
 import { useToolpadComponent } from '../toolpadComponents';
 import {
+  getElementNodeComponentId,
+  isPageColumn,
+  isPageRow,
   PAGE_COLUMN_COMPONENT_ID,
   PAGE_ROW_COMPONENT_ID,
-  getElementNodeComponentId,
-} from '../../../utils/components';
+} from '../../../toolpadComponents';
 
 type SlotDirection = 'horizontal' | 'vertical';
 
@@ -663,13 +665,9 @@ export default function RenderPanel({ className }: RenderPanelProps) {
           throw new Error(`Invalid drop target "${activeSlot.parentId}" of type "${parent.type}"`);
         }
 
-        const isParentRowContainer =
-          appDom.isPage(parent) || getElementNodeComponentId(parent) === PAGE_COLUMN_COMPONENT_ID;
+        const isParentRowContainer = appDom.isPage(parent) || isPageColumn(parent);
 
-        if (
-          isParentRowContainer &&
-          getElementNodeComponentId(draggedNode) !== PAGE_ROW_COMPONENT_ID
-        ) {
+        if (isParentRowContainer && !isPageRow(draggedNode)) {
           // TODO: this logic should probably live in the DomReducer?
           const container = appDom.createElement(dom, PAGE_ROW_COMPONENT_ID, {});
           domApi.addNode(container, parent, 'children');
@@ -689,7 +687,7 @@ export default function RenderPanel({ className }: RenderPanelProps) {
           const isOnlyRowElement =
             dragParent &&
             appDom.isElement(dragParent) &&
-            dragParent.attributes.component.value === PAGE_ROW_COMPONENT_ID &&
+            isPageRow(dragParent) &&
             appDom.getChildNodes(dom, dragParent).children.length === 1;
 
           domApi.moveNode(
@@ -772,7 +770,7 @@ export default function RenderPanel({ className }: RenderPanelProps) {
       const isOnlyRowElement =
         parent &&
         appDom.isElement(parent) &&
-        parent.attributes.component.value === PAGE_ROW_COMPONENT_ID &&
+        isPageRow(parent) &&
         appDom.getChildNodes(dom, parent).children.length === 1;
 
       domApi.removeNode(toRemove.id);

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -684,12 +684,23 @@ export default function RenderPanel({ className }: RenderPanelProps) {
             domApi.addNode(newNode, parent, 'children', activeSlot.parentIndex);
           }
         } else if (selection) {
+          const dragParent = appDom.getParent(dom, draggedNode);
+
+          const isOnlyRowElement =
+            dragParent &&
+            getElementNodeComponentId(dragParent as appDom.ElementNode) === PAGE_ROW_COMPONENT_ID &&
+            appDom.getChildNodes(dom, dragParent).children.length === 1;
+
           domApi.moveNode(
             selection,
             activeSlot.parentId,
             activeSlot.parentProp,
             activeSlot.parentIndex,
           );
+
+          if (isOnlyRowElement) {
+            domApi.removeNode(dragParent.id);
+          }
         }
       }
 

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -688,7 +688,8 @@ export default function RenderPanel({ className }: RenderPanelProps) {
 
           const isOnlyRowElement =
             dragParent &&
-            getElementNodeComponentId(dragParent as appDom.ElementNode) === PAGE_ROW_COMPONENT_ID &&
+            (dragParent as appDom.ElementNode).attributes.component?.value ===
+              PAGE_ROW_COMPONENT_ID &&
             appDom.getChildNodes(dom, dragParent).children.length === 1;
 
           domApi.moveNode(
@@ -766,12 +767,12 @@ export default function RenderPanel({ className }: RenderPanelProps) {
   const handleDelete = React.useCallback(
     (nodeId: NodeId) => {
       const toRemove = appDom.getNode(dom, nodeId);
-      const parent = appDom.getParent(dom, toRemove) as appDom.ElementNode;
+      const parent = appDom.getParent(dom, toRemove);
 
       const isOnlyRowElement =
         parent &&
-        getElementNodeComponentId(parent) === PAGE_ROW_COMPONENT_ID &&
-        appDom.getChildNodes(dom, parent).children.length === 1;
+        (parent as appDom.ElementNode).attributes.component?.value === PAGE_ROW_COMPONENT_ID &&
+        appDom.getChildNodes(dom, parent as appDom.ElementNode).children.length === 1;
 
       domApi.removeNode(toRemove.id);
 

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -93,6 +93,7 @@ const OverlayRoot = styled('div')({
   },
 
   [`& .${overlayClasses.nodeHud}`]: {
+    border: '1px dashed rgba(255,0,0,.2)',
     // capture mouse events
     pointerEvents: 'initial',
     position: 'absolute',
@@ -582,14 +583,16 @@ export default function RenderPanel({ className }: RenderPanelProps) {
 
     const component = draggedNode.attributes.component.value;
 
-    const isRowComponent = component === ROW_COMPONENT;
-    const dropTargetComponent = isRowComponent ? COLUMN_COMPONENT : ROW_COMPONENT;
-    const dropTargetNodes = [
-      pageNode,
-      ...pageNodes.filter(
-        (node) => (node as appDom.ElementNode).attributes.component?.value === dropTargetComponent,
-      ),
-    ];
+    const dropTargetNodes =
+      component === ROW_COMPONENT
+        ? [
+            pageNode,
+            pageNodes.filter(
+              (node) =>
+                (node as appDom.ElementNode).attributes.component?.value === COLUMN_COMPONENT,
+            ),
+          ]
+        : pageNodes;
 
     /**
      * Return all nodes that are available for insertion.

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/RenderPanel.tsx
@@ -582,10 +582,14 @@ export default function RenderPanel({ className }: RenderPanelProps) {
 
     const component = draggedNode.attributes.component.value;
 
-    const dropTargetComponent = component === ROW_COMPONENT ? COLUMN_COMPONENT : ROW_COMPONENT;
-    const dropTargetNodes = pageNodes.filter(
-      (node) => (node as appDom.ElementNode).attributes.component?.value === dropTargetComponent,
-    );
+    const isRowComponent = component === ROW_COMPONENT;
+    const dropTargetComponent = isRowComponent ? COLUMN_COMPONENT : ROW_COMPONENT;
+    const dropTargetNodes = [
+      pageNode,
+      ...pageNodes.filter(
+        (node) => (node as appDom.ElementNode).attributes.component?.value === dropTargetComponent,
+      ),
+    ];
 
     /**
      * Return all nodes that are available for insertion.
@@ -596,7 +600,7 @@ export default function RenderPanel({ className }: RenderPanelProps) {
       ? new Set<appDom.AppDomNode>([selectedNode, ...appDom.getDescendants(dom, selectedNode)])
       : new Set();
     return dropTargetNodes.filter((n) => !excludedNodes.has(n));
-  }, [dom, getCurrentlyDraggedNode, pageNodes, selectedNode]);
+  }, [dom, getCurrentlyDraggedNode, pageNode, pageNodes, selectedNode]);
 
   const availableDropTargetIds = React.useMemo(
     () => new Set(availableDropTargets.map((n) => n.id)),

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -42,7 +42,11 @@ import * as appDom from '../appDom';
 import { NodeId, VersionOrPreview } from '../types';
 import { createProvidedContext } from '../utils/react';
 import AppOverview from '../components/AppOverview';
-import { getToolpadComponents } from '../toolpadComponents';
+import {
+  getElementNodeComponentId,
+  getToolpadComponents,
+  PAGE_ROW_COMPONENT_ID,
+} from '../toolpadComponents';
 import AppThemeProvider from './AppThemeProvider';
 import evalJsBindings, {
   BindingEvaluationResult,
@@ -53,7 +57,6 @@ import createCodeComponent from './createCodeComponent';
 import { HTML_ID_APP_ROOT } from '../constants';
 import usePageTitle from '../utils/usePageTitle';
 import DomProvider, { useDomContext } from './DomProvider';
-import { getElementNodeComponentId, PAGE_ROW_COMPONENT_ID } from '../utils/components';
 
 const AppRoot = styled('div')({
   overflow: 'auto' /* prevents margins from collapsing into root */,

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -53,8 +53,7 @@ import createCodeComponent from './createCodeComponent';
 import { HTML_ID_APP_ROOT } from '../constants';
 import usePageTitle from '../utils/usePageTitle';
 import DomProvider, { useDomContext } from './DomProvider';
-
-const PAGE_ROW_COMPONENT_ID = 'PageRow';
+import { getElementNodeComponentId, PAGE_ROW_COMPONENT_ID } from '../utils/components';
 
 const AppRoot = styled('div')({
   overflow: 'auto' /* prevents margins from collapsing into root */,
@@ -77,13 +76,13 @@ const [useSetControlledBindingContext, SetControlledBindingContextProvider] =
   );
 
 function getComponentId(elm: appDom.ElementNode): string {
-  const componentId = elm.attributes.component.value;
+  const componentId = getElementNodeComponentId(elm);
   return componentId;
 }
 
 function useElmToolpadComponent(elm: appDom.ElementNode): ToolpadComponent {
   const getComponent = useComponentsContext();
-  const componentId = elm.attributes.component.value;
+  const componentId = getElementNodeComponentId(elm);
   return getComponent(componentId);
 }
 

--- a/packages/toolpad-app/src/toolpadComponents/index.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/index.tsx
@@ -15,8 +15,8 @@ export interface InstantiatedComponent extends ToolpadComponentDefinition {
 export type InstantiatedComponents = Record<string, InstantiatedComponent | undefined>;
 
 const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
-  ['PageRow', { displayName: 'PageRow', builtin: 'PageRow' }],
-  ['PageColumn', { displayName: 'Container', builtin: 'PageColumn' }],
+  ['PageRow', { displayName: 'Row', builtin: 'PageRow' }],
+  ['PageColumn', { displayName: 'Column', builtin: 'PageColumn' }],
   ['Stack', { displayName: 'Stack', builtin: 'Stack' }],
   ['Button', { displayName: 'Button', builtin: 'Button' }],
   ['Image', { displayName: 'Image', builtin: 'Image' }],

--- a/packages/toolpad-app/src/toolpadComponents/index.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/index.tsx
@@ -16,7 +16,7 @@ export type InstantiatedComponents = Record<string, InstantiatedComponent | unde
 
 const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
   ['PageRow', { displayName: 'PageRow', builtin: 'PageRow' }],
-  ['PageColumn', { displayName: 'PageColumn', builtin: 'PageColumn' }],
+  ['PageColumn', { displayName: 'Container', builtin: 'PageColumn' }],
   ['Stack', { displayName: 'Stack', builtin: 'Stack' }],
   ['Button', { displayName: 'Button', builtin: 'Button' }],
   ['Image', { displayName: 'Image', builtin: 'Image' }],

--- a/packages/toolpad-app/src/toolpadComponents/index.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/index.tsx
@@ -14,9 +14,12 @@ export interface InstantiatedComponent extends ToolpadComponentDefinition {
 }
 export type InstantiatedComponents = Record<string, InstantiatedComponent | undefined>;
 
+export const PAGE_ROW_COMPONENT_ID = 'PageRow';
+export const PAGE_COLUMN_COMPONENT_ID = 'PageColumn';
+
 const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
-  ['PageRow', { displayName: 'Row', builtin: 'PageRow' }],
-  ['PageColumn', { displayName: 'Column', builtin: 'PageColumn' }],
+  [PAGE_ROW_COMPONENT_ID, { displayName: 'Row', builtin: 'PageRow' }],
+  [PAGE_COLUMN_COMPONENT_ID, { displayName: 'Column', builtin: 'PageColumn' }],
   ['Stack', { displayName: 'Stack', builtin: 'Stack' }],
   ['Button', { displayName: 'Button', builtin: 'Button' }],
   ['Image', { displayName: 'Image', builtin: 'Image' }],
@@ -62,4 +65,16 @@ export function getToolpadComponent(
 ): ToolpadComponentDefinition | null {
   const component = components[componentId];
   return component || null;
+}
+
+export function getElementNodeComponentId(elementNode: appDom.ElementNode): string {
+  return elementNode.attributes.component.value;
+}
+
+export function isPageRow(elementNode: appDom.ElementNode): boolean {
+  return getElementNodeComponentId(elementNode) === PAGE_ROW_COMPONENT_ID;
+}
+
+export function isPageColumn(elementNode: appDom.ElementNode): boolean {
+  return getElementNodeComponentId(elementNode) === PAGE_COLUMN_COMPONENT_ID;
 }

--- a/packages/toolpad-app/src/toolpadComponents/index.tsx
+++ b/packages/toolpad-app/src/toolpadComponents/index.tsx
@@ -16,6 +16,7 @@ export type InstantiatedComponents = Record<string, InstantiatedComponent | unde
 
 const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
   ['PageRow', { displayName: 'PageRow', builtin: 'PageRow' }],
+  ['PageColumn', { displayName: 'PageColumn', builtin: 'PageColumn' }],
   ['Stack', { displayName: 'Stack', builtin: 'Stack' }],
   ['Button', { displayName: 'Button', builtin: 'Button' }],
   ['Image', { displayName: 'Image', builtin: 'Image' }],

--- a/packages/toolpad-app/src/utils/components.ts
+++ b/packages/toolpad-app/src/utils/components.ts
@@ -1,9 +1,8 @@
-import type * as appDom from "../appDom";
-
+import type * as appDom from '../appDom';
 
 export const PAGE_ROW_COMPONENT_ID = 'PageRow';
 export const PAGE_COLUMN_COMPONENT_ID = 'PageColumn';
 
 export function getElementNodeComponentId(elementNode: appDom.ElementNode): string {
-    return elementNode.attributes.component.value
+  return elementNode.attributes.component.value;
 }

--- a/packages/toolpad-app/src/utils/components.ts
+++ b/packages/toolpad-app/src/utils/components.ts
@@ -1,0 +1,7 @@
+import type * as appDom from "../appDom";
+
+
+export const PAGE_ROW_COMPONENT_ID = 'PageRow';
+export const PAGE_COLUMN_COMPONENT_ID = 'PageColumn';
+
+export const getElementNodeComponentId = (elementNode: appDom.ElementNode): string => elementNode.attributes.component.value

--- a/packages/toolpad-app/src/utils/components.ts
+++ b/packages/toolpad-app/src/utils/components.ts
@@ -1,8 +1,0 @@
-import type * as appDom from '../appDom';
-
-export const PAGE_ROW_COMPONENT_ID = 'PageRow';
-export const PAGE_COLUMN_COMPONENT_ID = 'PageColumn';
-
-export function getElementNodeComponentId(elementNode: appDom.ElementNode): string {
-  return elementNode.attributes.component.value;
-}

--- a/packages/toolpad-app/src/utils/components.ts
+++ b/packages/toolpad-app/src/utils/components.ts
@@ -4,4 +4,6 @@ import type * as appDom from "../appDom";
 export const PAGE_ROW_COMPONENT_ID = 'PageRow';
 export const PAGE_COLUMN_COMPONENT_ID = 'PageColumn';
 
-export const getElementNodeComponentId = (elementNode: appDom.ElementNode): string => elementNode.attributes.component.value
+export function getElementNodeComponentId(elementNode: appDom.ElementNode): string {
+    return elementNode.attributes.component.value
+}

--- a/packages/toolpad-components/src/PageColumn.tsx
+++ b/packages/toolpad-components/src/PageColumn.tsx
@@ -7,10 +7,9 @@ export interface PageColumnProps {
   spacing?: number;
   children?: React.ReactNode;
   alignItems?: StackProps['alignItems'];
-  justifyContent?: StackProps['justifyContent'];
 }
 
-function PageColumn({ span, spacing, children, alignItems, justifyContent }: PageColumnProps) {
+function PageColumn({ span, spacing, children, alignItems }: PageColumnProps) {
   return (
     <Stack
       direction="column"
@@ -18,7 +17,6 @@ function PageColumn({ span, spacing, children, alignItems, justifyContent }: Pag
         gap: spacing,
         p: spacing,
         alignItems,
-        justifyContent,
         width: `${(span / 12) * 100}vw`,
       }}
     >
@@ -31,7 +29,6 @@ PageColumn.defaultProps = {
   spacing: 2,
   span: 1,
   alignItems: 'center',
-  justifyContent: 'start',
 };
 
 export default createComponent(PageColumn, {
@@ -49,14 +46,6 @@ export default createComponent(PageColumn, {
       },
       label: 'Horizontal alignment',
       control: { type: 'HorizontalAlign' },
-    },
-    justifyContent: {
-      typeDef: {
-        type: 'string',
-        enum: ['start', 'center', 'end', 'stretch', 'baseline'],
-      },
-      label: 'Vertical alignment',
-      control: { type: 'VerticalAlign' },
     },
     children: {
       typeDef: { type: 'element' },

--- a/packages/toolpad-components/src/PageColumn.tsx
+++ b/packages/toolpad-components/src/PageColumn.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Stack, StackProps } from '@mui/material';
+import { createComponent } from '@mui/toolpad-core';
+
+export interface PageColumnProps {
+  spacing?: number;
+  children?: React.ReactNode;
+  alignItems?: StackProps['alignItems'];
+  justifyContent?: StackProps['justifyContent'];
+}
+
+function PageColumn({ spacing, children, alignItems, justifyContent }: PageColumnProps) {
+  return (
+    <Stack
+      direction="column"
+      sx={{ gap: spacing, p: spacing, alignItems, justifyContent, flexWrap: 'wrap' }}
+    >
+      {children}
+    </Stack>
+  );
+}
+
+PageColumn.defaultProps = {
+  spacing: 2,
+  alignItems: 'center',
+  justifyContent: 'start',
+};
+
+export default createComponent(PageColumn, {
+  argTypes: {
+    spacing: {
+      typeDef: { type: 'number' },
+    },
+    alignItems: {
+      typeDef: {
+        type: 'string',
+        enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
+      },
+      label: 'Horizontal alignment',
+      control: { type: 'HorizontalAlign' },
+    },
+    justifyContent: {
+      typeDef: {
+        type: 'string',
+        enum: ['start', 'center', 'end', 'stretch', 'baseline'],
+      },
+      label: 'Vertical alignment',
+      control: { type: 'VerticalAlign' },
+    },
+    children: {
+      typeDef: { type: 'element' },
+      control: { type: 'slots' },
+    },
+  },
+});

--- a/packages/toolpad-components/src/PageColumn.tsx
+++ b/packages/toolpad-components/src/PageColumn.tsx
@@ -3,17 +3,24 @@ import { Stack, StackProps } from '@mui/material';
 import { createComponent } from '@mui/toolpad-core';
 
 export interface PageColumnProps {
+  span: number;
   spacing?: number;
   children?: React.ReactNode;
   alignItems?: StackProps['alignItems'];
   justifyContent?: StackProps['justifyContent'];
 }
 
-function PageColumn({ spacing, children, alignItems, justifyContent }: PageColumnProps) {
+function PageColumn({ span, spacing, children, alignItems, justifyContent }: PageColumnProps) {
   return (
     <Stack
       direction="column"
-      sx={{ gap: spacing, p: spacing, alignItems, justifyContent, flexWrap: 'wrap' }}
+      sx={{
+        gap: spacing,
+        p: spacing,
+        alignItems,
+        justifyContent,
+        width: `${(span / 12) * 100}vw`,
+      }}
     >
       {children}
     </Stack>
@@ -22,12 +29,16 @@ function PageColumn({ spacing, children, alignItems, justifyContent }: PageColum
 
 PageColumn.defaultProps = {
   spacing: 2,
+  span: 1,
   alignItems: 'center',
   justifyContent: 'start',
 };
 
 export default createComponent(PageColumn, {
   argTypes: {
+    span: {
+      typeDef: { type: 'number' },
+    },
     spacing: {
       typeDef: { type: 'number' },
     },

--- a/packages/toolpad-components/src/PageColumn.tsx
+++ b/packages/toolpad-components/src/PageColumn.tsx
@@ -18,6 +18,7 @@ function PageColumn({ span, spacing, children, alignItems }: PageColumnProps) {
         p: spacing,
         alignItems,
         width: `${(span / 12) * 100}vw`,
+        maxWidth: '100%',
       }}
     >
       {children}
@@ -28,7 +29,7 @@ function PageColumn({ span, spacing, children, alignItems }: PageColumnProps) {
 PageColumn.defaultProps = {
   spacing: 2,
   span: 1,
-  alignItems: 'center',
+  alignItems: 'start',
 };
 
 export default createComponent(PageColumn, {

--- a/packages/toolpad-components/src/PageColumn.tsx
+++ b/packages/toolpad-components/src/PageColumn.tsx
@@ -26,19 +26,15 @@ function PageColumn({ span, spacing, children, alignItems }: PageColumnProps) {
   );
 }
 
-PageColumn.defaultProps = {
-  spacing: 2,
-  span: 1,
-  alignItems: 'start',
-};
-
 export default createComponent(PageColumn, {
   argTypes: {
     span: {
       typeDef: { type: 'number' },
+      defaultValue: 1,
     },
     spacing: {
       typeDef: { type: 'number' },
+      defaultValue: 2,
     },
     alignItems: {
       typeDef: {
@@ -47,6 +43,7 @@ export default createComponent(PageColumn, {
       },
       label: 'Horizontal alignment',
       control: { type: 'HorizontalAlign' },
+      defaultValue: 'start',
     },
     children: {
       typeDef: { type: 'element' },

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -3,26 +3,26 @@ import { Stack, StackProps } from '@mui/material';
 import { createComponent } from '@mui/toolpad-core';
 
 export interface PageRowProps {
+  spacing?: number;
   children?: React.ReactNode;
   alignItems?: StackProps['alignItems'];
 }
 
-function PageRow({ children, alignItems }: PageRowProps) {
+function PageRow({ spacing, children, alignItems }: PageRowProps) {
   return (
     <Stack
       direction="row"
       sx={{
+        gap: spacing,
+        p: spacing,
         alignItems,
+        width: '100%',
       }}
     >
       {children}
     </Stack>
   );
 }
-
-PageRow.defaultProps = {
-  alignItems: 'start',
-};
 
 export default createComponent(PageRow, {
   argTypes: {

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -1,24 +1,28 @@
 import * as React from 'react';
-import { Stack } from '@mui/material';
+import { Stack, StackProps } from '@mui/material';
 import { createComponent } from '@mui/toolpad-core';
 
 export interface PageRowProps {
   children?: React.ReactNode;
+  alignItems?: StackProps['alignItems'];
 }
 
-function PageRow({ children }: PageRowProps) {
+function PageRow({ children, alignItems }: PageRowProps) {
   return (
     <Stack
       direction="row"
       sx={{
-        alignItems: 'start',
-        justifyContent: 'start',
+        alignItems,
       }}
     >
       {children}
     </Stack>
   );
 }
+
+PageRow.defaultProps = {
+  alignItems: 'start',
+};
 
 export default createComponent(PageRow, {
   argTypes: {

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -1,20 +1,18 @@
 import * as React from 'react';
-import { Stack, StackProps } from '@mui/material';
+import { Stack } from '@mui/material';
 import { createComponent } from '@mui/toolpad-core';
 
 export interface PageRowProps {
   children?: React.ReactNode;
-  alignItems?: StackProps['alignItems'];
-  justifyContent?: StackProps['justifyContent'];
 }
 
-function PageRow({ children, alignItems, justifyContent }: PageRowProps) {
+function PageRow({ children }: PageRowProps) {
   return (
     <Stack
       direction="row"
       sx={{
-        alignItems,
-        justifyContent,
+        alignItems: 'start',
+        justifyContent: 'start',
       }}
     >
       {children}

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -26,17 +26,11 @@ function PageRow({ spacing, children, alignItems, justifyContent }: PageRowProps
   );
 }
 
-PageRow.defaultProps = {
-  spacing: 0,
-  alignItems: 'start',
-  justifyContent: 'start',
-};
-
 export default createComponent(PageRow, {
   argTypes: {
     spacing: {
       typeDef: { type: 'number' },
-      defaultValue: 2,
+      defaultValue: 0,
     },
     alignItems: {
       typeDef: {

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -3,17 +3,19 @@ import { Stack, StackProps } from '@mui/material';
 import { createComponent } from '@mui/toolpad-core';
 
 export interface PageRowProps {
-  spacing?: number;
   children?: React.ReactNode;
   alignItems?: StackProps['alignItems'];
   justifyContent?: StackProps['justifyContent'];
 }
 
-function PageRow({ spacing, children, alignItems, justifyContent }: PageRowProps) {
+function PageRow({ children, alignItems, justifyContent }: PageRowProps) {
   return (
     <Stack
       direction="row"
-      sx={{ gap: spacing, p: spacing, alignItems, justifyContent, flexWrap: 'wrap' }}
+      sx={{
+        alignItems,
+        justifyContent,
+      }}
     >
       {children}
     </Stack>

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -6,9 +6,10 @@ export interface PageRowProps {
   spacing?: number;
   children?: React.ReactNode;
   alignItems?: StackProps['alignItems'];
+  justifyContent?: StackProps['justifyContent'];
 }
 
-function PageRow({ spacing, children, alignItems }: PageRowProps) {
+function PageRow({ spacing, children, alignItems, justifyContent }: PageRowProps) {
   return (
     <Stack
       direction="row"
@@ -16,6 +17,7 @@ function PageRow({ spacing, children, alignItems }: PageRowProps) {
         gap: spacing,
         p: spacing,
         alignItems,
+        justifyContent,
         width: '100%',
       }}
     >
@@ -23,6 +25,12 @@ function PageRow({ spacing, children, alignItems }: PageRowProps) {
     </Stack>
   );
 }
+
+PageRow.defaultProps = {
+  spacing: 0,
+  alignItems: 'start',
+  justifyContent: 'start',
+};
 
 export default createComponent(PageRow, {
   argTypes: {
@@ -37,7 +45,7 @@ export default createComponent(PageRow, {
       },
       label: 'Vertical alignment',
       control: { type: 'VerticalAlign' },
-      defaultValue: 'center',
+      defaultValue: 'start',
     },
     justifyContent: {
       typeDef: {

--- a/packages/toolpad-components/src/Stack.tsx
+++ b/packages/toolpad-components/src/Stack.tsx
@@ -37,6 +37,9 @@ export default createComponent(Stack, {
     },
     sx: {
       typeDef: { type: 'object' },
+      defaultValue: {
+        minWidth: `${(1 / 12) * 100}vw`,
+      },
     },
   },
 });

--- a/packages/toolpad-components/src/index.tsx
+++ b/packages/toolpad-components/src/index.tsx
@@ -1,5 +1,7 @@
 export { default as PageRow } from './PageRow.js';
 
+export { default as PageColumn } from './PageColumn.js';
+
 export { default as Stack } from './Stack.js';
 
 export { default as Button } from './Button.js';

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -56,7 +56,7 @@ function PlaceholderWrapper(props: PlaceholderWrapperProps) {
       style={{
         display: 'block',
         minHeight: 40,
-        minWidth: 200,
+        minWidth: '100%',
       }}
     />
   );

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -56,7 +56,8 @@ function PlaceholderWrapper(props: PlaceholderWrapperProps) {
       style={{
         display: 'block',
         minHeight: 40,
-        minWidth: '100%',
+        minWidth: `${(1 / 12) * 100}vw`,
+        width: '100%',
       }}
     />
   );

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -56,7 +56,6 @@ function PlaceholderWrapper(props: PlaceholderWrapperProps) {
       style={{
         display: 'block',
         minHeight: 40,
-        minWidth: `${(1 / 12) * 100}vw`,
         width: '100%',
       }}
     />


### PR DESCRIPTION
- Enhance app editor with new column components that take a span from 1 to 12.
- Disable placing rows explicitly.
- Automatic removal or addition of rows according to https://www.notion.so/mui-org/App-Editor-Enhancements-070bf8ba0e2145a2aaaf50d67a24983e.

<img width="1792" alt="Screen Shot 2022-05-24 at 19 58 11" src="https://user-images.githubusercontent.com/10789765/170112021-8681622f-5e86-4a40-a20a-b38521910eb9.png">

@Janpot Please review and let me know if it's all good, and if we should merge this already as a first step.
I've also created a new utils file for some constants/operations that were being used a lot, let me know if that approach is good or if you prefer some other way, I'm totally fine with changing it.

Will try to enable drag & drop with quadrants next up, so that columns can be created automatically when an element is added under another, among other features that will should improve the UX a lot.
Also we can eventually remove the spacing in rows and columns, or being able to edit them or see them, if we later decide that's the way to go.