### PR TITLE
Allow null/undefined connections

### DIFF
--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -331,22 +331,18 @@ async function applyTransform<Q>(
   };
 }
 
-export async function execApi<Q>(
+export async function execApi<P, Q>(
   appId: string,
   api: appDom.ApiNode<Q>,
   params: Q,
 ): Promise<ApiResult<any>> {
-  const dataSource: ServerDataSource<any, Q, any> | undefined =
+  const dataSource: ServerDataSource<P, Q, any> | undefined =
     serverDataSources[api.attributes.dataSource.value];
   if (!dataSource) {
     throw new Error(`Unknown datasource "${api.attributes.dataSource.value}" for api "${api.id}"`);
   }
 
-  const connectionParams = await getConnectionParams(appId, api.attributes.connectionId.value);
-
-  if (!connectionParams) {
-    throw new Error(`Connection "${api.attributes.connectionId.value}" is not configured"`);
-  }
+  const connectionParams = await getConnectionParams<P>(appId, api.attributes.connectionId.value);
 
   const transformEnabled = api.attributes.transformEnabled?.value;
   let result = await dataSource.exec(connectionParams, api.attributes.query.value, params);
@@ -356,12 +352,12 @@ export async function execApi<Q>(
   return result;
 }
 
-export async function execQuery<Q>(
+export async function execQuery<P, Q>(
   appId: string,
   query: appDom.QueryNode<Q>,
   params: Q,
 ): Promise<ApiResult<any>> {
-  const dataSource: ServerDataSource<any, Q, any> | undefined =
+  const dataSource: ServerDataSource<P, Q, any> | undefined =
     query.attributes.dataSource && serverDataSources[query.attributes.dataSource.value];
   if (!dataSource) {
     throw new Error(
@@ -369,11 +365,7 @@ export async function execQuery<Q>(
     );
   }
 
-  const connectionParams = await getConnectionParams(appId, query.attributes.connectionId.value);
-
-  if (!connectionParams) {
-    throw new Error(`Connection "${query.attributes.connectionId.value}" is not configured"`);
-  }
+  const connectionParams = await getConnectionParams<P>(appId, query.attributes.connectionId.value);
 
   const transformEnabled = query.attributes.transformEnabled?.value;
   let result = await dataSource.exec(connectionParams, query.attributes.query.value, params);
@@ -401,9 +393,6 @@ export async function dataSourceFetchPrivate<P, Q>(
   }
 
   const connectionParams = connection.attributes.params.value;
-  if (!connectionParams) {
-    throw new Error(`Connection "${connection.id}" is not configured"`);
-  }
 
   return dataSource.execPrivate(connectionParams, query);
 }

--- a/packages/toolpad-app/src/toolpadDataSources/googleSheets/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/googleSheets/server.ts
@@ -11,6 +11,7 @@ import {
   GoogleSheetsPrivateQuery,
   GoogleSheetsApiQuery,
 } from './types';
+import { Maybe } from '../../utils/types';
 
 /**
  * Create an OAuth2 client based on the configuration
@@ -71,7 +72,7 @@ function createSheetsClient(client: OAuth2Client) {
  */
 
 async function execPrivate(
-  connection: GoogleSheetsConnectionParams,
+  connection: Maybe<GoogleSheetsConnectionParams>,
   query: GoogleSheetsPrivateQuery,
 ): Promise<any> {
   const client = createOAuthClient();
@@ -146,7 +147,7 @@ async function execPrivate(
  */
 
 async function exec(
-  connection: GoogleSheetsConnectionParams,
+  connection: Maybe<GoogleSheetsConnectionParams>,
   query: GoogleSheetsApiQuery,
 ): Promise<ApiResult<any>> {
   const client = createOAuthClient();

--- a/packages/toolpad-app/src/toolpadDataSources/movies/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/movies/server.ts
@@ -1,9 +1,10 @@
 import moviesData from '../../../movies.json';
 import { ApiResult, ServerDataSource } from '../../types';
+import { Maybe } from '../../utils/types';
 import { MoviesConnectionParams, MoviesQuery, Movie } from './types';
 
 async function exec(
-  connection: MoviesConnectionParams,
+  connection: Maybe<MoviesConnectionParams>,
   moviesQuery: MoviesQuery,
 ): Promise<ApiResult<Movie[]>> {
   const data = moviesData.movies.filter((movie) =>

--- a/packages/toolpad-app/src/toolpadDataSources/postgres/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/postgres/server.ts
@@ -1,7 +1,8 @@
 import { ApiResult, ServerDataSource } from '../../types';
+import { Maybe } from '../../utils/types';
 import { PostgresConnectionParams, PostgresQuery } from './types';
 
-async function execPrivate(connection: PostgresConnectionParams, query: any): Promise<any> {
+async function execPrivate(connection: Maybe<PostgresConnectionParams>, query: any): Promise<any> {
   // eslint-disable-next-line no-console
   console.log(`executing private query "${query}"`);
   if (query === 'getAllTables') {
@@ -11,12 +12,12 @@ async function execPrivate(connection: PostgresConnectionParams, query: any): Pr
 }
 
 async function exec(
-  connection: PostgresConnectionParams,
+  connection: Maybe<PostgresConnectionParams>,
   postgresQuery: PostgresQuery,
 ): Promise<ApiResult<any>> {
   // eslint-disable-next-line no-console
   console.log(
-    `executing "${postgresQuery.text}" with "${postgresQuery.params}" on "${connection.host}"`,
+    `executing "${postgresQuery.text}" with "${postgresQuery.params}" on "${connection?.host}"`,
   );
   return {
     data: [],

--- a/packages/toolpad-app/src/toolpadDataSources/rest/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/server.ts
@@ -3,6 +3,7 @@ import { ServerDataSource, ApiResult } from '../../types';
 import { FetchQuery, RestConnectionParams } from './types';
 import * as bindings from '../../utils/bindings';
 import evalExpression from '../../server/evalExpression';
+import { Maybe } from '../../utils/types';
 
 async function resolveBindableString(
   bindable: BindableAttrValue<string>,
@@ -30,7 +31,7 @@ async function resolveBindableString(
 }
 
 async function exec(
-  connection: RestConnectionParams,
+  connection: Maybe<RestConnectionParams>,
   fetchQuery: FetchQuery,
   params: Record<string, string>,
 ): Promise<ApiResult<any>> {

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -8,7 +8,7 @@ import {
   ComponentConfig,
 } from '@mui/toolpad-core';
 import { PaletteMode } from '@mui/material';
-import type { Branded, WithControlledProp } from './utils/types';
+import type { Branded, Maybe, WithControlledProp } from './utils/types';
 import type { Rectangle } from './utils/geometry';
 
 export interface EditorProps<T> {
@@ -112,9 +112,9 @@ export interface ClientDataSource<P = {}, Q = {}> {
 
 export interface ServerDataSource<P = {}, Q = {}, PQ = {}, D = {}> {
   // Execute a private query on this connection, intended for editors only
-  execPrivate?: (connection: P, query: PQ) => Promise<any>;
+  execPrivate?: (connection: Maybe<P>, query: PQ) => Promise<any>;
   // Execute a query on this connection, intended for viewers
-  exec: (connection: P, query: Q, params: any) => Promise<ApiResult<D>>;
+  exec: (connection: Maybe<P>, query: Q, params: any) => Promise<ApiResult<D>>;
   createHandler?: () => (
     api: CreateHandlerApi<P>,
     req: NextApiRequest,


### PR DESCRIPTION
The datasource can be in charge of deciding wether `null` is valid as a connection. e.g. when it can have defaults, like the rest connection

fixes https://github.com/mui/mui-toolpad/issues/527
