### PR TITLE
Fix hidden tooltips issue in code editor

### DIFF
--- a/packages/toolpad-app/src/components/SplitPane.tsx
+++ b/packages/toolpad-app/src/components/SplitPane.tsx
@@ -43,7 +43,11 @@ const WrappedSplitPane = React.forwardRef<
         // Prevent the content from stretching the Panel out
         minWidth: 0,
         minHeight: 0,
+        overflow: 'initial',
         ...props.paneStyle,
+      }}
+      style={{
+        overflow: 'initial',
       }}
       {...props}
     />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

![image](https://user-images.githubusercontent.com/437214/180413355-14465c7d-9c93-4b95-9dc8-82b4b338f218.png)

I fixed the issue of tooltip being hidden. Tested other usages of split pane all seems still fine, however I'm not really sure what was meant by split pane overflow being hidden 🤔 I'm trying to think of a reasons but can't come up with anything, for me it seems logical that the consumer would be controlling overflow 🤔 