### PR TITLE
Increase the render.com plan to standard

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,7 @@ services:
     buildCommand: yarn --frozen-lockfile --prod=false && yarn release:build
     startCommand: yarn start
     healthCheckPath: /health-check
-    plan: starter plus
+    plan: standard
     pullRequestPreviewsEnabled: true
     envVars:
       - key: TOOLPAD_DATABASE_URL


### PR DESCRIPTION
So we're running out of memory during the build (which happens during startup). With our current plan there's enough memory to run the app, just not to start it up. The obvious answer is to instead build on CI and run on [render.com](http://render.com/). With their current feature set it's possible to turn of auto-deploys and trigger a deploy from CI via a webhook. Unfortunately this doesn't work with PR previews. The feature that made us choose [render.com](http://render.com/).
To unstuck us for now we can beef up the plan to `standard` which doubles up the RAM to 2GB.