### PR TITLE
Make sure the component properties panel overflows correctly

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentPanel.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/ComponentPanel.tsx
@@ -12,6 +12,7 @@ const classes = {
 const ComponentPanelRoot = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
+  height: '100%',
   [`& .${classes.panel}`]: {
     flex: 1,
     padding: theme.spacing(2),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
