### PR TITLE
Disable retries by default in user applications

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
@@ -234,6 +234,7 @@ function QueryNodeEditorDialog<Q, P, PQ>({
   const queryPreview = client.useQuery(
     'execQuery',
     previewQuery ? [appId, previewQuery, previewParams] : null,
+    { retry: false },
   );
 
   const handleUpdatePreview = React.useCallback(() => {

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -557,7 +557,17 @@ export default function ToolpadApp({ basename, appId, version, dom }: ToolpadApp
 
   const appContext = React.useMemo(() => ({ appId, version }), [appId, version]);
 
-  const queryClient = React.useMemo(() => new QueryClient(), []);
+  const queryClient = React.useMemo(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+          },
+        },
+      }),
+    [],
+  );
 
   const components = React.useMemo(() => getToolpadComponents(dom), [dom]);
 


### PR DESCRIPTION
To improve the response time during editing
We can add a global or per-query option if the need arises