### PR TITLE
Fix the list in setup docs

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,15 +18,15 @@ Make sure you have the following tools installed:
 
 1.  Download the docker compose file
 
-```sh
-curl -LO https://raw.githubusercontent.com/mui/mui-toolpad/master/docker/compose/docker-compose.yml
-```
+    ```sh
+    curl -LO https://raw.githubusercontent.com/mui/mui-toolpad/master/docker/compose/docker-compose.yml
+    ```
 
-1. Start the docker compose services
+1.  Start the docker compose services
 
-```sh
-docker-compose -f docker/compose/docker-compose.yml up -d
-```
+    ```sh
+    docker-compose -f docker/compose/docker-compose.yml up -d
+    ```
 
 MUI Toolpad will be accessible under `http://localhost:3000/`.
 

--- a/packages/toolpad-app/src/components/ToolpadShell.tsx
+++ b/packages/toolpad-app/src/components/ToolpadShell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { styled, AppBar, Toolbar, IconButton, Typography, Box } from '@mui/material';
-import MenuIcon from '@mui/icons-material/Menu';
+import HomeIcon from '@mui/icons-material/Home';
 
 export interface ToolpadShellProps {
   navigation?: React.ReactNode;
@@ -44,7 +44,7 @@ function Header({ actions, navigation }: HeaderProps) {
           component="a"
           href={`/`}
         >
-          <MenuIcon fontSize="medium" />
+          <HomeIcon fontSize="medium" />
         </IconButton>
         <Typography
           data-test-id="brand"


### PR DESCRIPTION
Make sure the codeblocks are indented under the list items so they don't break it up