### PR TITLE
Fix render.com

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,6 @@ services:
     startCommand: yarn start
     healthCheckPath: /health-check
     plan: starter plus
-    previewPlan: starter
     pullRequestPreviewsEnabled: true
     envVars:
       - key: TOOLPAD_DATABASE_URL
@@ -23,7 +22,6 @@ databases:
   - name: toolpad-db
     ipAllowList: []
     plan: starter
-    previewPlan: starter
 
 envVarGroups:
   - name: toolpad-settings


### PR DESCRIPTION
Tried deploying without running `prisma migrate deploy`, which worked. So this confirms the problem.
Updating the `previewPlan` to enable deploys again