### PR TITLE
Extract canvas logic in top level layout

### DIFF
--- a/packages/toolpad-app/pages/app-canvas/[[...path]].tsx
+++ b/packages/toolpad-app/pages/app-canvas/[[...path]].tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next';
 import * as React from 'react';
-import AppCanvas, { AppCanvasProps } from '../../src/runtime/AppCanvas';
+import AppCanvas, { AppCanvasProps } from '../../src/canvas';
 
 const App: NextPage<AppCanvasProps> = () => <AppCanvas basename="/app-canvas" />;
 export default App;

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { fireEvent } from '@mui/toolpad-core/runtime';
-import ToolpadApp, { EditorHooks, EditorHooksContext } from '../ToolpadApp';
-import * as appDom from '../../appDom';
+import ToolpadApp, { CanvasHooks, CanvasHooksContext } from '../runtime';
+import * as appDom from '../appDom';
 
 export interface AppCanvasState {
   appId: string;
@@ -54,7 +54,7 @@ export default function AppCanvas({ basename }: AppCanvasProps) {
     fireEvent({ type: 'afterRender' });
   });
 
-  const editorHooks: EditorHooks = React.useMemo(() => {
+  const editorHooks: CanvasHooks = React.useMemo(() => {
     return {
       navigateToPage(pageNodeId) {
         fireEvent({ type: 'pageNavigationRequest', pageNodeId });
@@ -63,7 +63,7 @@ export default function AppCanvas({ basename }: AppCanvasProps) {
   }, []);
 
   return state ? (
-    <EditorHooksContext.Provider value={editorHooks}>
+    <CanvasHooksContext.Provider value={editorHooks}>
       <ToolpadApp
         hidePreviewBanner
         dom={state.dom}
@@ -71,7 +71,7 @@ export default function AppCanvas({ basename }: AppCanvasProps) {
         appId={state.appId}
         basename={`${basename}/${state.appId}`}
       />
-    </EditorHooksContext.Provider>
+    </CanvasHooksContext.Provider>
   ) : (
     <div>loading...</div>
   );

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -59,11 +59,14 @@ export interface NavigateToPage {
   (pageNodeId: NodeId): void;
 }
 
-export interface EditorHooks {
+/**
+ * Context created by the app canvas to override behavior for the app editor
+ */
+export interface CanvasHooks {
   navigateToPage?: NavigateToPage;
 }
 
-export const EditorHooksContext = React.createContext<EditorHooks>({});
+export const CanvasHooksContext = React.createContext<CanvasHooks>({});
 
 function usePageNavigator(): NavigateToPage {
   const navigate = useNavigate();
@@ -74,8 +77,8 @@ function usePageNavigator(): NavigateToPage {
     [navigate],
   );
 
-  const editorHooks = React.useContext(EditorHooksContext);
-  return editorHooks.navigateToPage || navigateToPage;
+  const canvasHooks = React.useContext(CanvasHooksContext);
+  return canvasHooks.navigateToPage || navigateToPage;
 }
 
 const AppRoot = styled('div')({

--- a/packages/toolpad-app/src/runtime/index.ts
+++ b/packages/toolpad-app/src/runtime/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ToolpadApp';
+export * from './ToolpadApp';


### PR DESCRIPTION
The components folder is starting to become unwieldy, so far we've treated the "application editor" as just another component. It's not meant for reuse. I'm proposing to extract this into its own top level folder, which can be more seen as entry-points into the application
Aiming towards a better top-level project layout. I propose:

* `./server`: all server only code (OK)
* `./runtime`: toolpad application runtime (OK)
* `./canvas`: application runtime with overrides, used inside the editor (this PR)
* `./toolpad`: Editor application (currently interleaved with ./components)
* `./components`: shared components (currently contains Toolpad editor as well)
* `./utils`: shared generic utility functions, do not put toolpad specific functionality in here (OK)
* `./toolpadDatasources`: available datasources, will rename to `./toolpad`
* `./`: toolpad specific libraries, we will let this folder grow until it becomes unwieldy and needs organization
