### PR TITLE
Make sure to produce valid code for custom components

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -31,7 +31,7 @@ function createDefaultCodeComponent(name: string): string {
       );
     }
 
-    export default createComponent(MyComponent, {
+    export default createComponent(${componentId}, {
       argTypes: {
         msg: {
           typeDef: { type: "string" },


### PR DESCRIPTION
Naming a code component differently than `MyComponent` results in an error. This PR fixes that