### PR TITLE
Delete confirmation dialog Doesn't need to be a form

### DIFF
--- a/packages/toolpad-app/src/components/Home.tsx
+++ b/packages/toolpad-app/src/components/Home.tsx
@@ -93,25 +93,22 @@ function AppDeleteDialog({ app, onClose }: AppDeleteDialogProps) {
 
   return (
     <Dialog open={!!app} onClose={onClose}>
-      <DialogForm>
-        <DialogTitle>Confirm delete</DialogTitle>
-        <DialogContent>
-          Are you sure you want to delete application &quot;{latestApp?.name}&quot;
-        </DialogContent>
-        <DialogActions>
-          <Button color="inherit" variant="text" onClick={onClose}>
-            Cancel
-          </Button>
-          <LoadingButton
-            type="submit"
-            loading={deleteAppMutation.isLoading}
-            onClick={handleDeleteClick}
-            color="error"
-          >
-            Delete
-          </LoadingButton>
-        </DialogActions>
-      </DialogForm>
+      <DialogTitle>Confirm delete</DialogTitle>
+      <DialogContent>
+        Are you sure you want to delete application &quot;{latestApp?.name}&quot;
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" variant="text" onClick={onClose}>
+          Cancel
+        </Button>
+        <LoadingButton
+          loading={deleteAppMutation.isLoading}
+          onClick={handleDeleteClick}
+          color="error"
+        >
+          Delete
+        </LoadingButton>
+      </DialogActions>
     </Dialog>
   );
 }


### PR DESCRIPTION
I think this was copy+pasted from another dialog. Not sure why Chrome doesn't submit the form.

Addressing part of https://github.com/mui/mui-toolpad/issues/573