### PR TITLE
Extract reusable code editor for TS modules

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/CodeComponentEditor/index.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { Box, Button, Stack, styled, Toolbar, Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
-import Editor from '@monaco-editor/react';
-import type * as monacoEditor from 'monaco-editor';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import ReactDOM from 'react-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 import { NodeId, createComponent, ToolpadComponent, TOOLPAD_COMPONENT } from '@mui/toolpad-core';
+import { useQuery } from 'react-query';
 import * as appDom from '../../../appDom';
 import { useDom, useDomApi } from '../../DomLoader';
 import { tryFormat } from '../../../utils/prettier';
@@ -20,6 +19,7 @@ import AppThemeProvider from '../../../runtime/AppThemeProvider';
 import useCodeComponent from './useCodeComponent';
 import { mapValues } from '../../../utils/collections';
 import ErrorAlert from '../PageEditor/ErrorAlert';
+import TsModuleEditor from '../../TsModuleEditor';
 
 const Noop = createComponent(() => null);
 
@@ -59,50 +59,44 @@ interface CodeComponentEditorContentProps {
 function CodeComponentEditorContent({ theme, codeComponentNode }: CodeComponentEditorContentProps) {
   const domApi = useDomApi();
 
+  const { data: typings } = useQuery<Record<string, string>>('/typings.json', async () => {
+    return fetch('/typings.json').then((res) => res.json());
+  });
+
+  const extraLibs = React.useMemo(() => {
+    return [
+      ...(typings
+        ? Object.entries(typings).map(([path, content]) => ({
+            content,
+            filePath: `file:///${path}`,
+          }))
+        : []),
+      {
+        content: `declare module "https://*";`,
+      },
+    ];
+  }, [typings]);
+
   const [input, setInput] = React.useState<string>(codeComponentNode.attributes.code.value);
+  React.useEffect(
+    () => setInput(codeComponentNode.attributes.code.value),
+    [codeComponentNode.attributes.code.value],
+  );
 
   const frameRef = React.useRef<HTMLIFrameElement>(null);
 
-  const editorRef = React.useRef<monacoEditor.editor.IStandaloneCodeEditor>();
-
   usePageTitle(`${codeComponentNode.name} | Toolpad editor`);
-
-  const updateInputExtern = React.useCallback((newInput: string) => {
-    const editor = editorRef.current;
-    if (!editor) {
-      return;
-    }
-
-    const model = editor.getModel();
-    if (!model) {
-      return;
-    }
-
-    // Used to restore cursor position
-    const state = editorRef.current?.saveViewState();
-
-    editor.executeEdits(null, [
-      {
-        range: model.getFullModelRange(),
-        text: newInput,
-      },
-    ]);
-
-    if (state) {
-      editorRef.current?.restoreViewState(state);
-    }
-  }, []);
 
   const handleSave = React.useCallback(() => {
     const pretty = tryFormat(input);
-    updateInputExtern(pretty);
+    setInput(pretty);
     domApi.setNodeNamespacedProp(
       codeComponentNode,
       'attributes',
       'code',
       appDom.createConst(pretty),
     );
-  }, [codeComponentNode, domApi, input, updateInputExtern]);
+  }, [codeComponentNode, domApi, input]);
 
   const allChangesAreCommitted = codeComponentNode.attributes.code.value === input;
 
@@ -112,52 +106,6 @@ function CodeComponentEditorContent({ theme, codeComponentNode }: CodeComponentE
   );
 
   useShortcut({ code: 'KeyS', metaKey: true }, handleSave);
-
-  const HandleEditorMount = React.useCallback(
-    (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: typeof monacoEditor) => {
-      editorRef.current = editor;
-
-      editor.updateOptions({
-        minimap: { enabled: false },
-        accessibilitySupport: 'off',
-      });
-
-      monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-        target: monaco.languages.typescript.ScriptTarget.Latest,
-        allowNonTsExtensions: true,
-        moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
-        module: monaco.languages.typescript.ModuleKind.CommonJS,
-        noEmit: true,
-        esModuleInterop: true,
-        jsx: monaco.languages.typescript.JsxEmit.React,
-        reactNamespace: 'React',
-        allowJs: true,
-        typeRoots: ['node_modules/@types'],
-      });
-
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(`declare module "https://*";`);
-
-      monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
-        noSemanticValidation: false,
-        noSyntaxValidation: false,
-      });
-
-      fetch('/typings.json')
-        .then((res) => res.json())
-        .then((typings) => {
-          Array.from(Object.entries(typings)).forEach(([path, content]) => {
-            monaco.languages.typescript.typescriptDefaults.addExtraLib(
-              content as string,
-              `file:///${path}`,
-            );
-          });
-        })
-        .catch((err) =>
-          console.error(`Failed to initialize typescript types on editor: ${err.message}`),
-        );
-    },
-    [],
-  );
 
   const [iframeLoaded, onLoad] = React.useReducer(() => true, false);
 
