### PR TITLE
Fixing app rename on "Enter" press

### DIFF
--- a/packages/toolpad-app/src/components/Home.tsx
+++ b/packages/toolpad-app/src/components/Home.tsx
@@ -215,9 +215,10 @@ function AppCard({ app, onDelete }: AppCardProps) {
       }
       if (event.key === 'Enter') {
         setEditingTitle(false);
+        handleAppRename((event.target as HTMLInputElement).value);
       }
     },
-    [app?.name],
+    [app?.name, handleAppRename],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Setting `editingTItle` to `false` does not automatically blur the input

- Fixes part of #573  

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
