### PR TITLE
Fixes to query editor layout

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -154,9 +154,11 @@ function ConnectionWrapper({ children, dataSourceId }: ConnectionWrapperProps) {
   }
 
   return (
-    <SplitPane split="vertical" allowResize size="50%">
-      {children}
-    </SplitPane>
+    <div style={{ flexGrow: 1, width: '100%' }}>
+      <SplitPane split="vertical" allowResize size="50%">
+        {children}
+      </SplitPane>
+    </div>
   );
 }
 interface QueryNodeEditorProps<Q, P> {
@@ -354,13 +356,18 @@ function QueryNodeEditorDialog<Q, P>({
           }}
         >
           <Box
-            sx={{ display: 'flex', flexDirection: 'row', minHeight: '500px', position: 'relative' }}
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              position: 'relative',
+              display: 'flex',
+            }}
           >
             <ConnectionWrapper dataSourceId={dataSourceId}>
               <Stack
                 sx={{
-                  flex: 1,
-                  minWidth: 0,
+                  width: '100%',
+                  height: '100%',
                   overflow: 'auto',
                 }}
               >
@@ -414,10 +421,8 @@ function QueryNodeEditorDialog<Q, P>({
               {dataSourceId === 'function' ? null : (
                 <Box
                   sx={{
-                    flex: 1,
-                    minWidth: 0,
-                    borderLeft: 1,
-                    borderColor: 'divider',
+                    width: '100%',
+                    height: '100%',
                     display: 'flex',
                     flexDirection: 'column',
                   }}

--- a/packages/toolpad-app/src/toolpadDataSources/function/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/function/client.tsx
@@ -186,67 +186,61 @@ function QueryEditor({
   };
 
   return (
-    <Box sx={{ height: 500, position: 'relative' }}>
-      <SplitPane split="vertical" size="50%" allowResize>
-        <SplitPane split="horizontal" size={85} primary="second" allowResize>
-          <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-            <Toolbar>
-              <LoadingButton startIcon={<PlayArrowIcon />} onClick={() => runPreview()}>
-                Preview
-              </LoadingButton>
-            </Toolbar>
-            <Box sx={{ flex: 1, minHeight: 0 }}>
-              <TypescriptEditor
-                value={value.query.module}
-                onChange={(newValue) => onChange({ ...value, query: { module: newValue } })}
-                extraLibs={extraLibs}
-              />
-            </Box>
-          </Box>
-
-          <Box sx={{ p: 2 }}>
-            <Typography>Parameters</Typography>
-            <ParametersEditor
-              value={params}
-              onChange={handleParamsChange}
-              globalScope={globalScope}
-              liveValue={paramsEditorLiveValue}
+    <SplitPane split="vertical" size="50%" allowResize>
+      <SplitPane split="horizontal" size={85} primary="second" allowResize>
+        <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+          <Toolbar>
+            <LoadingButton startIcon={<PlayArrowIcon />} onClick={() => runPreview()}>
+              Preview
+            </LoadingButton>
+          </Toolbar>
+          <Box sx={{ flex: 1, minHeight: 0 }}>
+            <TypescriptEditor
+              value={value.query.module}
+              onChange={(newValue) => onChange({ ...value, query: { module: newValue } })}
+              extraLibs={extraLibs}
             />
           </Box>
-        </SplitPane>
+        </Box>
 
-        <SplitPane split="horizontal" size="30%" minSize={30} primary="second" allowResize>
-          <Box sx={{ height: '100%', overflow: 'auto', mx: 1 }}>
-            {preview?.error ? (
-              <ErrorAlert error={preview?.error} />
-            ) : (
-              <JsonView src={preview?.data} />
-            )}
-          </Box>
-
-          <TabContext value={debuggerTab}>
-            <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
-              <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-                <TabList onChange={handleDebuggerTabChange} aria-label="Debugger">
-                  <Tab label="Console" value="console" />
-                  <Tab label="Network" value="network" />
-                </TabList>
-              </Box>
-              <DebuggerTabPanel value="console">
-                <Console sx={{ flex: 1 }} value={previewLogs} onChange={setPreviewLogs} />
-              </DebuggerTabPanel>
-              <DebuggerTabPanel value="network">
-                <HarViewer har={preview?.har} />
-              </DebuggerTabPanel>
-            </Box>
-          </TabContext>
-
-          {/*       <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
- <Console sx={{ flex: 1 }} value={previewLogs} onChange={setPreviewLogs} /> 
-          </Box> */}
-        </SplitPane>
+        <Box sx={{ p: 2 }}>
+          <Typography>Parameters</Typography>
+          <ParametersEditor
+            value={params}
+            onChange={handleParamsChange}
+            globalScope={globalScope}
+            liveValue={paramsEditorLiveValue}
+          />
+        </Box>
       </SplitPane>
-    </Box>
+
+      <SplitPane split="horizontal" size="30%" minSize={30} primary="second" allowResize>
+        <Box sx={{ height: '100%', overflow: 'auto', mx: 1 }}>
+          {preview?.error ? (
+            <ErrorAlert error={preview?.error} />
+          ) : (
+            <JsonView src={preview?.data} />
+          )}
+        </Box>
+
+        <TabContext value={debuggerTab}>
+          <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+              <TabList onChange={handleDebuggerTabChange} aria-label="Debugger">
+                <Tab label="Console" value="console" />
+                <Tab label="Network" value="network" />
+              </TabList>
+            </Box>
+            <DebuggerTabPanel value="console">
+              <Console sx={{ flex: 1 }} value={previewLogs} onChange={setPreviewLogs} />
+            </DebuggerTabPanel>
+            <DebuggerTabPanel value="network">
+              <HarViewer har={preview?.har} />
+            </DebuggerTabPanel>
+          </Box>
+        </TabContext>
+      </SplitPane>
+    </SplitPane>
   );
 }
 


### PR DESCRIPTION
### Recommended to hide whitespace while reviewing

Fixes https://github.com/mui/mui-toolpad/issues/692


* We can keep the methodology from https://github.com/mui/mui-toolpad/pull/676, it's sound
* Give explicit height to the `DialogContent`, this solved most of the problems
* Fix layout/overflow issues from https://github.com/mui/mui-toolpad/issues/692 (looks like they were introduced way before)
* Invert the logic one how we display the legacy view. We now have an implicit to do list in `LEGACY_DATASOURCE_QUERY_EDITOR_LAYOUT` that we can tackle one by one
* Remove some legacy comments
* Remove some leftover? `height: 500px`