### PR TITLE
Move control of spacing into the datasource QueryEditor

### DIFF
--- a/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/components/AppEditor/PageEditor/QueryEditor.tsx
@@ -337,9 +337,6 @@ function QueryNodeEditorDialog<Q, P>({
                 flex: 1,
                 minWidth: 0,
                 overflow: 'auto',
-                gap: 2,
-                px: 3,
-                py: 1,
               }}
             >
               <ConnectionContextProvider value={queryEditorContext}>
@@ -355,9 +352,9 @@ function QueryNodeEditorDialog<Q, P>({
                 />
               </ConnectionContextProvider>
 
-              <Grid container direction="row" spacing={1}>
-                {/* TODO: move transform inside of the dataSource.QueryEditor and remove the conditional */}
-                {dataSourceId === 'function' ? null : (
+              {/* TODO: move transform inside of the dataSource.QueryEditor and remove the conditional */}
+              {dataSourceId === 'function' ? null : (
+                <Grid container direction="row" spacing={1} sx={{ px: 3, pb: 1, mt: 2 }}>
                   <React.Fragment>
                     <Divider />
                     <Grid item xs={6}>
@@ -384,9 +381,10 @@ function QueryNodeEditorDialog<Q, P>({
                       </Stack>
                     </Grid>
                   </React.Fragment>
-                )}
-              </Grid>
+                </Grid>
+              )}
             </Stack>
+
             {/* TODO: move preview inside of the dataSource.QueryEditor and remove the conditional */}
             {dataSourceId === 'function' ? null : (
               <Box

--- a/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
@@ -129,7 +129,7 @@ function QueryEditor({
   );
 
   return (
-    <Stack direction="column" gap={2}>
+    <Stack direction="column" gap={2} sx={{ px: 3, pt: 1 }}>
       <Autocomplete
         fullWidth
         value={fetchedFile.data ?? null}

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -201,7 +201,7 @@ function QueryEditor({
   });
 
   return (
-    <Stack gap={2}>
+    <Stack gap={2} sx={{ px: 3, pt: 1 }}>
       <Typography>Parameters</Typography>
       <ParametersEditor
         value={params}


### PR DESCRIPTION
Extracting this from https://github.com/mui/mui-toolpad/pull/641