### PR TITLE
Fix sheets queries not updating when connection changes

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/ApiEditor/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/ApiEditor/index.tsx
@@ -32,7 +32,7 @@ interface ApiEditorContentProps<Q> {
   apiNode: appDom.ApiNode<Q>;
 }
 
-function ApiEditorContent<Q, PQ>({ appId, className, apiNode }: ApiEditorContentProps<Q>) {
+function ApiEditorContent<Q>({ appId, className, apiNode }: ApiEditorContentProps<Q>) {
   const domApi = useDomApi();
   const dom = useDom();
 
@@ -71,13 +71,6 @@ function ApiEditorContent<Q, PQ>({ appId, className, apiNode }: ApiEditorContent
   const previewQuery = useQuery(['api', debouncedPreviewApi], async () =>
     client.query.execApi(appId, debouncedPreviewApi, {}),
   );
-
-  const queryEditorApi = React.useMemo(() => {
-    return {
-      fetchPrivate: async (query: PQ | {}) =>
-        client.query.dataSourceFetchPrivate(appId, conectionId, query),
-    };
-  }, [appId, conectionId]);
 
   const handleConnectionChange = React.useCallback(
     (newConnectionId) => {
@@ -175,14 +168,17 @@ function ApiEditorContent<Q, PQ>({ appId, className, apiNode }: ApiEditorContent
             </Button>
           </Toolbar>
           <Stack spacing={2}>
-            <dataSource.QueryEditor
-              api={queryEditorApi}
-              // TODO: Add disabled mode to QueryEditor
-              // disabled={!connection}
-              value={apiQuery}
-              onChange={(newApiQuery) => setApiQuery(newApiQuery)}
-              globalScope={{}}
-            />
+            {connection ? (
+              <dataSource.QueryEditor
+                appId={appId}
+                connectionId={connection.id}
+                // TODO: Add disabled mode to QueryEditor
+                // disabled={!connection}
+                value={apiQuery}
+                onChange={(newApiQuery) => setApiQuery(newApiQuery)}
+                globalScope={{}}
+              />
+            ) : null}
             <Stack>
               <FormControlLabel
                 label="Transform API response"

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
@@ -107,7 +107,7 @@ interface QueryNodeEditorProps<Q, P> {
   node: appDom.QueryNode<Q, P>;
 }
 
-function QueryNodeEditorDialog<Q, P, PQ>({
+function QueryNodeEditorDialog<Q, P>({
   open,
   node,
   onClose,
@@ -239,19 +239,6 @@ function QueryNodeEditorDialog<Q, P, PQ>({
     onClose();
   }, [onRemove, node, onClose]);
 
-  const fetchPrivate = React.useCallback(
-    (query: PQ | {}) => {
-      return client.query.dataSourceFetchPrivate(appId, connectionId, query);
-    },
-    [appId, connectionId],
-  );
-
-  const queryEditorApi = React.useMemo(() => {
-    return {
-      fetchPrivate,
-    };
-  }, [fetchPrivate]);
-
   const paramsObject: Record<string, any> = React.useMemo(() => {
     const liveParamValues: [string, any][] = liveParams.map(([name, result]) => [
       name,
@@ -317,7 +304,8 @@ function QueryNodeEditorDialog<Q, P, PQ>({
           <Divider />
           <Typography>Build query:</Typography>
           <dataSource.QueryEditor
-            api={queryEditorApi}
+            appId={appId}
+            connectionId={connectionId}
             value={input.attributes.query.value}
             onChange={handleQueryChange}
             globalScope={{ query: paramsObject }}

--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -6,7 +6,7 @@ import {
   Release,
   Prisma,
 } from '../../prisma/generated/client';
-import { ServerDataSource, ApiResult, NodeId, VersionOrPreview, PrivateApiResult } from '../types';
+import { ServerDataSource, ApiResult, NodeId, VersionOrPreview } from '../types';
 import serverDataSources from '../toolpadDataSources/server';
 import * as appDom from '../appDom';
 import { omit } from '../utils/immutability';
@@ -387,7 +387,7 @@ export async function dataSourceFetchPrivate<P, Q>(
   appId: string,
   connectionId: NodeId,
   query: Q,
-): Promise<PrivateApiResult<any>> {
+): Promise<any> {
   const connection: appDom.ConnectionNode<P> = await getConnection<P>(appId, connectionId);
   const dataSourceId = connection.attributes.dataSource.value;
   const dataSource: ServerDataSource<P, Q, any> | undefined = serverDataSources[dataSourceId];

--- a/packages/toolpad-app/src/toolpadDataSources/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/client.tsx
@@ -6,7 +6,7 @@ import { NodeId, ClientDataSource } from '../types';
 import * as appDom from '../appDom';
 import googleSheets from './googleSheets/client';
 
-const clientDataSources: { [key: string]: ClientDataSource<any, any, any> | undefined } = {
+const clientDataSources: { [key: string]: ClientDataSource<any, any> | undefined } = {
   movies,
   postgres,
   rest,

--- a/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
@@ -1,25 +1,18 @@
 import { Stack, Button, Checkbox, TextField, Autocomplete, FormControlLabel } from '@mui/material';
 import * as React from 'react';
-import { useQuery } from 'react-query';
-import {
-  ClientDataSource,
-  ConnectionEditorProps,
-  QueryEditorProps,
-  PrivateApiResult,
-} from '../../types';
+import { UseQueryResult } from 'react-query';
+import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
 import {
   GoogleSheetsConnectionParams,
   GoogleSheetsApiQuery,
   GoogleSheetsPrivateQueryType,
-  GoogleSheetsPrivateQuery,
   GoogleDriveFile,
   GoogleSpreadsheet,
   GoogleSheet,
   GoogleDriveFiles,
 } from './types';
 import useDebounced from '../../utils/useDebounced';
-
-const dataSourceName = 'Google Sheets';
+import client from '../../api';
 
 function getInitialQueryValue(): GoogleSheetsApiQuery {
   return { ranges: 'A1:Z10', spreadsheetId: '', sheetName: '', headerRow: false };
@@ -33,63 +26,56 @@ function isConnectionValid(connection: GoogleSheetsConnectionParams | null): boo
 }
 
 function QueryEditor({
-  api,
+  appId,
+  connectionId,
   value,
   onChange,
-}: QueryEditorProps<GoogleSheetsApiQuery, GoogleSheetsPrivateQuery>) {
+}: QueryEditorProps<GoogleSheetsApiQuery>) {
   const [spreadsheetQuery, setSpreadsheetQuery] = React.useState<string | null>(null);
 
   const debouncedSpreadsheetQuery = useDebounced(spreadsheetQuery, 300);
 
-  const fetchedFiles: PrivateApiResult<GoogleDriveFiles> = useQuery(
-    [
-      dataSourceName,
-      GoogleSheetsPrivateQueryType.FILES_LIST,
-      value?.spreadsheetId,
-      debouncedSpreadsheetQuery,
-    ],
-    () => {
-      return api.fetchPrivate({
-        type: GoogleSheetsPrivateQueryType.FILES_LIST,
-        spreadsheetQuery,
-      });
-    },
+  const fetchedFiles: UseQueryResult<GoogleDriveFiles> = client.useQuery('dataSourceFetchPrivate', [
+    appId,
+    connectionId,
     {
-      keepPreviousData: true,
+      type: GoogleSheetsPrivateQueryType.FILES_LIST,
+      spreadsheetQuery: debouncedSpreadsheetQuery,
     },
+  ]);
+
+  const fetchedFile: UseQueryResult<GoogleDriveFile> = client.useQuery(
+    'dataSourceFetchPrivate',
+    value.spreadsheetId
+      ? [
+          appId,
+          connectionId,
+          {
+            type: GoogleSheetsPrivateQueryType.FILE_GET,
+            spreadsheetId: value.spreadsheetId,
+          },
+        ]
+      : null,
   );
 
-  const fetchedFile: PrivateApiResult<GoogleDriveFile> = useQuery(
-    [dataSourceName, GoogleSheetsPrivateQueryType.FILE_GET, value?.spreadsheetId],
-    () => {
-      return api.fetchPrivate({
-        type: GoogleSheetsPrivateQueryType.FILE_GET,
-        spreadsheetId: value?.spreadsheetId,
-      });
-    },
-    {
-      keepPreviousData: true,
-      enabled: Boolean(value?.spreadsheetId),
-    },
-  );
-
-  const fetchedSpreadsheet: PrivateApiResult<GoogleSpreadsheet> = useQuery(
-    [dataSourceName, GoogleSheetsPrivateQueryType.FETCH_SPREADSHEET, value?.spreadsheetId],
-    () => {
-      return api.fetchPrivate({
-        type: GoogleSheetsPrivateQueryType.FETCH_SPREADSHEET,
-        spreadsheetId: value?.spreadsheetId,
-      });
-    },
-    {
-      enabled: Boolean(value?.spreadsheetId),
-    },
+  const fetchedSpreadsheet: UseQueryResult<GoogleSpreadsheet> = client.useQuery(
+    'dataSourceFetchPrivate',
+    value.spreadsheetId
+      ? [
+          appId,
+          connectionId,
+          {
+            type: GoogleSheetsPrivateQueryType.FETCH_SPREADSHEET,
+            spreadsheetId: value.spreadsheetId,
+          },
+        ]
+      : null,
   );
 
   const selectedSheet = React.useMemo(
     () =>
-      fetchedSpreadsheet?.data?.sheets?.find(
-        (sheet) => sheet?.properties?.title === value?.sheetName,
+      fetchedSpreadsheet.data?.sheets?.find(
+        (sheet) => sheet.properties?.title === value.sheetName,
       ) ?? null,
     [fetchedSpreadsheet, value],
   );
@@ -119,7 +105,7 @@ function QueryEditor({
     (event: React.ChangeEvent<HTMLInputElement>) => {
       onChange({
         ...value,
-        ranges: event.target?.value,
+        ranges: event.target.value,
       });
     },
     [onChange, value],
@@ -129,7 +115,7 @@ function QueryEditor({
     (event: React.ChangeEvent<HTMLInputElement>) => {
       onChange({
         ...value,
-        headerRow: event.target?.checked,
+        headerRow: event.target.checked,
       });
     },
     [onChange, value],
@@ -149,11 +135,11 @@ function QueryEditor({
       <Autocomplete
         size="small"
         fullWidth
-        value={fetchedFile?.data ?? null}
-        loading={fetchedFiles?.isLoading}
+        value={fetchedFile.data ?? null}
+        loading={fetchedFiles.isLoading}
         loadingText={'Loading...'}
-        options={fetchedFiles?.data?.files ?? []}
-        getOptionLabel={(option: GoogleDriveFile) => option?.name ?? ''}
+        options={fetchedFiles.data?.files ?? []}
+        getOptionLabel={(option: GoogleDriveFile) => option.name ?? ''}
         onInputChange={handleSpreadsheetInput}
         onChange={handleSpreadsheetChange}
         isOptionEqualToValue={(option: GoogleDriveFile, val: GoogleDriveFile) =>
@@ -162,8 +148,8 @@ function QueryEditor({
         renderInput={(params) => <TextField {...params} size="small" label="Select spreadsheet" />}
         renderOption={(props, option) => {
           return (
-            <li {...props} key={option?.id}>
-              {option?.name}
+            <li {...props} key={option.id}>
+              {option.name}
             </li>
           );
         }}
@@ -171,11 +157,11 @@ function QueryEditor({
       <Autocomplete
         size="small"
         fullWidth
-        loading={fetchedSpreadsheet?.isLoading}
+        loading={fetchedSpreadsheet.isLoading}
         value={selectedSheet}
         loadingText={'Loading...'}
-        options={fetchedSpreadsheet?.data?.sheets ?? []}
-        getOptionLabel={(option: GoogleSheet) => option?.properties?.title ?? ''}
+        options={fetchedSpreadsheet.data?.sheets ?? []}
+        getOptionLabel={(option: GoogleSheet) => option.properties?.title ?? ''}
         onChange={handleSheetChange}
         renderInput={(params) => <TextField {...params} size="small" label="Select sheet" />}
         renderOption={(props, option) => {
@@ -190,8 +176,8 @@ function QueryEditor({
         size="small"
         label="Range"
         helperText={`In the form of A1:Z999`}
-        value={value?.ranges}
-        disabled={!value?.sheetName}
+        value={value.ranges}
+        disabled={!value.sheetName}
         onChange={handleRangeChange}
       />
       <FormControlLabel
@@ -199,7 +185,7 @@ function QueryEditor({
         control={
           <Checkbox
             size="small"
-            checked={value?.headerRow}
+            checked={value.headerRow}
             onChange={handleTransformChange}
             inputProps={{ 'aria-label': 'controlled' }}
           />
@@ -232,12 +218,8 @@ function ConnectionParamsInput({
   );
 }
 
-const dataSource: ClientDataSource<
-  GoogleSheetsConnectionParams,
-  GoogleSheetsApiQuery,
-  GoogleSheetsPrivateQuery
-> = {
-  displayName: dataSourceName,
+const dataSource: ClientDataSource<GoogleSheetsConnectionParams, GoogleSheetsApiQuery> = {
+  displayName: 'Google Sheets',
   ConnectionParamsInput,
   isConnectionValid,
   QueryEditor,

--- a/packages/toolpad-app/src/toolpadDataSources/postgres/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/postgres/client.tsx
@@ -1,7 +1,6 @@
 import { Button, Stack, TextareaAutosize, TextField, Toolbar } from '@mui/material';
 import * as React from 'react';
 import { useForm } from 'react-hook-form';
-import { useQuery } from 'react-query';
 import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
 import { validation } from '../../utils/forms';
 import { Maybe } from '../../utils/types';
@@ -84,8 +83,7 @@ function ConnectionParamsInput({
   );
 }
 
-function QueryEditor({ value, onChange, api }: QueryEditorProps<PostgresQuery>) {
-  const result = useQuery('getAllTables', () => api.fetchPrivate('getAllTables'));
+function QueryEditor({ value, onChange }: QueryEditorProps<PostgresQuery>) {
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
       onChange({ ...value, text: event.target.value });
@@ -94,7 +92,6 @@ function QueryEditor({ value, onChange, api }: QueryEditorProps<PostgresQuery>) 
   );
   return (
     <div>
-      <div>{JSON.stringify(result.data, null, 2)}</div>
       <TextareaAutosize
         maxRows={4}
         value={value.text}

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -75,13 +75,6 @@ export interface ApiResult<D = any> {
   fields?: ApiResultFields;
 }
 
-export interface PrivateApiResult<D = any> {
-  data?: D;
-  isLoading: boolean;
-  isIdle: boolean;
-  isSuccess: boolean;
-}
-
 export interface CreateHandlerApi<P = unknown> {
   setConnectionParams: (appId: string, connectionId: string, props: P) => Promise<void>;
   getConnectionParams: (appId: string, connectionId: string) => Promise<P>;
@@ -94,34 +87,31 @@ export interface ConnectionEditorProps<P> extends WithControlledProp<P | null> {
 }
 export type ConnectionParamsEditor<P = {}> = React.FC<ConnectionEditorProps<P>>;
 
-export interface QueryEditorApi<PQ> {
-  fetchPrivate: (query: PQ) => Promise<PrivateApiResult<any>>;
-}
-
-export interface QueryEditorProps<Q, PQ = {}> extends WithControlledProp<Q> {
-  api: QueryEditorApi<PQ>;
+export interface QueryEditorProps<Q> extends WithControlledProp<Q> {
+  appId: string;
+  connectionId: NodeId;
   globalScope: Record<string, any>;
 }
 
-export type QueryEditor<Q = {}, PQ = {}> = React.FC<QueryEditorProps<Q, PQ>>;
+export type QueryEditor<Q = {}> = React.FC<QueryEditorProps<Q>>;
 
 export interface ConnectionStatus {
   timestamp: number;
   error?: string;
 }
 
-export interface ClientDataSource<P = {}, Q = {}, PQ = {}> {
+export interface ClientDataSource<P = {}, Q = {}> {
   displayName: string;
   ConnectionParamsInput: ConnectionParamsEditor<P>;
   isConnectionValid: (connection: P) => boolean;
-  QueryEditor: QueryEditor<Q, PQ>;
+  QueryEditor: QueryEditor<Q>;
   getInitialQueryValue: () => Q;
   getArgTypes?: (query: Q) => ArgTypeDefinitions;
 }
 
 export interface ServerDataSource<P = {}, Q = {}, PQ = {}, D = {}> {
   // Execute a private query on this connection, intended for editors only
-  execPrivate?: (connection: P, query: PQ) => Promise<PrivateApiResult<any>>;
+  execPrivate?: (connection: P, query: PQ) => Promise<any>;
   // Execute a query on this connection, intended for viewers
   exec: (connection: P, query: Q, params: any) => Promise<ApiResult<D>>;
   createHandler?: () => (


### PR DESCRIPTION
During testing I noticed some weird behavior with the Query editor: if you had two sheets connections and try to switch between the two, the sheets query editor doesn't update. It's because no part of the key of `useQuery` updates when the connection changes. This is a design flaw. Fixing it by calling the `client` directly and passing `appId` and `connectionId` directly.