### PR TITLE
Add split panes to connections dialog

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -40,6 +40,7 @@ import { WithControlledProp } from '../../../utils/types';
 import { useDom, useDomApi } from '../../DomLoader';
 import { mapValues } from '../../../utils/collections';
 import { ConnectionContextProvider } from '../../../toolpadDataSources/context';
+import SplitPane from '../../../components/SplitPane';
 
 export interface ConnectionSelectProps extends WithControlledProp<NodeId | null> {
   dataSource?: string;
@@ -145,6 +146,22 @@ function ConnectionSelectorDialog<Q>({ open, onCreated, onClose }: DataSourceSel
   );
 }
 
+interface ConnectionWrapperProps {
+  dataSourceId: string;
+  children: React.ReactNode;
+}
+
+function ConnectionWrapper({ children, dataSourceId }: ConnectionWrapperProps) {
+  if (dataSourceId === 'function') {
+    return <Box flex={1}>{children}</Box>;
+  }
+
+  return (
+    <SplitPane split="vertical" allowResize size="50%">
+      {children}
+    </SplitPane>
+  );
+}
 interface QueryNodeEditorProps<Q, P> {
   open: boolean;
   onClose: () => void;
@@ -331,94 +348,105 @@ function QueryNodeEditorDialog<Q, P>({
       <Divider />
 
       {dataSourceId && dataSource ? (
-        <DialogContent sx={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', p: 0 }}>
-          <Box sx={{ display: 'flex', flexDirection: 'row', minHeight: 0 }}>
-            <Stack
-              sx={{
-                flex: 1,
-                minWidth: 0,
-                overflow: 'auto',
-              }}
-            >
-              <ConnectionContextProvider value={queryEditorContext}>
-                <dataSource.QueryEditor
-                  connectionParams={connection?.attributes.params.value}
-                  value={{
-                    query: input.attributes.query.value,
-                    params: input.params,
-                  }}
-                  liveParams={liveParams}
-                  onChange={handleQueryChange}
-                  globalScope={pageState}
-                />
-              </ConnectionContextProvider>
-
-              {/* TODO: move transform inside of the dataSource.QueryEditor and remove the conditional */}
-              {dataSourceId === 'function' ? null : (
-                <Grid container direction="row" spacing={1} sx={{ px: 3, pb: 1, mt: 2 }}>
-                  <React.Fragment>
-                    <Divider />
-                    <Grid item xs={6}>
-                      <Stack>
-                        <FormControlLabel
-                          label="Transform response"
-                          control={
-                            <Checkbox
-                              checked={input.attributes.transformEnabled?.value ?? false}
-                              onChange={handleTransformEnabledChange}
-                              inputProps={{ 'aria-label': 'controlled' }}
-                            />
-                          }
-                        />
-
-                        <JsExpressionEditor
-                          globalScope={{}}
-                          value={
-                            input.attributes.transform?.value ?? '(data) => {\n  return data;\n}'
-                          }
-                          onChange={handleTransformFnChange}
-                          disabled={!input.attributes.transformEnabled?.value}
-                        />
-                      </Stack>
-                    </Grid>
-                  </React.Fragment>
-                </Grid>
-              )}
-            </Stack>
-
-            {/* TODO: move preview inside of the dataSource.QueryEditor and remove the conditional */}
-            {dataSourceId === 'function' ? null : (
-              <Box
+        <DialogContent
+          sx={{
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+            p: 0,
+          }}
+        >
+          <Box
+            sx={{ display: 'flex', flexDirection: 'row', minHeight: '500px', position: 'relative' }}
+          >
+            <ConnectionWrapper dataSourceId={dataSourceId}>
+              <Stack
                 sx={{
                   flex: 1,
                   minWidth: 0,
-                  borderLeft: 1,
-                  borderColor: 'divider',
-                  display: 'flex',
-                  flexDirection: 'column',
+                  overflow: 'auto',
                 }}
               >
-                <Toolbar>
-                  <LoadingButton
-                    size="medium"
-                    disabled={previewParams === paramsObject && previewQuery === input}
-                    loading={isPreviewLoading}
-                    loadingPosition="start"
-                    variant="contained"
-                    onClick={handleUpdatePreview}
-                    startIcon={<PlayArrowIcon />}
-                  >
-                    Preview
-                  </LoadingButton>
-                </Toolbar>
-                <Box sx={{ flex: 1, minHeight: 0, px: 3, py: 1, overflow: 'auto' }}>
-                  {queryPreview.error ? <ErrorAlert error={queryPreview.error} /> : null}
-                  {queryPreview.isSuccess ? <JsonView src={queryPreview.data} /> : null}
+                <ConnectionContextProvider value={queryEditorContext}>
+                  <dataSource.QueryEditor
+                    connectionParams={connection?.attributes.params.value}
+                    value={{
+                      query: input.attributes.query.value,
+                      params: input.params,
+                    }}
+                    liveParams={liveParams}
+                    onChange={handleQueryChange}
+                    globalScope={pageState}
+                  />
+                </ConnectionContextProvider>
+
+                {/* TODO: move transform inside of the dataSource.QueryEditor and remove the conditional */}
+                {dataSourceId === 'function' ? null : (
+                  <Grid container direction="row" spacing={1} sx={{ px: 3, pb: 1, mt: 2 }}>
+                    <React.Fragment>
+                      <Divider />
+                      <Grid item xs={6}>
+                        <Stack>
+                          <FormControlLabel
+                            label="Transform response"
+                            control={
+                              <Checkbox
+                                checked={input.attributes.transformEnabled?.value ?? false}
+                                onChange={handleTransformEnabledChange}
+                                inputProps={{ 'aria-label': 'controlled' }}
+                              />
+                            }
+                          />
+
+                          <JsExpressionEditor
+                            globalScope={{}}
+                            value={
+                              input.attributes.transform?.value ?? '(data) => {\n  return data;\n}'
+                            }
+                            onChange={handleTransformFnChange}
+                            disabled={!input.attributes.transformEnabled?.value}
+                          />
+                        </Stack>
+                      </Grid>
+                    </React.Fragment>
+                  </Grid>
+                )}
+              </Stack>
+
+              {/* TODO: move preview inside of the dataSource.QueryEditor and remove the conditional */}
+              {dataSourceId === 'function' ? null : (
+                <Box
+                  sx={{
+                    flex: 1,
+                    minWidth: 0,
+                    borderLeft: 1,
+                    borderColor: 'divider',
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
+                >
+                  <Toolbar>
+                    <LoadingButton
+                      size="medium"
+                      disabled={previewParams === paramsObject && previewQuery === input}
+                      loading={isPreviewLoading}
+                      loadingPosition="start"
+                      variant="contained"
+                      onClick={handleUpdatePreview}
+                      startIcon={<PlayArrowIcon />}
+                    >
+                      Preview
+                    </LoadingButton>
+                  </Toolbar>
+                  <Box sx={{ flex: 1, minHeight: 0, px: 3, py: 1, overflow: 'auto' }}>
+                    {queryPreview.error ? <ErrorAlert error={queryPreview.error} /> : null}
+                    {queryPreview.isSuccess ? <JsonView src={queryPreview.data} /> : null}
+                  </Box>
                 </Box>
-              </Box>
-            )}
+              )}
+            </ConnectionWrapper>
           </Box>
-          <Divider />
+
           <Stack direction="row" alignItems="center" sx={{ pt: 2, px: 3, gap: 2 }}>
             <FormControlLabel
               control={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


![image](https://user-images.githubusercontent.com/437214/180236640-a9c061f9-5570-4de3-97d5-a990fa347ef4.png)

I've added `SplitPane` however I'm not a big fan of implementation right now. I had to add `ConnectionWrapper` which is a pretty dumb component which allows either to use split pane or not. I think to do it more cleaning we would need to refactor layout and maybe unify each connection type 🤔 