### PR TITLE
Remove obsolete DataGrid license code

### DIFF
--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -2,7 +2,6 @@ import {
   DataGridProProps,
   DataGridPro,
   GridToolbar,
-  LicenseInfo,
   GridColumnResizeParams,
   GridColumns,
   GridRowsProp,
@@ -121,15 +120,6 @@ export function inferColumns(rows: GridRowsProp): GridColumns {
     field,
     type: inferColumnType(value),
   }));
-}
-
-const LICENSE =
-  typeof window !== 'undefined'
-    ? window.document.querySelector('meta[name=x-data-grid-pro-license]')?.getAttribute('content')
-    : null;
-
-if (LICENSE) {
-  LicenseInfo.setLicenseKey(LICENSE);
 }
 
 const EMPTY_COLUMNS: GridColumns = [];


### PR DESCRIPTION
This isn't doing anything anymore now that we run the [toolpad runtime on Next.js](https://github.com/mui/mui-toolpad/pull/415). The runtime license key gets set by `./pages/_app.ts` now.
