### PR TITLE
Create proper fallback behavior after delete

### DIFF
--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -497,6 +497,18 @@ export function getDescendants(dom: AppDom, node: AppDomNode): readonly AppDomNo
   return [...children, ...children.flatMap((child) => getDescendants(dom, child))];
 }
 
+/**
+ * Get all siblings of a `node`
+ */
+export function getSiblings(dom: AppDom, node: AppDomNode): readonly AppDomNode[] {
+  return Object.values(dom.nodes).filter(
+    (sibling) =>
+      sibling.parentId === node.parentId &&
+      sibling.parentProp === node.parentProp &&
+      sibling.id !== node.id,
+  );
+}
+
 export function getAncestors(dom: AppDom, node: AppDomNode): readonly AppDomNode[] {
   const parent = getParent(dom, node);
   return parent ? [...getAncestors(dom, parent), parent] : [];

--- a/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/index.tsx
@@ -87,10 +87,6 @@ function findFirstSibling(dom: appDom.AppDom, node: appDom.AppDomNode) {
   );
 }
 
-function findFirstOfType(dom: appDom.AppDom, type: appDom.AppDomNode['type']) {
-  return Object.values(dom.nodes).find((node) => node.type === type);
-}
-
 function getLinkToNodeEditor(appId: string, node: appDom.AppDomNode): string | undefined {
   switch (node.type) {
     case 'page':
@@ -220,14 +216,7 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
         const sibling = findFirstSibling(dom, deletedNode);
         if (sibling) {
           redirectAfterDelete = getLinkToNodeEditor(appId, sibling);
-        } else if (deletedNode.type !== 'page') {
-          const firstPage = findFirstOfType(dom, 'page');
-          if (firstPage) {
-            redirectAfterDelete = getLinkToNodeEditor(appId, firstPage);
-          }
-        }
-
-        if (!redirectAfterDelete) {
+        } else {
           redirectAfterDelete = `/app/${appId}/editor`;
         }
       }

--- a/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/index.tsx
@@ -15,7 +15,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
-import { useNavigate, useLocation, matchRoutes } from 'react-router-dom';
+import { useNavigate, useLocation, matchRoutes, Location } from 'react-router-dom';
 import { NodeId } from '../../../types';
 import * as appDom from '../../../appDom';
 import { useDom, useDomApi } from '../../DomLoader';
@@ -65,6 +65,47 @@ function HierarchyTreeItem(props: StyledTreeItemProps) {
   );
 }
 
+function getActiveNodeId(location: Location): NodeId | null {
+  const match =
+    matchRoutes(
+      [
+        { path: `/app/:appId/editor/pages/:activeNodeId` },
+        { path: `/app/:appId/editor/apis/:activeNodeId` },
+        { path: `/app/:appId/editor/codeComponents/:activeNodeId` },
+        { path: `/app/:appId/editor/connections/:activeNodeId` },
+      ],
+      location,
+    ) || [];
+
+  const selected: NodeId[] = match.map((route) => route.params.activeNodeId as NodeId);
+  return selected.length > 0 ? selected[0] : null;
+}
+
+function findFirstSibling(dom: appDom.AppDom, node: appDom.AppDomNode) {
+  return Object.values(dom.nodes).find(
+    (sibling) => sibling.type === node.type && sibling.id !== node.id,
+  );
+}
+
+function findFirstOfType(dom: appDom.AppDom, type: appDom.AppDomNode['type']) {
+  return Object.values(dom.nodes).find((node) => node.type === type);
+}
+
+function getLinkToNodeEditor(appId: string, node: appDom.AppDomNode): string | undefined {
+  switch (node.type) {
+    case 'page':
+      return `/app/${appId}/editor/pages/${node.id}`;
+    case 'connection':
+      return `/app/${appId}/editor/connections/${node.id}`;
+    case 'codeComponent':
+      return `/app/${appId}/editor/codeComponents/${node.id}`;
+    case 'api':
+      return `/app/${appId}/editor/apis/${node.id}`;
+    default:
+      return undefined;
+  }
+}
+
 export interface HierarchyExplorerProps {
   appId: string;
   className?: string;
@@ -88,18 +129,8 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
   );
 
   const location = useLocation();
