### PR TITLE
Add Tooltip explaining that an app must be deployed before accessing it

### DIFF
--- a/packages/toolpad-app/src/components/Home.tsx
+++ b/packages/toolpad-app/src/components/Home.tsx
@@ -18,6 +18,7 @@ import {
   Toolbar,
   Typography,
   Box,
+  Tooltip,
 } from '@mui/material';
 import * as React from 'react';
 import { LoadingButton } from '@mui/lab';
@@ -228,6 +229,26 @@ function AppCard({ app, activeDeployment, onDelete }: AppCardProps) {
     }
   }, [appTitleInput, editingTitle]);
 
+  const openDisabled = !app || !activeDeployment;
+  let openButton = (
+    <Button
+      disabled={!app || !activeDeployment}
+      size="small"
+      component="a"
+      href={app ? `deploy/${app.id}` : ''}
+    >
+      Open
+    </Button>
+  );
+
+  if (openDisabled) {
+    openButton = (
+      <Tooltip title="The app hasn't been deployed yet">
+        <span>{openButton}</span>
+      </Tooltip>
+    );
+  }
+
   return (
     <React.Fragment>
       <Card sx={{ gridColumn: 'span 1' }}>
@@ -278,14 +299,7 @@ function AppCard({ app, activeDeployment, onDelete }: AppCardProps) {
           >
             Edit
           </Button>
-          <Button
-            disabled={!app || !activeDeployment}
-            size="small"
-            component="a"
-            href={app ? `deploy/${app.id}` : ''}
-          >
-            View
-          </Button>
+          {openButton}
         </CardActions>
       </Card>
       <Menu


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
