### PR TITLE
Some fixes on the release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,12 @@
     "yarn-deduplicate": "^4.0.0"
   },
   "dependencies": {
+    "chalk": "^5.0.1",
     "cross-env": "^7.0.3",
     "dotenv-cli": "^5.1.0",
     "inquirer": "^8.2.4",
     "jest-environment-jsdom": "^28.0.0-alpha.8",
+    "semver": "^7.3.7",
     "yargs": "^17.5.1"
   }
 }

--- a/scripts/releaseDocker.js
+++ b/scripts/releaseDocker.js
@@ -99,20 +99,23 @@ async function main({ yes, force, commit, releaseTag, 'no-latest': noLatest, ...
   }
 
   if (!yes) {
+    const baseImage = `${IMAGE_NAME}:${commit}`;
     const imagesToBePublished = tags.map((tag) => `${IMAGE_NAME}:${tag}`);
+    const message = [
+      `Docker image ${chalk.blue(baseImage)} will be published as:`,
+      ...imagesToBePublished.map((image) => `    - ${chalk.blue(image)}`),
+      `  Does this look right?`,
+    ].join('\n');
+
     const answers = await inquirer.prompt([
       {
-        name: 'confirmed',
-        message: `Docker image ${chalk.blue(
-          `${IMAGE_NAME}:${commit}`,
-        )} will be published as \n${imagesToBePublished
-          .map((image) => `    - ${chalk.blue(image)}`)
-          .join('\n')}\n  Does this look right?`,
+        name: 'publishConfirmed',
         type: 'confirm',
+        message,
       },
     ]);
 
-    if (!answers.confirmed) {
+    if (!answers.publishConfirmed) {
       // eslint-disable-next-line no-console
       console.log(`Canceled`);
       return;

--- a/scripts/releaseDocker.js
+++ b/scripts/releaseDocker.js
@@ -53,7 +53,7 @@ async function showFile(commit, file) {
   return stdout;
 }
 
-async function main({ yes, force, commit, releaseTag }) {
+async function main({ yes, force, commit, releaseTag, 'no-latest': noLatest, ...rest }) {
   const { default: chalk } = await import('chalk');
 
   if (!commit) {
@@ -94,7 +94,7 @@ async function main({ yes, force, commit, releaseTag }) {
 
   const tags = [releaseTag];
 
-  if (!isPrerelease) {
+  if (!noLatest && !isPrerelease) {
     tags.push(LATEST_TAG);
   }
 
@@ -106,8 +106,8 @@ async function main({ yes, force, commit, releaseTag }) {
         message: `Docker image ${chalk.blue(
           `${IMAGE_NAME}:${commit}`,
         )} will be published as \n${imagesToBePublished
-          .map((image) => `  - ${chalk.blue(image)}`)
-          .join('\n')}`,
+          .map((image) => `    - ${chalk.blue(image)}`)
+          .join('\n')}\n  Does this look right?`,
         type: 'confirm',
       },
     ]);
@@ -145,6 +145,11 @@ yargs
         })
         .option('force', {
           describe: 'Create tag, even if it already exists',
+          type: 'boolean',
+          default: false,
+        })
+        .option('no-latest', {
+          describe: 'Don\'t create the "latest" tag.',
           type: 'boolean',
           default: false,
         });

--- a/scripts/releaseDocker.js
+++ b/scripts/releaseDocker.js
@@ -57,16 +57,18 @@ async function main({ yes, force, commit, releaseTag, 'no-latest': noLatest, ...
   const { default: chalk } = await import('chalk');
 
   if (!commit) {
-    const log = await commitLog();
     const answers = await inquirer.prompt([
       {
         name: 'commit',
         message: 'Which commit contains the release?',
         type: 'list',
-        choices: log.map((entry) => ({
-          value: entry.commit,
-          name: `${chalk.blue(entry.commit)} ${entry.subject}`,
-        })),
+        async choices() {
+          const log = await commitLog();
+          return log.map((entry) => ({
+            value: entry.commit,
+            name: `${chalk.blue(entry.commit)} ${entry.subject}`,
+          }));
+        },
         pageSize: 20,
       },
     ]);
@@ -75,14 +77,15 @@ async function main({ yes, force, commit, releaseTag, 'no-latest': noLatest, ...
   }
 
   if (!releaseTag) {
-    const lernaJson = JSON.parse(await showFile(commit, 'lerna.json'));
-
     const answers = await inquirer.prompt([
       {
         name: 'releaseTag',
         message: 'Which tag will this be release under?',
         type: 'input',
-        default: lernaJson.version,
+        async default() {
+          const lernaJson = JSON.parse(await showFile(commit, 'lerna.json'));
+          return lernaJson.version;
+        },
       },
     ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,6 +3095,11 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
+  integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"


### PR DESCRIPTION
- automatically infer whether it's a prerelease from the semver version tag
- use correct latest tag `latest` instead of `latest-test`
- list images to be published when asking for confirmation
- add option `--no-latest` to not release with `latest`
