### PR TITLE
Better empty state for Typography

### DIFF
--- a/packages/toolpad-components/src/Typography.tsx
+++ b/packages/toolpad-components/src/Typography.tsx
@@ -13,7 +13,16 @@ interface TypographyProps extends Omit<MuiTypographyProps, 'children'> {
 
 function Typography({ value, loading, sx, ...props }: TypographyProps) {
   return (
-    <MuiTypography sx={{ minWidth: loading ? 150 : undefined, ...sx }} {...props}>
+    <MuiTypography
+      sx={{
+        minWidth: loading || !value ? 150 : undefined,
+        // This will give it height, even when empty.
+        // REMARK: Does it make sense to put it in core?
+        [`&:empty::before`]: { content: '""', display: 'inline-block' },
+        ...sx,
+      }}
+      {...props}
+    >
       {loading ? <Skeleton /> : value}
     </MuiTypography>
   );


### PR DESCRIPTION
* Use `:empty` pseudoselector to give a default height when the typography is empty (Perhaps it even makes sense to make this default behavior in `@mui/material`?)
* Give a minimum width when empty content