-  const match =
-    matchRoutes(
-      [
-        { path: `/app/:appId/editor/pages/:activeNodeId` },
-        { path: `/app/:appId/editor/apis/:activeNodeId` },
-        { path: `/app/:appId/editor/codeComponents/:activeNodeId` },
-        { path: `/app/:appId/editor/connections/:activeNodeId` },
-      ],
-      location,
-    ) || [];
 
-  const selected: NodeId[] = match.map((route) => route.params.activeNodeId as NodeId);
+  const activeNode = getActiveNodeId(location);
 
   const handleToggle = (event: React.SyntheticEvent, nodeIds: string[]) => {
     setExpanded(nodeIds as NodeId[]);
@@ -183,11 +214,33 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
 
   const handleDeleteNode = React.useCallback(() => {
     if (deletedNodeId) {
+      let redirectAfterDelete: string | undefined;
+      if (deletedNodeId === activeNode) {
+        const deletedNode = appDom.getNode(dom, deletedNodeId);
+        const sibling = findFirstSibling(dom, deletedNode);
+        if (sibling) {
+          redirectAfterDelete = getLinkToNodeEditor(appId, sibling);
+        } else if (deletedNode.type !== 'page') {
+          const firstPage = findFirstOfType(dom, 'page');
+          if (firstPage) {
+            redirectAfterDelete = getLinkToNodeEditor(appId, firstPage);
+          }
+        }
+
+        if (!redirectAfterDelete) {
+          redirectAfterDelete = `/app/${appId}/editor`;
+        }
+      }
+
       domApi.removeNode(deletedNodeId);
-      navigate(`/app/${appId}/editor/`);
+
+      if (redirectAfterDelete) {
+        navigate(redirectAfterDelete);
+      }
+
       handledeleteNodeDialogClose();
     }
-  }, [deletedNodeId, domApi, navigate, appId, handledeleteNodeDialogClose]);
+  }, [deletedNodeId, activeNode, domApi, handledeleteNodeDialogClose, dom, appId, navigate]);
 
   const deletedNode = deletedNodeId && appDom.getMaybeNode(dom, deletedNodeId);
   const latestDeletedNode = useLatest(deletedNode);
@@ -196,7 +249,7 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
     <HierarchyExplorerRoot className={className}>
       <TreeView
         aria-label="hierarchy explorer"
-        selected={selected}
+        selected={activeNode ? [activeNode] : []}
         onNodeSelect={handleSelect}
         expanded={expanded}
         onNodeToggle={handleToggle}

--- a/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/index.tsx
@@ -81,12 +81,6 @@ function getActiveNodeId(location: Location): NodeId | null {
   return selected.length > 0 ? selected[0] : null;
 }
 
-function findFirstSibling(dom: appDom.AppDom, node: appDom.AppDomNode) {
-  return Object.values(dom.nodes).find(
-    (sibling) => sibling.type === node.type && sibling.id !== node.id,
-  );
-}
-
 function getLinkToNodeEditor(appId: string, node: appDom.AppDomNode): string | undefined {
   switch (node.type) {
     case 'page':
@@ -213,9 +207,10 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
       let redirectAfterDelete: string | undefined;
       if (deletedNodeId === activeNode) {
         const deletedNode = appDom.getNode(dom, deletedNodeId);
-        const sibling = findFirstSibling(dom, deletedNode);
-        if (sibling) {
-          redirectAfterDelete = getLinkToNodeEditor(appId, sibling);
+        const siblings = appDom.getSiblings(dom, deletedNode);
+        const firstSiblingOfType = siblings.find((sibling) => sibling.type === deletedNode.type);
+        if (firstSiblingOfType) {
+          redirectAfterDelete = getLinkToNodeEditor(appId, firstSiblingOfType);
         } else {
           redirectAfterDelete = `/app/${appId}/editor`;
         }

--- a/packages/toolpad-app/src/components/AppEditor/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/index.tsx
@@ -60,7 +60,11 @@ function FileEditor({ appId }: FileEditorProps) {
         <Route
           index
           element={
-            firstPage ? <Navigate to={`pages/${firstPage.id}`} /> : <NoPageFound appId={appId} />
+            firstPage ? (
+              <Navigate to={`pages/${firstPage.id}`} replace />
+            ) : (
+              <NoPageFound appId={appId} />
+            )
           }
         />
       </Route>


### PR DESCRIPTION
When a node is deleted and its editor is active at the moment do the following:
- navigate to the first of the same type (e.g. after deleting a code component, open the first code component)
- if none: navigate to the first page
- if none: navigate to the project root