### PR TITLE
Add instructions on configuring a different port in dev mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
           command: |
             # See https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command
             TAG=$CIRCLE_SHA1 docker-compose -f ./docker/compose/docker-compose.yml up -d
-            yarn workspace @mui/toolpad-app waitForApp
+            yarn workspace @mui/toolpad-app waitForApp --url=http://172.17.0.1:3000/
             docker run -it --rm \
               --ipc=host \
               -v "$CIRCLE_WORKING_DIRECTORY:/tests" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,9 @@ If you would like to hack on MUI Toolpad or want to run the latest version, you 
 
    ```sh
    TOOLPAD_DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
+   # For a custom port:
+   # PORT=3004
+   # EXTERNAL_URL=http://localhost:3004/
    ```
 
 1. Now you can run the MUI Toolpad dev command to start the application

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: muicom/toolpad:${TAG:-latest}
     environment:
       - TOOLPAD_DATABASE_URL=postgresql://toolpad-app:secretpw@postgres:5432/postgres?connect_timeout=10
+      - PORT=3000
+      - EXTERNAL_URL=http://localhost:3000/
     ports:
       - '3000:3000'
 


### PR DESCRIPTION
Least invasive way of setting up port 3004 in dev but still requires manual action. i.e. 3000 is the default but gets overwritten in dev. We can go further than this, depending on team preference