### PR TITLE
Remove unnecessary type=submit from buttons

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/HierarchyExplorer/index.tsx
@@ -293,17 +293,10 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
           Delete {latestDeletedNode?.type} &quot;{latestDeletedNode?.name}&quot;?
         </DialogTitle>
         <DialogActions>
-          <Button
-            type="submit"
-            color="inherit"
-            variant="text"
-            onClick={handledeleteNodeDialogClose}
-          >
+          <Button color="inherit" variant="text" onClick={handledeleteNodeDialogClose}>
             Cancel
           </Button>
-          <Button type="submit" onClick={handleDeleteNode}>
-            Delete
-          </Button>
+          <Button onClick={handleDeleteNode}>Delete</Button>
         </DialogActions>
       </Dialog>
     </HierarchyExplorerRoot>


### PR DESCRIPTION
Similar problem as https://github.com/mui/mui-toolpad/pull/579. These buttons shouldn't have type "submit"