### PR TITLE
Rework query editor layout

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/JsExpressionEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/JsExpressionEditor.tsx
@@ -11,8 +11,7 @@ const TypescriptEditor = lazyComponent(() => import('../../TypescriptEditor'), {
 
 const JsExpressionEditorRoot = styled('div')(({ theme }) => ({
   height: 150,
-  border: '1px solid black',
-  borderColor: theme.palette.divider,
+  border: `1px solid ${theme.palette.divider}`,
 }));
 
 export interface JsExpressionEditorProps extends WithControlledProp<string> {

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
@@ -17,6 +17,7 @@ import {
   MenuItem,
   SxProps,
   Alert,
+  Box,
 } from '@mui/material';
 import * as React from 'react';
 import AddIcon from '@mui/icons-material/Add';
@@ -316,68 +317,89 @@ function QueryNodeEditorDialog<Q, P>({
   const queryEditorContext = React.useMemo(() => ({ appId, connectionId }), [appId, connectionId]);
 
   return (
-    <Dialog fullWidth maxWidth="xl" open={open} onClose={handleClose} scroll="body">
+    <Dialog fullWidth maxWidth="xl" open={open} onClose={handleClose}>
+      <DialogTitle>
+        <Stack direction="row" gap={2}>
+          <NodeNameEditor node={node} />
+          <ConnectionSelect
+            dataSource={dataSourceId}
+            value={input.attributes.connectionId.value || null}
+            onChange={handleConnectionChange}
+          />
+        </Stack>
+      </DialogTitle>
+      <Divider />
       {dataSourceId && dataSource ? (
-        <DialogContent>
-          <Stack spacing={2} py={1}>
-            <Stack direction="row" gap={2}>
-              <NodeNameEditor node={node} />
-              <ConnectionSelect
-                dataSource={dataSourceId}
-                value={input.attributes.connectionId.value || null}
-                onChange={handleConnectionChange}
-              />
+        <DialogContent sx={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', p: 0 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'row', minHeight: 0 }}>
+            <Stack
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                overflow: 'auto',
+                gap: 2,
+                px: 3,
+                py: 1,
+              }}
+            >
+              <ConnectionContextProvider value={queryEditorContext}>
+                <dataSource.QueryEditor
+                  connectionParams={connection?.attributes.params.value}
+                  value={{
+                    query: input.attributes.query.value,
+                    params: input.params,
+                  }}
+                  liveParams={liveParams}
+                  onChange={handleQueryChange}
+                  globalScope={pageState}
+                />
+              </ConnectionContextProvider>
+
+              <Grid container direction="row" spacing={1}>
+                {/* TODO: move transform inside of the dataSource.QueryEditor and remove the conditional */}
+                {dataSourceId === 'function' ? null : (
+                  <React.Fragment>
+                    <Divider />
+                    <Grid item xs={6}>
+                      <Stack>
+                        <FormControlLabel
+                          label="Transform response"
+                          control={
+                            <Checkbox
+                              checked={input.attributes.transformEnabled?.value ?? false}
+                              onChange={handleTransformEnabledChange}
+                              inputProps={{ 'aria-label': 'controlled' }}
+                            />
+                          }
+                        />
+
+                        <JsExpressionEditor
+                          globalScope={{}}
+                          value={
+                            input.attributes.transform?.value ?? '(data) => {\n  return data;\n}'
+                          }
+                          onChange={handleTransformFnChange}
+                          disabled={!input.attributes.transformEnabled?.value}
+                        />
+                      </Stack>
+                    </Grid>
+                  </React.Fragment>
+                )}
+              </Grid>
             </Stack>
-
-            <Divider />
-            <ConnectionContextProvider value={queryEditorContext}>
-              <dataSource.QueryEditor
-                connectionParams={connection?.attributes.params.value}
-                value={{
-                  query: input.attributes.query.value,
-                  params: input.params,
-                }}
-                liveParams={liveParams}
-                onChange={handleQueryChange}
-                globalScope={pageState}
-              />
-            </ConnectionContextProvider>
-            <Grid container direction="row" spacing={1}>
-              {/* TODO: move transform inside of the dataSource.QueryEditor and remove the conditional */}
-              {dataSourceId === 'function' ? null : (
-                <React.Fragment>
-                  <Divider />
-                  <Grid item xs={6}>
-                    <Stack>
-                      <FormControlLabel
-                        label="Transform response"
-                        control={
-                          <Checkbox
-                            checked={input.attributes.transformEnabled?.value ?? false}
-                            onChange={handleTransformEnabledChange}
-                            inputProps={{ 'aria-label': 'controlled' }}
-                          />
-                        }
-                      />
-
-                      <JsExpressionEditor
-                        globalScope={{}}
-                        value={
-                          input.attributes.transform?.value ?? '(data) => {\n  return data;\n}'
-                        }
-                        onChange={handleTransformFnChange}
-                        disabled={!input.attributes.transformEnabled?.value}
-                      />
-                    </Stack>
-                  </Grid>
-                </React.Fragment>
-              )}
-            </Grid>
             {/* TODO: move preview inside of the dataSource.QueryEditor and remove the conditional */}
             {dataSourceId === 'function' ? null : (
-              <React.Fragment>
-                <Divider />
-                <Toolbar disableGutters>
+              <Box
+                sx={{
+                  flex: 1,
+                  minWidth: 0,
+                  borderLeft: 1,
+                  borderColor: 'divider',
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <Toolbar>
                   <LoadingButton
                     size="medium"
                     disabled={previewParams === paramsObject && previewQuery === input}
@@ -390,42 +412,43 @@ function QueryNodeEditorDialog<Q, P>({
                     Preview
                   </LoadingButton>
                 </Toolbar>
-                {queryPreview.error ? <ErrorAlert error={queryPreview.error} /> : null}
-                {queryPreview.isSuccess ? <JsonView src={queryPreview.data} /> : null}
-              </React.Fragment>
+                <Box sx={{ flex: 1, minHeight: 0, px: 3, py: 1, overflow: 'auto' }}>
+                  {queryPreview.error ? <ErrorAlert error={queryPreview.error} /> : null}
+                  {queryPreview.isSuccess ? <JsonView src={queryPreview.data} /> : null}
+                </Box>
+              </Box>
             )}
-
-            <Divider />
-            <Stack direction="row" gap={1} alignItems="center">
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={input.attributes.refetchOnWindowFocus?.value ?? true}
-                    onChange={handleRefetchOnWindowFocusChange}
-                  />
-                }
-                label="Refetch on window focus"
-              />
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={input.attributes.refetchOnReconnect?.value ?? true}
-                    onChange={handleRefetchOnReconnectChange}
-                  />
-                }
-                label="Refetch on network reconnect"
-              />
-              <TextField
-                InputProps={{
-                  startAdornment: <InputAdornment position="start">s</InputAdornment>,
-                }}
-                sx={{ maxWidth: 300 }}
-                type="number"
-                label="Refetch interval"
-                value={refetchIntervalInSeconds(input.attributes.refetchInterval?.value) ?? ''}
-                onChange={handleRefetchIntervalChange}
-              />
-            </Stack>
+          </Box>
+          <Divider />
+          <Stack direction="row" alignItems="center" sx={{ pt: 2, px: 3, gap: 2 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={input.attributes.refetchOnWindowFocus?.value ?? true}
+                  onChange={handleRefetchOnWindowFocusChange}
+                />
+              }
+              label="Refetch on window focus"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={input.attributes.refetchOnReconnect?.value ?? true}
+                  onChange={handleRefetchOnReconnectChange}
+                />
+              }
+              label="Refetch on network reconnect"
+            />
+            <TextField
+              InputProps={{
+                startAdornment: <InputAdornment position="start">s</InputAdornment>,
+              }}
+              sx={{ maxWidth: 300 }}
+              type="number"
+              label="Refetch interval"
+              value={refetchIntervalInSeconds(input.attributes.refetchInterval?.value) ?? ''}
+              onChange={handleRefetchIntervalChange}
+            />
           </Stack>
         </DialogContent>
       ) : (

--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
@@ -345,7 +345,7 @@ function QueryNodeEditorDialog<Q, P>({
             <Grid container direction="row" spacing={1}>
               {/* TODO: move transform inside of the dataSource.QueryEditor and remove the conditional */}
               {dataSourceId === 'function' ? null : (
-                <>
+                <React.Fragment>
                   <Divider />
                   <Grid item xs={6}>
                     <Stack>
@@ -370,12 +370,12 @@ function QueryNodeEditorDialog<Q, P>({
                       />
                     </Stack>
                   </Grid>
-                </>
+                </React.Fragment>
               )}
             </Grid>
             {/* TODO: move preview inside of the dataSource.QueryEditor and remove the conditional */}
             {dataSourceId === 'function' ? null : (
-              <>
+              <React.Fragment>
                 <Divider />
                 <Toolbar disableGutters>
                   <LoadingButton
@@ -392,7 +392,7 @@ function QueryNodeEditorDialog<Q, P>({
                 </Toolbar>
                 {queryPreview.error ? <ErrorAlert error={queryPreview.error} /> : null}
                 {queryPreview.isSuccess ? <JsonView src={queryPreview.data} /> : null}
-              </>
+              </React.Fragment>
             )}
 
             <Divider />


### PR DESCRIPTION
Moving things around in anticipation of giving more control of rendering to the individual datasources.

* Remove title and use name box + connection selector as title
* maintain the dialog height to the same height as the screen
* move client side fetch options to the bottom
* two pane layout inside with query editor left and previewer on the right

<img width="1383" alt="Screenshot 2022-07-13 at 12 49 01" src="https://user-images.githubusercontent.com/2109932/178717016-9352c5e5-4bdd-4dc9-b893-31a4c0facf06.png">

