### PR TITLE
Fix shortcut in dialogs

### DIFF
--- a/packages/toolpad-app/src/components/propertyControls/json.tsx
+++ b/packages/toolpad-app/src/components/propertyControls/json.tsx
@@ -77,7 +77,7 @@ function JsonPropEditor({ label, argType, value, onChange, disabled }: EditorPro
     [schemaUri],
   );
 
-  useShortcut({ code: 'KeyS', metaKey: true }, handleSave);
+  useShortcut({ code: 'KeyS', metaKey: true, disabled: !dialogOpen }, handleSave);
 
   return (
     <React.Fragment>

--- a/packages/toolpad-app/src/utils/useShortcut.ts
+++ b/packages/toolpad-app/src/utils/useShortcut.ts
@@ -3,10 +3,18 @@ import * as React from 'react';
 export interface ShortCut {
   code: string;
   metaKey?: boolean;
+  disabled?: boolean;
 }
 
-export default function useShortcut({ code, metaKey = false }: ShortCut, handler: () => void) {
+export default function useShortcut(
+  { code, metaKey = false, disabled = false }: ShortCut,
+  handler: () => void,
+) {
   React.useEffect(() => {
+    if (disabled) {
+      return () => {};
+    }
+
     const handleKeydown = (event: KeyboardEvent) => {
       if (event.code === code && event.metaKey === metaKey) {
         handler();
@@ -16,5 +24,5 @@ export default function useShortcut({ code, metaKey = false }: ShortCut, handler
 
     document.addEventListener('keydown', handleKeydown);
     return () => document.removeEventListener('keydown', handleKeydown);
-  }, [code, metaKey, handler]);
+  }, [code, metaKey, handler, disabled]);
 }


### PR DESCRIPTION
Cmd+S from another part of the UI was interferring with the binding editor

* Add Cmd+S to binding editor
* Disable shortcut when dialogs are closed

Fixes https://github.com/mui/mui-toolpad/issues/547