### PR TITLE
Tweak update button position and visibility in component editor

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
@@ -154,11 +154,7 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
         <Toolbar sx={{ mt: 2 }}>
           <NodeNameEditor node={codeComponentNode} sx={{ maxWidth: 300 }} />
         </Toolbar>
-        <Toolbar>
-          <Button disabled={allChangesAreCommitted} onClick={handleSave}>
-            Update
-          </Button>
-        </Toolbar>
+
         <Box flex={1}>
           <SplitPane split="vertical" allowResize size="50%">
             <TypescriptEditor
@@ -189,6 +185,21 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
             frameDocument.body,
           )
         : null}
+      <Toolbar
+        sx={{
+          position: 'absolute',
+          bottom: 0,
+          right: 0,
+          width: '100%',
+          zIndex: 1,
+          background: '#f2f2f2',
+          justifyContent: 'end',
+        }}
+      >
+        <Button disabled={allChangesAreCommitted} onClick={handleSave} variant="contained">
+          Update
+        </Button>
+      </Toolbar>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

![image](https://user-images.githubusercontent.com/437214/179991347-f5d5721c-9148-451f-a067-471c7a295237.png)

- Moved toolbar below the editor
- Also changed variant for button so it's more visible. IMO since its the main CTA it could use that extra visibility