### PR TITLE
Rest dataSource: add baseUrl and headers support

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/ApiEditor/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/ApiEditor/index.tsx
@@ -172,8 +172,7 @@ function ApiEditorContent<Q>({ appId, className, apiNode }: ApiEditorContentProp
               <dataSource.QueryEditor
                 appId={appId}
                 connectionId={connection.id}
-                // TODO: Add disabled mode to QueryEditor
-                // disabled={!connection}
+                connectionParams={connection.attributes.params.value}
                 value={apiQuery}
                 onChange={(newApiQuery) => setApiQuery(newApiQuery)}
                 globalScope={{}}

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/BindableEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/BindableEditor.tsx
@@ -27,7 +27,7 @@ function renderDefaultControl(params: RenderControlParams<any>) {
   return <DefaultControl {...params} />;
 }
 
-interface RenderControlParams<V> extends WithControlledProp<V> {
+export interface RenderControlParams<V> extends WithControlledProp<V> {
   label: string;
   disabled: boolean;
 }

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
@@ -115,11 +115,13 @@ function QueryNodeEditorDialog<Q, P>({
   onSave,
 }: QueryNodeEditorProps<Q, P>) {
   const { appId } = usePageEditorState();
+  const dom = useDom();
 
   const [input, setInput] = React.useState(node);
   React.useEffect(() => setInput(node), [node]);
 
   const connectionId = input.attributes.connectionId.value;
+  const connection = appDom.getMaybeNode(dom, connectionId, 'connection');
   const dataSourceId = input.attributes.dataSource?.value;
   const dataSource = (dataSourceId && dataSources[dataSourceId]) || null;
 
@@ -306,6 +308,7 @@ function QueryNodeEditorDialog<Q, P>({
           <dataSource.QueryEditor
             appId={appId}
             connectionId={connectionId}
+            connectionParams={connection?.attributes.params.value}
             value={input.attributes.query.value}
             onChange={handleQueryChange}
             globalScope={{ query: paramsObject }}
@@ -314,7 +317,7 @@ function QueryNodeEditorDialog<Q, P>({
           <Typography>Options:</Typography>
           <Grid container direction="row" spacing={1}>
             <Grid item xs={4}>
-              <Stack direction="column">
+              <Stack direction="column" gap={1}>
                 <FormControlLabel
                   control={
                     <Checkbox

--- a/packages/toolpad-app/src/components/MapEntriesEditor.tsx
+++ b/packages/toolpad-app/src/components/MapEntriesEditor.tsx
@@ -1,0 +1,129 @@
+import { Box, TextField, IconButton, SxProps } from '@mui/material';
+import * as React from 'react';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { WithControlledProp } from '../utils/types';
+
+function renderStringValueEditor({ label, value, onChange }: RenderValueEditorParams<string>) {
+  return (
+    <TextField
+      label={label}
+      size="small"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  );
+}
+
+interface RenderValueEditorParams<V> extends WithControlledProp<V> {
+  label?: string;
+  disabled?: boolean;
+}
+
+interface RenderValueEditor<V> {
+  (params: RenderValueEditorParams<V>): React.ReactNode;
+}
+
+interface MapEntriesEditorExtraProps<V> {
+  defaultValue: V;
+  renderValueEditor: RenderValueEditor<V>;
+}
+
+type MapEntriesEditorTypedProps<V> = string extends V
+  ? Partial<MapEntriesEditorExtraProps<V>>
+  : MapEntriesEditorExtraProps<V>;
+
+export type MapEntriesEditorProps<V> = WithControlledProp<[string, V][]> & {
+  label?: string;
+  fieldLabel?: string;
+  valueLabel?: string;
+  autoFocus?: boolean;
+  sx?: SxProps;
+  disabled?: boolean;
+} & MapEntriesEditorTypedProps<V>;
+
+export default function MapEntriesEditor<V = string>({
+  value,
+  onChange,
+  label,
+  fieldLabel = 'field',
+  valueLabel = 'value',
+  defaultValue: defaultValueProp,
+  autoFocus = false,
+  sx,
+  renderValueEditor: renderValueEditorProp,
+  disabled,
+}: MapEntriesEditorProps<V>) {
+  const fieldInputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleRemove = React.useCallback(
+    (index: number) => () => {
+      onChange(value.filter((entry, i) => i !== index));
+    },
+    [onChange, value],
+  );
+
+  const isValidFieldName: boolean[] = React.useMemo(() => {
+    const counts: Record<string, number> = {};
+    value.forEach(([field]) => {
+      counts[field] = counts[field] ? counts[field] + 1 : 1;
+    });
+    return value.map(([field]) => !!field && counts[field] <= 1);
+  }, [value]);
+
+  const renderValueEditor =
+    renderValueEditorProp ?? (renderStringValueEditor as unknown as RenderValueEditor<V>);
+
+  const defaultValue = defaultValueProp ?? ('' as unknown as V);
+
+  return (
+    <Box sx={sx} display="grid" gridTemplateColumns="1fr 2fr auto" alignItems="center" gap={1}>
+      {label ? <Box gridColumn="span 3">{label}:</Box> : null}
+      {value.map(([field, fieldValue], index) => {
+        return (
+          <React.Fragment key={index}>
+            <TextField
+              disabled={disabled}
+              label={valueLabel}
+              size="small"
+              value={field}
+              autoFocus
+              onChange={(event) =>
+                onChange(
+                  value.map((entry, i) => (i === index ? [event.target.value, entry[1]] : entry)),
+                )
+              }
+              error={!isValidFieldName[index]}
+            />
+
+            {renderValueEditor({
+              label: field,
+              value: fieldValue,
+              onChange(newValue) {
+                onChange(value.map((entry, i) => (i === index ? [entry[0], newValue] : entry)));
+              },
+              disabled,
+            })}
+
+            <IconButton aria-label="Delete property" onClick={handleRemove(index)} size="small">
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </React.Fragment>
+        );
+      })}
+
+      <form autoComplete="off" style={{ display: 'contents' }}>
+        <TextField
+          inputRef={fieldInputRef}
+          size="small"
+          label={fieldLabel}
+          value=""
+          onChange={(event) => {
+            onChange([...value, [event.target.value, defaultValue]]);
+          }}
+          autoFocus={autoFocus}
+          disabled={disabled}
+        />
+      </form>
+    </Box>
+  );
+}

--- a/packages/toolpad-app/src/components/MapEntriesEditor.tsx
+++ b/packages/toolpad-app/src/components/MapEntriesEditor.tsx
@@ -120,7 +120,12 @@ export default function MapEntriesEditor<V = string>({
               disabled: entryDisabled,
             })}
 
-            <IconButton aria-label="Delete property" onClick={handleRemove(index)} size="small">
+            <IconButton
+              aria-label="Delete property"
+              onClick={handleRemove(index)}
+              size="small"
+              disabled={entryDisabled}
+            >
               <DeleteIcon fontSize="small" />
             </IconButton>
           </React.Fragment>

--- a/packages/toolpad-app/src/components/StringRecordEditor.tsx
+++ b/packages/toolpad-app/src/components/StringRecordEditor.tsx
@@ -108,7 +108,7 @@ export default function StringRecordEditor({
         <React.Fragment key={field}>
           {editedField === field ? (
             <TextField
-              label={valueLabel}
+              label={fieldLabel}
               value={editedFieldNewName}
               autoFocus
               onChange={(event) => setEditedFieldNewName(event.target.value)}

--- a/packages/toolpad-app/src/components/ToolpadShell.tsx
+++ b/packages/toolpad-app/src/components/ToolpadShell.tsx
@@ -36,6 +36,7 @@ function Header({ actions, navigation }: HeaderProps) {
     >
       <Toolbar>
         <IconButton
+          size="medium"
           edge="start"
           color="inherit"
           aria-label="Home"
@@ -43,7 +44,7 @@ function Header({ actions, navigation }: HeaderProps) {
           component="a"
           href={`/`}
         >
-          <MenuIcon />
+          <MenuIcon fontSize="medium" />
         </IconButton>
         <Typography
           data-test-id="brand"

--- a/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
@@ -30,7 +30,7 @@ function QueryEditor({
   connectionId,
   value,
   onChange,
-}: QueryEditorProps<GoogleSheetsApiQuery>) {
+}: QueryEditorProps<GoogleSheetsConnectionParams, GoogleSheetsApiQuery>) {
   const [spreadsheetQuery, setSpreadsheetQuery] = React.useState<string | null>(null);
 
   const debouncedSpreadsheetQuery = useDebounced(spreadsheetQuery, 300);

--- a/packages/toolpad-app/src/toolpadDataSources/movies/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/movies/client.tsx
@@ -12,9 +12,9 @@ import {
 import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import data from '../../../movies.json';
-import { ClientDataSource, ConnectionEditorProps } from '../../types';
+import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
 import { validation } from '../../utils/forms';
-import { Maybe, WithControlledProp } from '../../utils/types';
+import { Maybe } from '../../utils/types';
 import { MoviesQuery, MoviesConnectionParams } from './types';
 
 function withDefaults(value: Maybe<MoviesConnectionParams>): MoviesConnectionParams {
@@ -52,7 +52,10 @@ function isValid(connection: MoviesConnectionParams): boolean {
   return !!connection.apiKey;
 }
 
-export function QueryEditor({ value, onChange }: WithControlledProp<MoviesQuery>) {
+export function QueryEditor({
+  value,
+  onChange,
+}: QueryEditorProps<MoviesConnectionParams, MoviesQuery>) {
   const handleChange = React.useCallback(
     (event: SelectChangeEvent<string>) => {
       onChange({ ...value, genre: event.target.value || null });

--- a/packages/toolpad-app/src/toolpadDataSources/movies/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/movies/client.tsx
@@ -13,7 +13,7 @@ import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import data from '../../../movies.json';
 import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
-import { validation } from '../../utils/forms';
+import { isSaveDisabled, validation } from '../../utils/forms';
 import { Maybe } from '../../utils/types';
 import { MoviesQuery, MoviesConnectionParams } from './types';
 
@@ -35,7 +35,7 @@ function ConnectionParamsInput({ value, onChange }: ConnectionEditorProps<Movies
   return (
     <Stack direction="column" gap={1}>
       <Toolbar disableGutters>
-        <Button onClick={doSubmit} disabled={!formState.isDirty || !formState.isValid}>
+        <Button onClick={doSubmit} disabled={isSaveDisabled(formState)}>
           Save
         </Button>
       </Toolbar>

--- a/packages/toolpad-app/src/toolpadDataSources/postgres/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/postgres/client.tsx
@@ -2,7 +2,7 @@ import { Button, Stack, TextareaAutosize, TextField, Toolbar } from '@mui/materi
 import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
-import { validation } from '../../utils/forms';
+import { isSaveDisabled, validation } from '../../utils/forms';
 import { Maybe } from '../../utils/types';
 import { PostgresConnectionParams, PostgresQuery } from './types';
 
@@ -44,7 +44,7 @@ function ConnectionParamsInput({
   return (
     <Stack direction="column" gap={1}>
       <Toolbar disableGutters>
-        <Button onClick={doSubmit} disabled={!formState.isDirty || !formState.isValid}>
+        <Button onClick={doSubmit} disabled={isSaveDisabled(formState)}>
           Save
         </Button>
       </Toolbar>

--- a/packages/toolpad-app/src/toolpadDataSources/postgres/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/postgres/client.tsx
@@ -78,7 +78,10 @@ function ConnectionParamsInput({
   );
 }
 
-function QueryEditor({ value, onChange }: QueryEditorProps<PostgresQuery>) {
+function QueryEditor({
+  value,
+  onChange,
+}: QueryEditorProps<PostgresConnectionParams, PostgresQuery>) {
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
       onChange({ ...value, text: event.target.value });

--- a/packages/toolpad-app/src/toolpadDataSources/rest/AuthenticationEditor.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/AuthenticationEditor.tsx
@@ -52,6 +52,7 @@ function BasicAuthEditor({ disabled, value, onChange }: AuthMethodEditorProps<Ba
         onChange={(event) => onChange({ ...value, user: event.target.value })}
       />
       <TextField
+        type="password"
         disabled={disabled}
         label="password"
         value={value.password}

--- a/packages/toolpad-app/src/toolpadDataSources/rest/AuthenticationEditor.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/AuthenticationEditor.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { Grid, MenuItem, Stack, TextField } from '@mui/material';
+import { ApiKeyAuth, Authentication, BasicAuth, BearerTokenAuth } from './types';
+import { Maybe, WithControlledProp } from '../../utils/types';
+
+interface ApiKeyAuthEditorProps extends WithControlledProp<ApiKeyAuth> {}
+
+function ApiKeyAuthEditor({ value, onChange }: ApiKeyAuthEditorProps) {
+  return (
+    <Stack gap={1}>
+      <TextField
+        label="header"
+        value={value.header}
+        onChange={(event) => onChange({ ...value, header: event.target.value })}
+      />
+      <TextField
+        label="key"
+        value={value.key}
+        onChange={(event) => onChange({ ...value, key: event.target.value })}
+      />
+    </Stack>
+  );
+}
+
+interface BearerTokenAuthEditorProps extends WithControlledProp<BearerTokenAuth> {}
+
+function BearerTokenAuthEditor({ value, onChange }: BearerTokenAuthEditorProps) {
+  return (
+    <Stack gap={1}>
+      <TextField
+        label="token"
+        value={value.token}
+        onChange={(event) => onChange({ ...value, token: event.target.value })}
+      />
+    </Stack>
+  );
+}
+
+interface BasicAuthEditorProps extends WithControlledProp<BasicAuth> {}
+
+function BasicAuthEditor({ value, onChange }: BasicAuthEditorProps) {
+  return (
+    <Stack gap={1}>
+      <TextField
+        label="user"
+        value={value.user}
+        onChange={(event) => onChange({ ...value, user: event.target.value })}
+      />
+      <TextField
+        label="password"
+        value={value.password}
+        onChange={(event) => onChange({ ...value, password: event.target.value })}
+      />
+    </Stack>
+  );
+}
+
+interface AuthenticationDetailsEditorProps extends WithControlledProp<Authentication> {}
+
+function AuthenticationDetailsEditor({ value, ...props }: AuthenticationDetailsEditorProps) {
+  switch (value.type) {
+    case 'basic':
+      return <BasicAuthEditor value={value} {...props} />;
+    case 'bearerToken':
+      return <BearerTokenAuthEditor value={value} {...props} />;
+    case 'apiKey':
+      return <ApiKeyAuthEditor value={value} {...props} />;
+    default:
+      throw new Error(`Unsupported authentication type "${(value as Authentication).type}"`);
+  }
+}
+
+function getInitialAuthenticationValue(type: string): Maybe<Authentication> {
+  if (!type) {
+    return null;
+  }
+  switch (type) {
+    case 'basic':
+      return { type, user: '', password: '' };
+    case 'bearerToken':
+      return { type, token: '' };
+    case 'apiKey':
+      return { type, header: '', key: '' };
+    default:
+      throw new Error(`Unsupported authentication type "${type}"`);
+  }
+}
+
+export interface AuthenticationEditorProps extends WithControlledProp<Maybe<Authentication>> {}
+
+export default function AuthenticationEditor({ value, onChange }: AuthenticationEditorProps) {
+  const handleTypeChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+      onChange(getInitialAuthenticationValue(event.target.value));
+    },
+    [onChange],
+  );
+
+  return (
+    <Grid container spacing={1}>
+      <Grid item xs={4}>
+        <TextField
+          select
+          label="authentication"
+          value={value?.type || ''}
+          onChange={handleTypeChange}
+          fullWidth
+        >
+          <MenuItem value="">No authentication</MenuItem>
+          <MenuItem value="basic">Basic</MenuItem>
+          <MenuItem value="bearerToken">Bearer token</MenuItem>
+          <MenuItem value="apiKey">API key</MenuItem>
+        </TextField>
+      </Grid>
+      <Grid item xs={4}>
+        {value ? <AuthenticationDetailsEditor value={value} onChange={onChange} /> : null}
+      </Grid>
+    </Grid>
+  );
+}

--- a/packages/toolpad-app/src/toolpadDataSources/rest/AuthenticationEditor.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/AuthenticationEditor.tsx
@@ -3,17 +3,21 @@ import { Grid, MenuItem, Stack, TextField } from '@mui/material';
 import { ApiKeyAuth, Authentication, BasicAuth, BearerTokenAuth } from './types';
 import { Maybe, WithControlledProp } from '../../utils/types';
 
-interface ApiKeyAuthEditorProps extends WithControlledProp<ApiKeyAuth> {}
+interface AuthMethodEditorProps<T> extends WithControlledProp<T> {
+  disabled?: boolean;
+}
 
-function ApiKeyAuthEditor({ value, onChange }: ApiKeyAuthEditorProps) {
+function ApiKeyAuthEditor({ disabled, value, onChange }: AuthMethodEditorProps<ApiKeyAuth>) {
   return (
     <Stack gap={1}>
       <TextField
+        disabled={disabled}
         label="header"
         value={value.header}
         onChange={(event) => onChange({ ...value, header: event.target.value })}
       />
       <TextField
+        disabled={disabled}
         label="key"
         value={value.key}
         onChange={(event) => onChange({ ...value, key: event.target.value })}
@@ -21,13 +25,15 @@ function ApiKeyAuthEditor({ value, onChange }: ApiKeyAuthEditorProps) {
     </Stack>
   );
 }
-
-interface BearerTokenAuthEditorProps extends WithControlledProp<BearerTokenAuth> {}
-
-function BearerTokenAuthEditor({ value, onChange }: BearerTokenAuthEditorProps) {
+function BearerTokenAuthEditor({
+  disabled,
+  value,
+  onChange,
+}: AuthMethodEditorProps<BearerTokenAuth>) {
   return (
     <Stack gap={1}>
       <TextField
+        disabled={disabled}
         label="token"
         value={value.token}
         onChange={(event) => onChange({ ...value, token: event.target.value })}
@@ -36,17 +42,17 @@ function BearerTokenAuthEditor({ value, onChange }: BearerTokenAuthEditorProps) 
   );
 }
 
-interface BasicAuthEditorProps extends WithControlledProp<BasicAuth> {}
-
-function BasicAuthEditor({ value, onChange }: BasicAuthEditorProps) {
+function BasicAuthEditor({ disabled, value, onChange }: AuthMethodEditorProps<BasicAuth>) {
   return (
     <Stack gap={1}>
       <TextField
+        disabled={disabled}
         label="user"
         value={value.user}
         onChange={(event) => onChange({ ...value, user: event.target.value })}
       />
       <TextField
+        disabled={disabled}
         label="password"
         value={value.password}
         onChange={(event) => onChange({ ...value, password: event.target.value })}
@@ -55,9 +61,7 @@ function BasicAuthEditor({ value, onChange }: BasicAuthEditorProps) {
   );
 }
 
-interface AuthenticationDetailsEditorProps extends WithControlledProp<Authentication> {}
-
-function AuthenticationDetailsEditor({ value, ...props }: AuthenticationDetailsEditorProps) {
+function AuthenticationDetailsEditor({ value, ...props }: AuthMethodEditorProps<Authentication>) {
   switch (value.type) {
     case 'basic':
       return <BasicAuthEditor value={value} {...props} />;
@@ -86,9 +90,15 @@ function getInitialAuthenticationValue(type: string): Maybe<Authentication> {
   }
 }
 
-export interface AuthenticationEditorProps extends WithControlledProp<Maybe<Authentication>> {}
+export interface AuthenticationEditorProps extends WithControlledProp<Maybe<Authentication>> {
+  disabled?: boolean;
+}
 
-export default function AuthenticationEditor({ value, onChange }: AuthenticationEditorProps) {
+export default function AuthenticationEditor({
+  disabled,
+  value,
+  onChange,
+}: AuthenticationEditorProps) {
   const handleTypeChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
       onChange(getInitialAuthenticationValue(event.target.value));
@@ -100,6 +110,7 @@ export default function AuthenticationEditor({ value, onChange }: Authentication
     <Grid container spacing={1}>
       <Grid item xs={4}>
         <TextField
+          disabled={disabled}
           select
           label="authentication"
           value={value?.type || ''}
@@ -113,7 +124,9 @@ export default function AuthenticationEditor({ value, onChange }: Authentication
         </TextField>
       </Grid>
       <Grid item xs={4}>
-        {value ? <AuthenticationDetailsEditor value={value} onChange={onChange} /> : null}
+        {value ? (
+          <AuthenticationDetailsEditor disabled={disabled} value={value} onChange={onChange} />
+        ) : null}
       </Grid>
     </Grid>
   );

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -1,12 +1,44 @@
 import * as React from 'react';
 import { ArgTypeDefinitions, BindableAttrValue, LiveBinding } from '@mui/toolpad-core';
-import { Button, Stack, TextField, Toolbar, Typography } from '@mui/material';
+import { Button, InputAdornment, Stack, TextField, Toolbar, Typography } from '@mui/material';
 import StringRecordEditor from '../../components/StringRecordEditor';
 import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
 import { FetchQuery, RestConnectionParams } from './types';
-import BindableEditor from '../../components/AppEditor/PageEditor/BindableEditor';
+import BindableEditor, {
+  RenderControlParams,
+} from '../../components/AppEditor/PageEditor/BindableEditor';
 import { useEvaluateLiveBinding } from '../../components/AppEditor/useEvaluateLiveBinding';
 import MapEntriesEditor from '../../components/MapEntriesEditor';
+
+interface UrlControlProps extends RenderControlParams<string> {
+  baseUrl?: string;
+}
+
+function UrlControl({ label, disabled, baseUrl, value, onChange }: UrlControlProps) {
+  const handleChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value);
+    },
+    [onChange],
+  );
+
+  return (
+    <TextField
+      fullWidth
+      value={value ?? ''}
+      disabled={disabled}
+      onChange={handleChange}
+      label={label}
+      InputProps={
+        baseUrl
+          ? {
+              startAdornment: <InputAdornment position="start">{baseUrl}</InputAdornment>,
+            }
+          : undefined
+      }
+    />
+  );
+}
 
 const EMPTY_ARRAY: [string, string][] = [];
 
@@ -78,6 +110,9 @@ function QueryEditor({
         server
         label="url"
         propType={{ type: 'string' }}
+        renderControl={(params) => {
+          return <UrlControl baseUrl={baseUrl} {...params} />;
+        }}
         value={value.url}
         onChange={handleUrlChange}
       />

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -14,7 +14,7 @@ function ConnectionParamsInput({
   value: valueProp,
   onChange,
 }: ConnectionEditorProps<RestConnectionParams>) {
-  const [input, setInput] = React.useState(valueProp || { url: '', headers: [] });
+  const [input, setInput] = React.useState(valueProp || { baseUrl: '', headers: [] });
   React.useEffect(() => setInput((existing) => valueProp ?? existing), [valueProp]);
 
   return (
@@ -23,22 +23,30 @@ function ConnectionParamsInput({
         <Button onClick={() => onChange(input)}>Save</Button>
       </Toolbar>
       <TextField
-        label="url"
-        size="small"
-        value={input.url}
-        onChange={(newUrl) => setInput((existing) => ({ ...existing, url: newUrl.target.value }))}
+        label="base url"
+        value={input.baseUrl}
+        onChange={(newUrl) =>
+          setInput((existing) => ({ ...existing, baseUrl: newUrl.target.value }))
+        }
       />
       <Typography>headers:</Typography>
       <MapEntriesEditor
         value={input.headers || EMPTY_ARRAY}
         onChange={(newHeaders) => setInput((existing) => ({ ...existing, headers: newHeaders }))}
-        disabled={!input.url}
+        disabled={!input.baseUrl}
       />
     </Stack>
   );
 }
 
-function QueryEditor({ globalScope, value, onChange }: QueryEditorProps<FetchQuery>) {
+function QueryEditor({
+  globalScope,
+  connectionParams,
+  value,
+  onChange,
+}: QueryEditorProps<RestConnectionParams, FetchQuery>) {
+  const baseUrl = connectionParams?.baseUrl;
+
   const handleUrlChange = React.useCallback(
     (newValue: BindableAttrValue<string> | null) => {
       onChange({ ...value, url: newValue || { type: 'const', value: '' } });

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -1,13 +1,41 @@
 import * as React from 'react';
 import { ArgTypeDefinitions, BindableAttrValue, LiveBinding } from '@mui/toolpad-core';
+import { Button, Stack, TextField, Toolbar, Typography } from '@mui/material';
 import StringRecordEditor from '../../components/StringRecordEditor';
-import { ClientDataSource, QueryEditorProps } from '../../types';
-import { FetchQuery } from './types';
+import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
+import { FetchQuery, RestConnectionParams } from './types';
 import BindableEditor from '../../components/AppEditor/PageEditor/BindableEditor';
 import { useEvaluateLiveBinding } from '../../components/AppEditor/useEvaluateLiveBinding';
+import MapEntriesEditor from '../../components/MapEntriesEditor';
 
-function ConnectionParamsInput() {
-  return null;
+const EMPTY_ARRAY: [string, string][] = [];
+
+function ConnectionParamsInput({
+  value: valueProp,
+  onChange,
+}: ConnectionEditorProps<RestConnectionParams>) {
+  const [input, setInput] = React.useState(valueProp || { url: '', headers: [] });
+  React.useEffect(() => setInput((existing) => valueProp ?? existing), [valueProp]);
+
+  return (
+    <Stack direction="column" gap={1}>
+      <Toolbar disableGutters>
+        <Button onClick={() => onChange(input)}>Save</Button>
+      </Toolbar>
+      <TextField
+        label="url"
+        size="small"
+        value={input.url}
+        onChange={(newUrl) => setInput((existing) => ({ ...existing, url: newUrl.target.value }))}
+      />
+      <Typography>headers:</Typography>
+      <MapEntriesEditor
+        value={input.headers || EMPTY_ARRAY}
+        onChange={(newHeaders) => setInput((existing) => ({ ...existing, headers: newHeaders }))}
+        disabled={!input.url}
+      />
+    </Stack>
+  );
 }
 
 function QueryEditor({ globalScope, value, onChange }: QueryEditorProps<FetchQuery>) {

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -69,12 +69,15 @@ function ConnectionParamsInput({ value, onChange }: ConnectionEditorProps<RestCo
     }),
   );
 
+  const baseUrlValue = watch('baseUrl');
   const headersValue = watch('headers');
   const authenticationValue = watch('authentication');
   const authenticationHeaders = getAuthenticationHeaders(authenticationValue);
 
   const mustHaveBaseUrl: boolean =
     (headersValue && headersValue.length > 0) || !!authenticationValue;
+
+  const headersAllowed = !!baseUrlValue;
 
   return (
     <Stack direction="column" gap={1}>
@@ -113,8 +116,9 @@ function ConnectionParamsInput({ value, onChange }: ConnectionEditorProps<RestCo
             const allHeaders = [...authenticationHeaders, ...fieldValue];
             return (
               <MapEntriesEditor
-                fieldLabel="header"
                 {...field}
+                disabled={!headersAllowed}
+                fieldLabel="header"
                 value={allHeaders}
                 onChange={(headers) => onFieldChange(headers.slice(authenticationHeaders.length))}
                 isEntryDisabled={(entry, index) => index < authenticationHeaders.length}
@@ -127,7 +131,11 @@ function ConnectionParamsInput({ value, onChange }: ConnectionEditorProps<RestCo
           name="authentication"
           control={control}
           render={({ field: { value: fieldValue, ref, ...field } }) => (
-            <AuthenticationEditor {...field} value={fieldValue ?? null} />
+            <AuthenticationEditor
+              {...field}
+              disabled={!headersAllowed}
+              value={fieldValue ?? null}
+            />
           )}
         />
       </Stack>

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -80,13 +80,16 @@ function ConnectionParamsInput({ value, onChange }: ConnectionEditorProps<RestCo
         <Controller
           name="headers"
           control={control}
-          render={({ field: { value: fieldValue = [], ref, ...field } }) => {
+          render={({
+            field: { value: fieldValue = [], onChange: onFieldChange, ref, ...field },
+          }) => {
             const allHeaders = [...authenticationHeaders, ...fieldValue];
             return (
               <MapEntriesEditor
                 fieldLabel="header"
                 {...field}
                 value={allHeaders}
+                onChange={(headers) => onFieldChange(headers.slice(authenticationHeaders.length))}
                 isEntryDisabled={(entry, index) => index < authenticationHeaders.length}
               />
             );

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -74,31 +74,33 @@ function ConnectionParamsInput({ value, onChange }: ConnectionEditorProps<RestCo
           Save
         </Button>
       </Toolbar>
-      <TextField label="base url" {...register('baseUrl')} />
-      <Typography>Headers:</Typography>
-      <Controller
-        name="headers"
-        control={control}
-        render={({ field: { value: fieldValue = [], ref, ...field } }) => {
-          const allHeaders = [...authenticationHeaders, ...fieldValue];
-          return (
-            <MapEntriesEditor
-              fieldLabel="header"
-              {...field}
-              value={allHeaders}
-              isEntryDisabled={(entry, index) => index < authenticationHeaders.length}
-            />
-          );
-        }}
-      />
-      <Typography>Authentication:</Typography>
-      <Controller
-        name="authentication"
-        control={control}
-        render={({ field: { value: fieldValue, ref, ...field } }) => (
-          <AuthenticationEditor {...field} value={fieldValue ?? null} />
-        )}
-      />
+      <Stack gap={3}>
+        <TextField label="base url" {...register('baseUrl')} />
+        <Typography>Headers:</Typography>
+        <Controller
+          name="headers"
+          control={control}
+          render={({ field: { value: fieldValue = [], ref, ...field } }) => {
+            const allHeaders = [...authenticationHeaders, ...fieldValue];
+            return (
+              <MapEntriesEditor
+                fieldLabel="header"
+                {...field}
+                value={allHeaders}
+                isEntryDisabled={(entry, index) => index < authenticationHeaders.length}
+              />
+            );
+          }}
+        />
+        <Typography>Authentication:</Typography>
+        <Controller
+          name="authentication"
+          control={control}
+          render={({ field: { value: fieldValue, ref, ...field } }) => (
+            <AuthenticationEditor {...field} value={fieldValue ?? null} />
+          )}
+        />
+      </Stack>
     </Stack>
   );
 }

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -1,14 +1,19 @@
 import * as React from 'react';
 import { ArgTypeDefinitions, BindableAttrValue, LiveBinding } from '@mui/toolpad-core';
 import { Button, InputAdornment, Stack, TextField, Toolbar, Typography } from '@mui/material';
+import { Controller, useForm } from 'react-hook-form';
 import StringRecordEditor from '../../components/StringRecordEditor';
 import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
 import { FetchQuery, RestConnectionParams } from './types';
+import { getAuthenticationHeaders } from './shared';
 import BindableEditor, {
   RenderControlParams,
 } from '../../components/AppEditor/PageEditor/BindableEditor';
 import { useEvaluateLiveBinding } from '../../components/AppEditor/useEvaluateLiveBinding';
 import MapEntriesEditor from '../../components/MapEntriesEditor';
+import { Maybe } from '../../utils/types';
+import AuthenticationEditor from './AuthenticationEditor';
+import { isSaveDisabled } from '../../utils/forms';
 
 interface UrlControlProps extends RenderControlParams<string> {
   baseUrl?: string;
@@ -40,32 +45,59 @@ function UrlControl({ label, disabled, baseUrl, value, onChange }: UrlControlPro
   );
 }
 
-const EMPTY_ARRAY: [string, string][] = [];
+function withDefaults(value: Maybe<RestConnectionParams>): RestConnectionParams {
+  return {
+    baseUrl: '',
+    headers: [],
+    authentication: null,
+    ...value,
+  };
+}
 
-function ConnectionParamsInput({
-  value: valueProp,
-  onChange,
-}: ConnectionEditorProps<RestConnectionParams>) {
-  const [input, setInput] = React.useState(valueProp || { baseUrl: '', headers: [] });
-  React.useEffect(() => setInput((existing) => valueProp ?? existing), [valueProp]);
+function ConnectionParamsInput({ value, onChange }: ConnectionEditorProps<RestConnectionParams>) {
+  const { handleSubmit, register, formState, reset, control, watch } = useForm({
+    defaultValues: withDefaults(value),
+    reValidateMode: 'onChange',
+    mode: 'all',
+  });
+  React.useEffect(() => reset(withDefaults(value)), [reset, value]);
+
+  const doSubmit = handleSubmit((connectionParams) => onChange(connectionParams));
+
+  const authentication = watch('authentication');
+  const authenticationHeaders = getAuthenticationHeaders(authentication);
 
   return (
     <Stack direction="column" gap={1}>
       <Toolbar disableGutters>
-        <Button onClick={() => onChange(input)}>Save</Button>
+        <Button onClick={doSubmit} disabled={isSaveDisabled(formState)}>
+          Save
+        </Button>
       </Toolbar>
-      <TextField
-        label="base url"
-        value={input.baseUrl}
-        onChange={(newUrl) =>
-          setInput((existing) => ({ ...existing, baseUrl: newUrl.target.value }))
-        }
+      <TextField label="base url" {...register('baseUrl')} />
+      <Typography>Headers:</Typography>
+      <Controller
+        name="headers"
+        control={control}
+        render={({ field: { value: fieldValue = [], ref, ...field } }) => {
+          const allHeaders = [...authenticationHeaders, ...fieldValue];
+          return (
+            <MapEntriesEditor
+              fieldLabel="header"
+              {...field}
+              value={allHeaders}
+              isEntryDisabled={(entry, index) => index < authenticationHeaders.length}
+            />
+          );
+        }}
       />
-      <Typography>headers:</Typography>
-      <MapEntriesEditor
-        value={input.headers || EMPTY_ARRAY}
-        onChange={(newHeaders) => setInput((existing) => ({ ...existing, headers: newHeaders }))}
-        disabled={!input.baseUrl}
+      <Typography>Authentication:</Typography>
+      <Controller
+        name="authentication"
+        control={control}
+        render={({ field: { value: fieldValue, ref, ...field } }) => (
+          <AuthenticationEditor {...field} value={fieldValue ?? null} />
+        )}
       />
     </Stack>
   );

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -90,7 +90,7 @@ function ConnectionParamsInput({ value, onChange }: ConnectionEditorProps<RestCo
             validate(input?: string) {
               if (!input) {
                 if (mustHaveBaseUrl) {
-                  return 'Must have a baseUrl when using headers';
+                  return 'A base url is required when headers are used';
                 }
                 return true;
               }

--- a/packages/toolpad-app/src/toolpadDataSources/rest/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/server.ts
@@ -5,7 +5,7 @@ import * as bindings from '../../utils/bindings';
 import evalExpression from '../../server/evalExpression';
 import { removeLeading } from '../../utils/strings';
 import { Maybe } from '../../utils/types';
-import { parseBaseUrl } from './shared';
+import { getAuthenticationHeaders, parseBaseUrl } from './shared';
 
 async function resolveBindableString(
   bindable: BindableAttrValue<string>,
@@ -52,7 +52,10 @@ async function exec(
   const queryUrl = parseQueryUrl(resolvedUrl, connection.baseUrl);
 
   const res = await fetch(queryUrl.href, {
-    headers: connection.headers,
+    headers: [
+      ...getAuthenticationHeaders(connection.authentication),
+      ...(connection.headers || []),
+    ],
   });
 
   if (!res.ok) {

--- a/packages/toolpad-app/src/toolpadDataSources/rest/shared.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/shared.ts
@@ -1,0 +1,9 @@
+import { ensureEndsWith } from '../../utils/strings';
+
+export function parseBaseUrl(baseUrl: string): URL {
+  const parsedBase = new URL(baseUrl);
+  parsedBase.pathname = ensureEndsWith(parsedBase.pathname, '/');
+  parsedBase.search = '';
+  parsedBase.hash = '';
+  return parsedBase;
+}

--- a/packages/toolpad-app/src/toolpadDataSources/rest/shared.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/shared.ts
@@ -1,4 +1,28 @@
 import { ensureEndsWith } from '../../utils/strings';
+import { Maybe } from '../../utils/types';
+import { Authentication } from './types';
+
+export function getAuthenticationHeaders(auth: Maybe<Authentication>): [string, string][] {
+  if (!auth) {
+    return [];
+  }
+
+  switch (auth.type) {
+    case 'basic':
+      return [
+        [
+          'Authorization',
+          `Basic ${Buffer.from(`${auth.user}:${auth.password}`, 'utf-8').toString('base64')}`,
+        ],
+      ];
+    case 'bearerToken':
+      return [['Authorization', `Bearer ${auth.token}`]];
+    case 'apiKey':
+      return [[auth.header, auth.key]];
+    default:
+      throw new Error(`Unsupported authentication type "${(auth as Authentication).type}"`);
+  }
+}
 
 export function parseBaseUrl(baseUrl: string): URL {
   const parsedBase = new URL(baseUrl);

--- a/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
@@ -1,8 +1,33 @@
 import { BindableAttrValue } from '@mui/toolpad-core';
+import { Maybe } from '../../utils/types';
+
+interface AuthenticationBase {
+  type: 'basic' | 'bearerToken' | 'apiKey';
+}
+
+export interface BasicAuth extends AuthenticationBase {
+  type: 'basic';
+  user: string;
+  password: string;
+}
+
+export interface BearerTokenAuth extends AuthenticationBase {
+  type: 'bearerToken';
+  token: string;
+}
+
+export interface ApiKeyAuth extends AuthenticationBase {
+  type: 'apiKey';
+  header: string;
+  key: string;
+}
+
+export type Authentication = BasicAuth | BearerTokenAuth | ApiKeyAuth;
 
 export interface RestConnectionParams {
   baseUrl?: string;
   headers?: [string, string][];
+  authentication?: Maybe<Authentication>;
 }
 
 export interface FetchQuery {

--- a/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
@@ -1,6 +1,9 @@
 import { BindableAttrValue } from '@mui/toolpad-core';
 
-export interface RestConnectionParams {}
+export interface RestConnectionParams {
+  url?: string;
+  headers?: [string, string][];
+}
 
 export interface FetchQuery {
   /**

--- a/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
@@ -1,7 +1,7 @@
 import { BindableAttrValue } from '@mui/toolpad-core';
 
 export interface RestConnectionParams {
-  url?: string;
+  baseUrl?: string;
   headers?: [string, string][];
 }
 

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -7,7 +7,7 @@ import {
   RuntimeError,
   ComponentConfig,
 } from '@mui/toolpad-core';
-import type { Branded, WithControlledProp } from './utils/types';
+import type { Branded, Maybe, WithControlledProp } from './utils/types';
 import type { Rectangle } from './utils/geometry';
 
 export interface EditorProps<T> {
@@ -87,13 +87,14 @@ export interface ConnectionEditorProps<P> extends WithControlledProp<P | null> {
 }
 export type ConnectionParamsEditor<P = {}> = React.FC<ConnectionEditorProps<P>>;
 
-export interface QueryEditorProps<Q> extends WithControlledProp<Q> {
+export interface QueryEditorProps<P, Q> extends WithControlledProp<Q> {
   appId: string;
   connectionId: NodeId;
+  connectionParams: Maybe<P>;
   globalScope: Record<string, any>;
 }
 
-export type QueryEditor<Q = {}> = React.FC<QueryEditorProps<Q>>;
+export type QueryEditor<P, Q = {}> = React.FC<QueryEditorProps<P, Q>>;
 
 export interface ConnectionStatus {
   timestamp: number;
@@ -104,7 +105,7 @@ export interface ClientDataSource<P = {}, Q = {}> {
   displayName: string;
   ConnectionParamsInput: ConnectionParamsEditor<P>;
   isConnectionValid: (connection: P) => boolean;
-  QueryEditor: QueryEditor<Q>;
+  QueryEditor: QueryEditor<P, Q>;
   getInitialQueryValue: () => Q;
   getArgTypes?: (query: Q) => ArgTypeDefinitions;
 }

--- a/packages/toolpad-app/src/utils/forms.ts
+++ b/packages/toolpad-app/src/utils/forms.ts
@@ -23,3 +23,9 @@ export function validation<T>(
     helperText: error ? errorMessage(error) : undefined,
   };
 }
+
+export function isSaveDisabled(formState: FormState<any>): boolean {
+  // Always destructure formState to trigger underlying react-hook-form Proxy object
+  const { isValid, isDirty } = formState;
+  return !isValid || !isDirty;
+}

--- a/packages/toolpad-app/src/utils/strings.ts
+++ b/packages/toolpad-app/src/utils/strings.ts
@@ -61,6 +61,22 @@ export function isAbsoluteUrl(maybeUrl: string) {
   }
 }
 
+export function removeLeading(input: string, prefix: string): string {
+  return input.startsWith(prefix) ? input.slice(prefix.length) : input;
+}
+
+export function removeTrailing(input: string, suffix: string): string {
+  return input.endsWith(suffix) ? input.slice(0, input.length - suffix.length) : input;
+}
+
+export function ensureStartsWith(input: string, prefix: string): string {
+  return input.startsWith(prefix) ? input : prefix + input;
+}
+
+export function ensureEndsWith(input: string, suffix: string): string {
+  return input.endsWith(suffix) ? input : input + suffix;
+}
+
 /**
  * Regex to statically find all static import statements
  *


### PR DESCRIPTION
Allows setting a `baseUrl` and headers. Also some authentication support for a few basic methods.

Closes https://github.com/mui/mui-toolpad/issues/401

![Screenshot 2022-06-03 at 14 44 08](https://user-images.githubusercontent.com/2109932/171856272-71ff80db-16b5-4f11-852b-ef424382df9c.png)

