### PR TITLE
Change the prisma initialization sequence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ If you would like to hack on MUI Toolpad or want to run the latest version, you 
 
 ### Notes for contributors:
 
-- Changes that you make to the prisma model will be automatically compiled, but you'll have to push them to the db manually, either by restarting the `yarn dev` command, or by running
+- Changes that you make to the prisma model will be automatically compiled, but you'll have to push them to the db manually:
 
   ```sh
   yarn prisma db push

--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn prisma generate && concurrently \"yarn:build:*\" && rimraf ./.next/cache",
     "start": "yarn waitForDb && yarn prisma migrate deploy && NODE_ENV=production node ./server.js",
-    "dev": "yarn prisma generate && yarn waitForDb && yarn prisma db push --skip-generate && concurrently \"yarn:dev:*\"",
+    "dev": "yarn prisma generate && yarn waitForDb && yarn prisma migrate deploy && concurrently \"yarn:dev:*\"",
     "lint": "next lint && prettier --check .",
     "fix": "next lint --fix && prettier --write .",
     "prisma": "prisma",
@@ -15,7 +15,7 @@
     "dev:next": "node ./server.js",
     "dev:react-devtools": "yarn build:react-devtools --watch",
     "dev:typings": "yarn build:typings",
-    "dev:prisma": "prisma generate --watch",
+    "dev:prisma-client": "prisma generate --watch",
     "waitForDb": "ts-node ./scripts/waitForDb.ts",
     "waitForApp": "ts-node ./scripts/waitForApp.ts"
   },


### PR DESCRIPTION
This called `prisma db push` during startup in development. Changing that so now you have to call it manually when you work on the schema, this makes devs more aware that there is some manual tending to do to the prisma setup