### PR TITLE
Hide privateQuery in a context

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
@@ -36,6 +36,7 @@ import { useEvaluateLiveBindings } from '../useEvaluateLiveBinding';
 import { WithControlledProp } from '../../../utils/types';
 import { useDom, useDomApi } from '../../DomLoader';
 import { mapValues } from '../../../utils/collections';
+import { QueryEditorContextProvider } from '../../../toolpadDataSources/context';
 
 export interface ConnectionSelectProps extends WithControlledProp<NodeId | null> {
   dataSource?: string;
@@ -306,6 +307,8 @@ function QueryNodeEditorDialog<Q, P>({
     throw new Error(`DataSource "${dataSourceId}" not found`);
   }
 
+  const queryEditorContext = React.useMemo(() => ({ appId, connectionId }), [appId, connectionId]);
+
   return (
     <Dialog fullWidth maxWidth="lg" open={open} onClose={handleClose} scroll="body">
       <DialogTitle>Edit Query ({node.id})</DialogTitle>
@@ -322,18 +325,18 @@ function QueryNodeEditorDialog<Q, P>({
 
           <Divider />
           <Typography>Build query:</Typography>
-          <dataSource.QueryEditor
-            appId={appId}
-            connectionId={connectionId}
-            connectionParams={connection?.attributes.params.value}
-            value={{
-              query: input.attributes.query.value,
-              params: input.params,
-            }}
-            liveParams={liveParams}
-            onChange={handleQueryChange}
-            globalScope={pageState}
-          />
+          <QueryEditorContextProvider value={queryEditorContext}>
+            <dataSource.QueryEditor
+              connectionParams={connection?.attributes.params.value}
+              value={{
+                query: input.attributes.query.value,
+                params: input.params,
+              }}
+              liveParams={liveParams}
+              onChange={handleQueryChange}
+              globalScope={pageState}
+            />
+          </QueryEditorContextProvider>
           <Divider />
           <Typography>Options:</Typography>
           <Grid container direction="row" spacing={1}>

--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -303,7 +303,7 @@ export async function loadReleaseDom(appId: string, version: number): Promise<ap
   return JSON.parse(release.snapshot.toString('utf-8')) as appDom.AppDom;
 }
 
-export async function getConnection<P = unknown>(
+async function getConnection<P = unknown>(
   appId: string,
   id: string,
 ): Promise<appDom.ConnectionNode<P>> {

--- a/packages/toolpad-app/src/toolpadDataSources/context.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/context.tsx
@@ -1,0 +1,22 @@
+import { UseQueryResult } from 'react-query';
+import { NodeId } from '../types';
+import { createProvidedContext } from '../utils/react';
+import client from '../api';
+
+export interface QueryEditorContext {
+  appId: string;
+  connectionId: NodeId;
+}
+
+const [useQueryEditorContext, QueryEditorContextProvider] =
+  createProvidedContext<QueryEditorContext>('QueryEditor');
+
+export { useQueryEditorContext, QueryEditorContextProvider };
+
+export function usePrivateQuery<Q = unknown, R = unknown>(query: Q | null): UseQueryResult<R> {
+  const { appId, connectionId } = useQueryEditorContext();
+  return client.useQuery(
+    'dataSourceFetchPrivate',
+    query == null ? null : [appId, connectionId, query],
+  );
+}

--- a/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
@@ -12,7 +12,7 @@ import {
   GoogleDriveFiles,
 } from './types';
 import useDebounced from '../../utils/useDebounced';
-import client from '../../api';
+import { usePrivateQuery } from '../context';
 
 function getInitialQueryValue(): GoogleSheetsApiQuery {
   return { ranges: 'A1:Z10', spreadsheetId: '', sheetName: '', headerRow: false };
@@ -26,8 +26,6 @@ function isConnectionValid(connection: GoogleSheetsConnectionParams | null): boo
 }
 
 function QueryEditor({
-  appId,
-  connectionId,
   value,
   onChange,
 }: QueryEditorProps<GoogleSheetsConnectionParams, GoogleSheetsApiQuery>) {
@@ -35,40 +33,26 @@ function QueryEditor({
 
   const debouncedSpreadsheetQuery = useDebounced(spreadsheetQuery, 300);
 
-  const fetchedFiles: UseQueryResult<GoogleDriveFiles> = client.useQuery('dataSourceFetchPrivate', [
-    appId,
-    connectionId,
-    {
-      type: GoogleSheetsPrivateQueryType.FILES_LIST,
-      spreadsheetQuery: debouncedSpreadsheetQuery,
-    },
-  ]);
+  const fetchedFiles: UseQueryResult<GoogleDriveFiles> = usePrivateQuery({
+    type: GoogleSheetsPrivateQueryType.FILES_LIST,
+    spreadsheetQuery: debouncedSpreadsheetQuery,
+  });
 
-  const fetchedFile: UseQueryResult<GoogleDriveFile> = client.useQuery(
-    'dataSourceFetchPrivate',
+  const fetchedFile: UseQueryResult<GoogleDriveFile> = usePrivateQuery(
     value.query.spreadsheetId
-      ? [
-          appId,
-          connectionId,
-          {
-            type: GoogleSheetsPrivateQueryType.FILE_GET,
-            spreadsheetId: value.query.spreadsheetId,
-          },
-        ]
+      ? {
+          type: GoogleSheetsPrivateQueryType.FILE_GET,
+          spreadsheetId: value.query.spreadsheetId,
+        }
       : null,
   );
 
-  const fetchedSpreadsheet: UseQueryResult<GoogleSpreadsheet> = client.useQuery(
-    'dataSourceFetchPrivate',
+  const fetchedSpreadsheet: UseQueryResult<GoogleSpreadsheet> = usePrivateQuery(
     value.query.spreadsheetId
-      ? [
-          appId,
-          connectionId,
-          {
-            type: GoogleSheetsPrivateQueryType.FETCH_SPREADSHEET,
-            spreadsheetId: value.query.spreadsheetId,
-          },
-        ]
+      ? {
+          type: GoogleSheetsPrivateQueryType.FETCH_SPREADSHEET,
+          spreadsheetId: value.query.spreadsheetId,
+        }
       : null,
   );
 

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -95,14 +95,8 @@ export interface QueryEditorModel<Q> {
 }
 
 export interface QueryEditorProps<P, Q> extends WithControlledProp<QueryEditorModel<Q>> {
-  appId: string;
-  connectionId: NodeId;
   connectionParams: Maybe<P>;
   globalScope: Record<string, any>;
-  /**
-   * @deprecated
-   */
-  queryScope?: Record<string, any>;
   liveParams: Record<string, LiveBinding>;
 }
 


### PR DESCRIPTION
Hide private query calls in a context. The datasource implementation shouldn't need to know about `appId`, `connectionId`.
We're still leaking it for the Oauth callback URL though.