### PR TITLE
Fix editable text value overflow

### DIFF
--- a/packages/toolpad-app/src/components/EditableText.tsx
+++ b/packages/toolpad-app/src/components/EditableText.tsx
@@ -22,14 +22,14 @@ const EditableText = React.forwardRef<HTMLInputElement, EditableTextProps>(
         inputRef={ref}
         sx={{ paddingBottom: '4px' }}
         InputProps={{ sx: { fontSize: '1.5rem', height: '1.5em' } }}
-        onKeyUp={onKeyUp ?? (() => { })}
-        onBlur={onBlur ?? (() => { })}
+        onKeyUp={onKeyUp ?? (() => {})}
+        onBlur={onBlur ?? (() => {})}
         defaultValue={defaultValue}
         error={isError}
         helperText={isError ? errorText : ''}
       />
     ) : (
-      <Tooltip title={defaultValue} enterDelay={500}>
+      <Tooltip title={defaultValue || ''} enterDelay={500}>
         <Typography gutterBottom variant={variant ?? 'body1'} component="div" noWrap>
           {loading ? <Skeleton /> : defaultValue}
         </Typography>

--- a/packages/toolpad-app/src/components/EditableText.tsx
+++ b/packages/toolpad-app/src/components/EditableText.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Skeleton, TextField, Typography, TypographyVariant } from '@mui/material';
+import { Skeleton, TextField, Typography, TypographyVariant, Tooltip } from '@mui/material';
 
 interface EditableTextProps {
   defaultValue?: string;
@@ -22,16 +22,18 @@ const EditableText = React.forwardRef<HTMLInputElement, EditableTextProps>(
         inputRef={ref}
         sx={{ paddingBottom: '4px' }}
         InputProps={{ sx: { fontSize: '1.5rem', height: '1.5em' } }}
-        onKeyUp={onKeyUp ?? (() => {})}
-        onBlur={onBlur ?? (() => {})}
+        onKeyUp={onKeyUp ?? (() => { })}
+        onBlur={onBlur ?? (() => { })}
         defaultValue={defaultValue}
         error={isError}
         helperText={isError ? errorText : ''}
       />
     ) : (
-      <Typography gutterBottom variant={variant ?? 'body1'} component="div">
-        {loading ? <Skeleton /> : defaultValue}
-      </Typography>
+      <Tooltip title={defaultValue} enterDelay={500}>
+        <Typography gutterBottom variant={variant ?? 'body1'} component="div" noWrap>
+          {loading ? <Skeleton /> : defaultValue}
+        </Typography>
+      </Tooltip>
     );
   },
 );

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -1,4 +1,4 @@
-import { styled, SxProps, Typography, Skeleton, Box, Divider } from '@mui/material';
+import { styled, SxProps, Typography, Tooltip, Skeleton, Box, Divider } from '@mui/material';
 import * as React from 'react';
 import HierarchyExplorer from './HierarchyExplorer';
 import client from '../../api';
@@ -20,7 +20,11 @@ export default function PagePanel({ appId, className, sx }: ComponentPanelProps)
   return (
     <PagePanelRoot className={className} sx={sx}>
       <Box sx={{ px: 2, py: 1 }}>
-        {isLoading ? <Skeleton variant="text" /> : <Typography>{app?.name}</Typography>}
+        {isLoading ? <Skeleton variant="text" /> : (
+          <Tooltip title={app?.name || ''} enterDelay={500}>
+            <Typography noWrap>{app?.name}</Typography>
+          </Tooltip>
+        )}
       </Box>
       <Divider />
       <HierarchyExplorer appId={appId} />

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -20,7 +20,9 @@ export default function PagePanel({ appId, className, sx }: ComponentPanelProps)
   return (
     <PagePanelRoot className={className} sx={sx}>
       <Box sx={{ px: 2, py: 1 }}>
-        {isLoading ? <Skeleton variant="text" /> : (
+        {isLoading ? (
+          <Skeleton variant="text" />
+        ) : (
           <Tooltip title={app?.name || ''} enterDelay={500}>
             <Typography noWrap>{app?.name}</Typography>
           </Tooltip>

--- a/packages/toolpad-app/src/toolpad/Home.tsx
+++ b/packages/toolpad-app/src/toolpad/Home.tsx
@@ -376,16 +376,16 @@ export default function Home() {
               case 'success':
                 return apps.length > 0
                   ? apps.map((app) => {
-                    const activeDeployment = activeDeploymentsByApp?.[app.id];
-                    return (
-                      <AppCard
-                        key={app.id}
-                        app={app}
-                        activeDeployment={activeDeployment}
-                        onDelete={() => setDeletedApp(app)}
-                      />
-                    );
-                  })
+                      const activeDeployment = activeDeploymentsByApp?.[app.id];
+                      return (
+                        <AppCard
+                          key={app.id}
+                          app={app}
+                          activeDeployment={activeDeployment}
+                          onDelete={() => setDeletedApp(app)}
+                        />
+                      );
+                    })
                   : 'No apps yet';
               default:
                 return '';

--- a/packages/toolpad-app/src/toolpad/Home.tsx
+++ b/packages/toolpad-app/src/toolpad/Home.tsx
@@ -284,7 +284,7 @@ function AppCard({ app, activeDeployment, onDelete }: AppCardProps) {
             errorText={`An app named "${appTitle}" already exists`}
             loading={Boolean(!app)}
             defaultValue={appTitle}
-            variant={'h5'}
+            variant={'subtitle1'}
             ref={appTitleInput}
           />
         </CardContent>
@@ -376,16 +376,16 @@ export default function Home() {
               case 'success':
                 return apps.length > 0
                   ? apps.map((app) => {
-                      const activeDeployment = activeDeploymentsByApp?.[app.id];
-                      return (
-                        <AppCard
-                          key={app.id}
-                          app={app}
-                          activeDeployment={activeDeployment}
-                          onDelete={() => setDeletedApp(app)}
-                        />
-                      );
-                    })
+                    const activeDeployment = activeDeploymentsByApp?.[app.id];
+                    return (
+                      <AppCard
+                        key={app.id}
+                        app={app}
+                        activeDeployment={activeDeployment}
+                        onDelete={() => setDeletedApp(app)}
+                      />
+                    );
+                  })
                   : 'No apps yet';
               default:
                 return '';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

1. Show ellipses for overflown text (I'm just not sure if it's fine that we now also truncate multi word names? 🤔 )
2. In addition I've added tooltip with a longer enter delay so that users can inspect actual value even if it's truncated.
3. Reduced size of name so that we have more space before truncating

![image](https://user-images.githubusercontent.com/437214/179984928-07b6a97a-e30b-4cf8-8876-8dc0172556e2.png)

![image](https://user-images.githubusercontent.com/437214/179986156-6c91e242-a4dc-48fc-9527-ab2028c99cd0.png)

4. I also noticed that it gets broken when editing app, so I fixed it there as well:

![image](https://user-images.githubusercontent.com/437214/179986982-dfa1c302-edb5-4560-ae88-8d4e50f34123.png)


@Janpot regarding table vs card view - lemme know if we should proceed that way, I think this could be a quick tweak - we could just add toolbar with icons and depending on local view state render either card or table

Off topic: I remember in previous team we implemented `TypographyOverflow` component - https://picasso.toptal.net/?path=/story/components-typographyoverflow--typographyoverflow - maybe it would be worth considering pitching similar functionality for the core component? 🤔 

Closes https://github.com/mui/mui-toolpad/issues/666