@@ -200,13 +148,11 @@ function CodeComponentEditorContent({ theme, codeComponentNode }: CodeComponentE
         </Toolbar>
         <Box flex={1} display="flex">
           <Box flex={1}>
-            <Editor
-              height="100%"
-              defaultValue={input}
+            <TsModuleEditor
+              path={`./codeComponents/${codeComponentNode.id}.tsx`}
+              value={input}
               onChange={(newValue) => setInput(newValue || '')}
-              path="./component.tsx"
-              language="typescript"
-              onMount={HandleEditorMount}
+              extraLibs={extraLibs}
             />
           </Box>
           <Box sx={{ flex: 1, position: 'relative' }}>

--- a/packages/toolpad-app/src/components/TsModuleEditor.tsx
+++ b/packages/toolpad-app/src/components/TsModuleEditor.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import Editor from '@monaco-editor/react';
+import type * as monacoEditor from 'monaco-editor';
+import { WithControlledProp } from '../utils/types';
+
+interface TsModuleEditorProps extends WithControlledProp<string> {
+  path: string;
+  extraLibs?: { content: string; filePath?: string }[];
+}
+
+export default function TsModuleEditor({ path, extraLibs, value, onChange }: TsModuleEditorProps) {
+  const editorRef = React.useRef<monacoEditor.editor.IStandaloneCodeEditor>();
+  const monacoRef = React.useRef<typeof monacoEditor>();
+
+  // @monaco-editor/react treats HandleEditorMount as stable. It will call the value that it
+  // received on first render. Let's use this ref to store the actual value of extraLibs.
+  const extraLibsRef = React.useRef(extraLibs || []);
+
+  const HandleEditorMount = React.useCallback(
+    (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: typeof monacoEditor) => {
+      editorRef.current = editor;
+      monacoRef.current = monaco;
+
+      editor.updateOptions({
+        minimap: { enabled: false },
+        accessibilitySupport: 'off',
+      });
+
+      monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+        target: monaco.languages.typescript.ScriptTarget.Latest,
+        allowNonTsExtensions: true,
+        moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+        module: monaco.languages.typescript.ModuleKind.CommonJS,
+        noEmit: true,
+        esModuleInterop: true,
+        jsx: monaco.languages.typescript.JsxEmit.React,
+        reactNamespace: 'React',
+        allowJs: true,
+        typeRoots: ['node_modules/@types'],
+      });
+
+      monacoRef.current?.languages.typescript.typescriptDefaults.setExtraLibs(extraLibsRef.current);
+
+      monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+        noSemanticValidation: false,
+        noSyntaxValidation: false,
+      });
+    },
+    [
+      // Don't add dependencies, @monaco-editor/react only uses the first occurence of this function it sees.
+    ],
+  );
+
+  React.useEffect(() => {
+    extraLibsRef.current = extraLibs || [];
+    monacoRef.current?.languages.typescript.typescriptDefaults.setExtraLibs(extraLibsRef.current);
+  }, [extraLibs]);
+
+  React.useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+
+    const model = editor.getModel();
+    if (!model) {
+      return;
+    }
+
+    const actualValue = model.getValue();
+
+    if (value === actualValue) {
+      return;
+    }
+
+    // Used to restore cursor position
+    const state = editorRef.current?.saveViewState();
+
+    editor.executeEdits(null, [
+      {
+        range: model.getFullModelRange(),
+        text: value,
+      },
+    ]);
+
+    if (state) {
+      editorRef.current?.restoreViewState(state);
+    }
+  }, [value]);
+
+  const handleChange = React.useCallback((newValue: string = '') => onChange(newValue), [onChange]);
+
+  return (
+    <Editor
+      height="100%"
+      defaultValue={value}
+      onChange={handleChange}
+      path={path}
+      language="typescript"
+      onMount={HandleEditorMount}
+    />
+  );
+}


### PR DESCRIPTION
In preparation of https://github.com/mui/mui-toolpad/issues/314

Extracting the code editor so it can be reused by the page module