### PR TITLE
Separate app canvas from toolpad app

### DIFF
--- a/packages/toolpad-app/pages/app-canvas/[appId]/[[...path]].tsx
+++ b/packages/toolpad-app/pages/app-canvas/[appId]/[[...path]].tsx
@@ -1,0 +1,24 @@
+import type { GetServerSideProps, NextPage } from 'next';
+import * as React from 'react';
+import { asArray } from '../../../src/utils/collections';
+import AppCanvas, { AppCanvasProps } from '../../../src/runtime/AppCanvas';
+
+export const getServerSideProps: GetServerSideProps<AppCanvasProps> = async (context) => {
+  const [appId] = asArray(context.query.appId);
+
+  if (!appId) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      appId,
+      basename: `/app-canvas/${appId}`,
+    },
+  };
+};
+
+const App: NextPage<AppCanvasProps> = (props) => <AppCanvas {...props} />;
+export default App;

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -85,7 +85,7 @@ export default function EditorCanvasHost({
       </Box>
       <CanvasFrame
         ref={frameRef}
-        src={`/app/${appId}/preview/pages/${pageNodeId}`}
+        src={`/app-canvas/${appId}/pages/${pageNodeId}`}
         // Used by the runtime to know when to load react devtools
         data-toolpad-canvas
       />

--- a/packages/toolpad-app/src/runtime/AppCanvas.tsx
+++ b/packages/toolpad-app/src/runtime/AppCanvas.tsx
@@ -1,28 +1,15 @@
 import * as React from 'react';
+import { fireEvent } from '@mui/toolpad-core/runtime';
+import ToolpadApp from './ToolpadApp';
 import * as appDom from '../appDom';
-import { createProvidedContext } from '../utils/react';
 
-const [useDomContext, DomContextProvider] = createProvidedContext<appDom.AppDom>('Dom');
-
-export interface ToolpadBridge {
-  updateDom(newDom: appDom.AppDom): void;
+export interface AppCanvasProps {
+  appId: string;
+  basename: string;
 }
 
-declare global {
-  interface Window {
-    __TOOLPAD_READY__?: boolean | (() => void);
-    __TOOLPAD_BRIDGE__?: ToolpadBridge;
-  }
-}
-
-export interface EditorCanvasProps {
-  dom: appDom.AppDom;
-  children?: React.ReactNode;
-}
-
-export default function DomProvider({ dom: domProp, children }: EditorCanvasProps) {
-  const [dom, setDom] = React.useState<appDom.AppDom>(domProp);
-  React.useEffect(() => setDom(domProp), [domProp]);
+export default function AppCanvas({ appId, basename }: AppCanvasProps) {
+  const [dom, setDom] = React.useState<appDom.AppDom | null>(null);
 
   React.useEffect(() => {
     // eslint-disable-next-line no-underscore-dangle
@@ -47,7 +34,14 @@ export default function DomProvider({ dom: domProp, children }: EditorCanvasProp
     };
   }, []);
 
-  return <DomContextProvider value={dom}>{children}</DomContextProvider>;
-}
+  React.useEffect(() => {
+    // Run after every render
+    fireEvent({ type: 'afterRender' });
+  });
 
-export { useDomContext };
+  return dom ? (
+    <ToolpadApp dom={dom} version="preview" appId={appId} basename={basename} />
+  ) : (
+    <div>loading...</div>
+  );
+}

--- a/packages/toolpad-app/src/runtime/AppCanvas/index.tsx
+++ b/packages/toolpad-app/src/runtime/AppCanvas/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { fireEvent } from '@mui/toolpad-core/runtime';
-import ToolpadApp from './ToolpadApp';
-import * as appDom from '../appDom';
+import ToolpadApp from '../ToolpadApp';
+import * as appDom from '../../appDom';
 
 export interface AppCanvasProps {
   appId: string;

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -54,7 +54,6 @@ import evalJsBindings, {
 import createCodeComponent from './createCodeComponent';
 import { HTML_ID_APP_ROOT } from '../constants';
 import usePageTitle from '../utils/usePageTitle';
-import DomProvider, { useDomContext } from './DomProvider';
 
 const AppRoot = styled('div')({
   overflow: 'auto' /* prevents margins from collapsing into root */,
@@ -66,6 +65,7 @@ interface AppContext {
   version: VersionOrPreview;
 }
 
+const [useDomContext, DomContextProvider] = createProvidedContext<appDom.AppDom>('Dom');
 const [useComponentsContext, ComponentsContextProvider] =
   createProvidedContext<(id: string) => ToolpadComponent>('Components');
 const [useAppContext, AppContextProvider] = createProvidedContext<AppContext>('App');
@@ -618,9 +618,9 @@ export default function ToolpadApp({ basename, appId, version, dom }: ToolpadApp
   React.useEffect(() => setResetNodeErrorsKey((key) => key + 1), [dom]);
 
   return (
-    <NoSsr>
-      <DomProvider dom={dom}>
-        <AppRoot id={HTML_ID_APP_ROOT}>
+    <AppRoot id={HTML_ID_APP_ROOT}>
+      <NoSsr>
+        <DomContextProvider value={dom}>
           <CssBaseline />
           <ErrorBoundary FallbackComponent={AppError}>
             <ResetNodeErrorsKeyProvider value={resetNodeErrorsKey}>
@@ -651,8 +651,8 @@ export default function ToolpadApp({ basename, appId, version, dom }: ToolpadApp
               </React.Suspense>
             </ResetNodeErrorsKeyProvider>
           </ErrorBoundary>
-        </AppRoot>
-      </DomProvider>
-    </NoSsr>
+        </DomContextProvider>
+      </NoSsr>
+    </AppRoot>
   );
 }

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -183,7 +183,8 @@ export type RuntimeEvent =
   | {
       type: 'pageBindingsUpdated';
       bindings: LiveBindings;
-    };
+    }
+  | { type: 'afterRender' };
 
 export interface ComponentConfig<P> {
   /**


### PR DESCRIPTION
Working towards a more reliable editor canvas. This PR extracts the canvas runtime as a wrapper of the app runtime.
