### PR TITLE
Replace Select with TextField

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/CreateApiNodeDialog.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/CreateApiNodeDialog.tsx
@@ -4,11 +4,8 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  FormControl,
-  InputLabel,
   MenuItem,
-  Select,
-  SelectChangeEvent,
+  TextField,
   Typography,
 } from '@mui/material';
 import * as React from 'react';
@@ -37,29 +34,26 @@ export function ConnectionSelect({ dataSource, value, onChange }: ConnectionSele
   }, [connections, dataSource]);
 
   const handleSelectionChange = React.useCallback(
-    (event: SelectChangeEvent<string>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       onChange((event.target.value as NodeId) || null);
     },
     [onChange],
   );
 
   return (
-    <FormControl fullWidth>
-      <InputLabel id="select-connection-type">Connection</InputLabel>
-      <Select
-        fullWidth
-        value={value || ''}
-        labelId="select-connection-type"
-        label="Connection"
-        onChange={handleSelectionChange}
-      >
-        {filtered.map((connection) => (
-          <MenuItem key={connection.id} value={connection.id}>
-            {connection.name} | {connection.attributes.dataSource.value}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <TextField
+      select
+      fullWidth
+      value={value || ''}
+      label="Connection"
+      onChange={handleSelectionChange}
+    >
+      {filtered.map((connection) => (
+        <MenuItem key={connection.id} value={connection.id}>
+          {connection.name} | {connection.attributes.dataSource.value}
+        </MenuItem>
+      ))}
+    </TextField>
   );
 }
 

--- a/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
@@ -4,10 +4,8 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  FormControl,
-  InputLabel,
   MenuItem,
-  Select,
+  TextField,
 } from '@mui/material';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -58,24 +56,23 @@ export default function CreateConnectionDialog({
       >
         <DialogTitle>Create a new MUI Toolpad Connection</DialogTitle>
         <DialogContent>
-          <FormControl sx={{ my: 1 }} fullWidth>
-            <InputLabel id="select-connection-type">Type</InputLabel>
-            <Select
-              labelId="select-connection-type"
-              value={dataSourceType}
-              label="Type"
-              onChange={(event) => setDataSourceType(event.target.value)}
-            >
-              {(Object.entries(dataSources) as ExactEntriesOf<typeof dataSources>).map(
-                ([type, dataSourceDef]) =>
-                  dataSourceDef && (
-                    <MenuItem key={type} value={type}>
-                      {dataSourceDef.displayName}
-                    </MenuItem>
-                  ),
-              )}
-            </Select>
-          </FormControl>
+          <TextField
+            select
+            sx={{ my: 1 }}
+            fullWidth
+            value={dataSourceType}
+            label="Type"
+            onChange={(event) => setDataSourceType(event.target.value)}
+          >
+            {(Object.entries(dataSources) as ExactEntriesOf<typeof dataSources>).map(
+              ([type, dataSourceDef]) =>
+                dataSourceDef && (
+                  <MenuItem key={type} value={type}>
+                    {dataSourceDef.displayName}
+                  </MenuItem>
+                ),
+            )}
+          </TextField>
         </DialogContent>
         <DialogActions>
           <Button color="inherit" variant="text" onClick={onClose}>

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryStateEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryStateEditor.tsx
@@ -4,13 +4,9 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
-  FormControl,
-  InputLabel,
   MenuItem,
-  Select,
   List,
   ListItem,
-  SelectChangeEvent,
   DialogActions,
   Box,
   LinearProgress,
@@ -100,7 +96,7 @@ function QueryStateNodeEditor<P>({ node }: QueryStateNodeEditorProps<P>) {
   const { apis = [] } = appDom.getChildNodes(dom, app);
 
   const handleSelectionChange = React.useCallback(
-    (event: SelectChangeEvent<'' | NodeId>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       const apiNodeId = event.target.value ? (event.target.value as NodeId) : null;
       domApi.setNodeNamespacedProp(node, 'attributes', 'api', appDom.createConst(apiNodeId));
     },
@@ -155,22 +151,20 @@ function QueryStateNodeEditor<P>({ node }: QueryStateNodeEditorProps<P>) {
     <React.Fragment>
       <Stack spacing={1} py={1}>
         <NodeNameEditor node={node} />
-        <FormControl fullWidth>
-          <InputLabel id={`select-data-query`}>Query</InputLabel>
-          <Select
-            value={node.attributes.api.value || ''}
-            labelId="select-data-query"
-            label="Query"
-            onChange={handleSelectionChange}
-          >
-            <MenuItem value="">---</MenuItem>
-            {apis.map(({ id, name }) => (
-              <MenuItem key={id} value={id}>
-                {name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <TextField
+          select
+          fullWidth
+          value={node.attributes.api.value || ''}
+          label="Query"
+          onChange={handleSelectionChange}
+        >
+          <MenuItem value="">---</MenuItem>
+          {apis.map(({ id, name }) => (
+            <MenuItem key={id} value={id}>
+              {name}
+            </MenuItem>
+          ))}
+        </TextField>
         <ParamsEditor node={node} argTypes={argTypes} />
         <FormControlLabel
           control={

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ThemeEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ThemeEditor.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
 import {
-  FormControl,
-  InputLabel,
-  Select,
   MenuItem,
   Stack,
   Button,
   ToggleButtonGroup,
   ToggleButton,
   styled,
+  TextField,
 } from '@mui/material';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
@@ -50,21 +48,19 @@ interface PaletteColorPickerProps extends WithControlledProp<string> {
 
 function PaletteColorPicker({ name, value, onChange }: PaletteColorPickerProps) {
   return (
-    <FormControl fullWidth>
-      <InputLabel id="select-color">{name}</InputLabel>
-      <Select
-        labelId="select-color"
-        value={value}
-        label={name}
-        onChange={(event) => onChange(event.target.value)}
-      >
-        {THEME_COLORS.map((color) => (
-          <MenuItem key={color} value={color}>
-            {color}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <TextField
+      select
+      fullWidth
+      value={value}
+      label={name}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {THEME_COLORS.map((color) => (
+        <MenuItem key={color} value={color}>
+          {color}
+        </MenuItem>
+      ))}
+    </TextField>
   );
 }
 

--- a/packages/toolpad-app/src/components/propertyControls/GridColumns.tsx
+++ b/packages/toolpad-app/src/components/propertyControls/GridColumns.tsx
@@ -4,16 +4,13 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  FormControl,
   IconButton,
-  InputLabel,
   List,
   ListItem,
   ListItemButton,
   ListItemText,
   Menu,
   MenuItem,
-  Select,
   Stack,
   TextField,
 } from '@mui/material';
@@ -128,45 +125,41 @@ function GridColumnsPropEditor({
                     handleColumnChange({ ...editedColumn, field: event.target.value })
                   }
                 />
-                <FormControl fullWidth>
-                  <InputLabel id={`select-type`}>type</InputLabel>
-                  <Select
-                    labelId={`select-type`}
-                    label="type"
-                    value={editedColumn.type ?? ''}
-                    disabled={disabled}
-                    onChange={(event) =>
-                      handleColumnChange({ ...editedColumn, type: event.target.value })
-                    }
-                  >
-                    {COLUMN_TYPES.map((type) => (
-                      <MenuItem key={type} value={type}>
-                        {type}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-                <FormControl fullWidth>
-                  <InputLabel id={`select-align`}>align</InputLabel>
-                  <Select
-                    labelId={`select-align`}
-                    label="align"
-                    value={editedColumn.align ?? ''}
-                    disabled={disabled}
-                    onChange={(event) =>
-                      handleColumnChange({
-                        ...editedColumn,
-                        align: (event.target.value as GridAlignment) || undefined,
-                      })
-                    }
-                  >
-                    {ALIGNMENTS.map((alignment) => (
-                      <MenuItem key={alignment} value={alignment}>
-                        {alignment}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
+                <TextField
+                  select
+                  fullWidth
+                  label="type"
+                  value={editedColumn.type ?? ''}
+                  disabled={disabled}
+                  onChange={(event) =>
+                    handleColumnChange({ ...editedColumn, type: event.target.value })
+                  }
+                >
+                  {COLUMN_TYPES.map((type) => (
+                    <MenuItem key={type} value={type}>
+                      {type}
+                    </MenuItem>
+                  ))}
+                </TextField>
+                <TextField
+                  select
+                  fullWidth
+                  label="align"
+                  value={editedColumn.align ?? ''}
+                  disabled={disabled}
+                  onChange={(event) =>
+                    handleColumnChange({
+                      ...editedColumn,
+                      align: (event.target.value as GridAlignment) || undefined,
+                    })
+                  }
+                >
+                  {ALIGNMENTS.map((alignment) => (
+                    <MenuItem key={alignment} value={alignment}>
+                      {alignment}
+                    </MenuItem>
+                  ))}
+                </TextField>
                 <TextField
                   label="width"
                   type="number"

--- a/packages/toolpad-app/src/components/propertyControls/select.tsx
+++ b/packages/toolpad-app/src/components/propertyControls/select.tsx
@@ -1,34 +1,32 @@
-import { FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { MenuItem, TextField } from '@mui/material';
 import * as React from 'react';
 import type { EditorProps } from '../../types';
 
 function SelectPropEditor({ label, argType, value, onChange, disabled }: EditorProps<string>) {
-  const id = React.useId();
   const items = argType.typeDef.type === 'string' ? argType.typeDef.enum ?? [] : [];
   const handleChange = React.useCallback(
-    (event: SelectChangeEvent<string>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       onChange(event.target.value);
     },
     [onChange],
   );
+
   return (
-    <FormControl fullWidth>
-      <InputLabel id={id}>{label}</InputLabel>
-      <Select
-        labelId={id}
-        label={label}
-        value={value ?? ''}
-        disabled={disabled}
-        onChange={handleChange}
-      >
-        <MenuItem value="">-</MenuItem>
-        {items.map((item) => (
-          <MenuItem key={item} value={item}>
-            {item}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <TextField
+      select
+      fullWidth
+      label={label}
+      value={value ?? ''}
+      disabled={disabled}
+      onChange={handleChange}
+    >
+      <MenuItem value="">-</MenuItem>
+      {items.map((item) => (
+        <MenuItem key={item} value={item}>
+          {item}
+        </MenuItem>
+      ))}
+    </TextField>
   );
 }
 

--- a/packages/toolpad-app/src/toolpadDataSources/movies/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/movies/client.tsx
@@ -1,14 +1,4 @@
-import {
-  Button,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-  Stack,
-  TextField,
-  Toolbar,
-} from '@mui/material';
+import { Button, MenuItem, Stack, TextField, Toolbar } from '@mui/material';
 import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import data from '../../../movies.json';
@@ -54,29 +44,21 @@ function isValid(connection: MoviesConnectionParams): boolean {
 
 export function QueryEditor({ value, onChange }: WithControlledProp<MoviesQuery>) {
   const handleChange = React.useCallback(
-    (event: SelectChangeEvent<string>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       onChange({ ...value, genre: event.target.value || null });
     },
     [value, onChange],
   );
   return (
     <Stack>
-      <FormControl fullWidth>
-        <InputLabel id="select-movie-genre">Genre</InputLabel>
-        <Select
-          labelId="select-movie-genre"
-          value={value.genre || ''}
-          label="Genre"
-          onChange={handleChange}
-        >
-          <MenuItem value={''}>Any</MenuItem>
-          {data.genres.map((genre) => (
-            <MenuItem key={genre} value={genre}>
-              {genre}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <TextField select fullWidth value={value.genre || ''} label="Genre" onChange={handleChange}>
+        <MenuItem value={''}>Any</MenuItem>
+        {data.genres.map((genre) => (
+          <MenuItem key={genre} value={genre}>
+            {genre}
+          </MenuItem>
+        ))}
+      </TextField>
     </Stack>
   );
 }

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -1,13 +1,5 @@
-// TODO: Remove after https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210 lands
-/// <reference types="react/next" />
 import * as React from 'react';
-import {
-  FormControl,
-  InputLabel,
-  Select as MuiSelect,
-  SelectProps as MuiSelectProps,
-  MenuItem,
-} from '@mui/material';
+import { TextFieldProps, MenuItem, TextField } from '@mui/material';
 import { createComponent } from '@mui/toolpad-core';
 
 export interface Selectoption {
@@ -15,27 +7,22 @@ export interface Selectoption {
   label?: string;
 }
 
-export interface SelectProps extends MuiSelectProps {
+export type SelectProps = TextFieldProps & {
   options: (string | Selectoption)[];
-}
+};
 
-function Select({ sx, label, options, size, ...props }: SelectProps) {
-  const labelId = React.useId();
+function Select({ sx, options, ...props }: SelectProps) {
   return (
-    <FormControl size={size} sx={{ minWidth: 120, ...sx }}>
-      <InputLabel id={labelId}>{label}</InputLabel>
-      <MuiSelect labelId={labelId} label={label} {...props}>
-        {options.map((option) => {
-          const parsedOption: Selectoption =
-            typeof option === 'string' ? { value: option } : option;
-          return (
-            <MenuItem key={parsedOption.value} value={parsedOption.value}>
-              {parsedOption.label ?? parsedOption.value}
-            </MenuItem>
-          );
-        }) ?? null}
-      </MuiSelect>
-    </FormControl>
+    <TextField select sx={{ minWidth: 120, ...sx }} {...props}>
+      {options.map((option) => {
+        const parsedOption: Selectoption = typeof option === 'string' ? { value: option } : option;
+        return (
+          <MenuItem key={parsedOption.value} value={parsedOption.value}>
+            {parsedOption.label ?? parsedOption.value}
+          </MenuItem>
+        );
+      }) ?? null}
+    </TextField>
   );
 }
 


### PR DESCRIPTION
TIL it's possible to implement `Select` using `TextField`. This simplifies the implementation a bit and removes the need of manually handling the label