### PR TITLE
Fix bindings not updating when adding a query

### DIFF
--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -413,17 +413,18 @@ function RenderedPage({ nodeId }: RenderedNodeProps) {
 
   const setControlledBinding = React.useCallback(
     (id: string, result: BindingEvaluationResult) => {
+      const parsedBinding = parsedBindings[id];
       setPageBindings((existing) => {
         if (!controlled.has(id)) {
           throw new Error(`Not a controlled binding "${id}"`);
         }
         return {
           ...existing,
-          [id]: { ...existing[id], result },
+          [id]: { ...parsedBinding, result },
         };
       });
     },
-    [controlled],
+    [parsedBindings, controlled],
   );
 
   const evaluatedBindings = React.useMemo(() => evalJsBindings(pageBindings), [pageBindings]);


### PR DESCRIPTION
Don't assume there is a binding already for a controlled property.

Fixes https://github.com/mui/mui-toolpad/issues/455