### PR TITLE
Add bindable enabled property to queries

### DIFF
--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -110,6 +110,7 @@ export interface QueryNode<Q = any, P = any> extends AppDomNodeBase {
     readonly refetchOnWindowFocus?: ConstantAttrValue<boolean>;
     readonly refetchOnReconnect?: ConstantAttrValue<boolean>;
     readonly refetchInterval?: ConstantAttrValue<number>;
+    readonly enabled?: ConstantAttrValue<boolean>;
   };
 }
 

--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -110,7 +110,7 @@ export interface QueryNode<Q = any, P = any> extends AppDomNodeBase {
     readonly refetchOnWindowFocus?: ConstantAttrValue<boolean>;
     readonly refetchOnReconnect?: ConstantAttrValue<boolean>;
     readonly refetchInterval?: ConstantAttrValue<number>;
-    readonly enabled?: ConstantAttrValue<boolean>;
+    readonly enabled?: BindableAttrValue<boolean>;
   };
 }
 

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -335,6 +335,7 @@ function QueryNode({ node }: QueryNodeProps) {
   const params = resolveBindables(bindings, `${node.id}.params`, node.params);
 
   const queryResult = useDataQuery(dataUrl, queryId, params, {
+    enabled: node.attributes.enabled?.value ?? true,
     refetchOnWindowFocus: node.attributes.refetchOnWindowFocus?.value,
     refetchOnReconnect: node.attributes.refetchOnReconnect?.value,
     refetchInterval: node.attributes.refetchInterval?.value,

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -19,6 +19,8 @@ import {
   Placeholder,
   BindableAttrValues,
   NodeId,
+  BindableAttrValue,
+  UseDataQueryConfig,
 } from '@mui/toolpad-core';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import {
@@ -36,6 +38,7 @@ import {
   NodeRuntimeWrapper,
   ResetNodeErrorsKeyProvider,
 } from '@mui/toolpad-core/runtime';
+import { pick } from 'lodash-es';
 import * as appDom from '../appDom';
 import { VersionOrPreview } from '../types';
 import { createProvidedContext } from '../utils/react';
@@ -54,6 +57,13 @@ import usePageTitle from '../utils/usePageTitle';
 import ComponentsContext, { useComponents, useComponent } from './ComponentsContext';
 import { AppModulesProvider, useAppModules } from './AppModulesProvider';
 import Pre from '../components/Pre';
+
+const USE_DATA_QUERY_CONFIG_KEYS: readonly (keyof UseDataQueryConfig)[] = [
+  'enabled',
+  'refetchInterval',
+  'refetchOnReconnect',
+  'refetchOnWindowFocus',
+];
 
 export interface NavigateToPage {
   (pageNodeId: NodeId): void;
@@ -334,12 +344,9 @@ function QueryNode({ node }: QueryNodeProps) {
   const queryId = node.id;
   const params = resolveBindables(bindings, `${node.id}.params`, node.params);
 
-  const queryResult = useDataQuery(dataUrl, queryId, params, {
-    enabled: node.attributes.enabled?.value ?? true,
-    refetchOnWindowFocus: node.attributes.refetchOnWindowFocus?.value,
-    refetchOnReconnect: node.attributes.refetchOnReconnect?.value,
-    refetchInterval: node.attributes.refetchInterval?.value,
-  });
+  const configBindings = pick(node.attributes, ...USE_DATA_QUERY_CONFIG_KEYS);
+  const options = resolveBindables(bindings, `${node.id}.config`, configBindings);
+  const queryResult = useDataQuery(dataUrl, queryId, params, options);
 
   React.useEffect(() => {
     const { isLoading, error, data, rows, ...result } = queryResult;
@@ -359,6 +366,25 @@ function QueryNode({ node }: QueryNodeProps) {
   }, [node.id, queryResult, setControlledBinding]);
 
   return null;
+}
+
+function parseBinding(bindable: BindableAttrValue<any> | undefined, scopePath: string | undefined) {
+  if (bindable?.type === 'const') {
+    return {
+      scopePath,
+      result: { value: bindable.value },
+    };
+  }
+  if (bindable?.type === 'jsExpression') {
+    return {
+      scopePath,
+      expression: bindable.value,
+    };
+  }
+  return {
+    scopePath,
+    result: { value: undefined },
+  };
 }
 
 function parseBindings(
@@ -405,16 +431,8 @@ function parseBindings(
               scopePath,
               result: { value: defaultValue },
             });
-          } else if (binding?.type === 'const') {
-            parsedBindingsMap.set(bindingId, {
-              scopePath,
-              result: { value: binding?.value },
-            });
-          } else if (binding?.type === 'jsExpression') {
-            parsedBindingsMap.set(bindingId, {
-              scopePath,
-              expression: binding?.value,
-            });
+          } else {
+            parsedBindingsMap.set(bindingId, parseBinding(binding, scopePath));
           }
         }
       }
@@ -425,17 +443,7 @@ function parseBindings(
         for (const [paramName, bindable] of Object.entries(elm.params)) {
           const bindingId = `${elm.id}.params.${paramName}`;
           const scopePath = `${elm.name}.params.${paramName}`;
-          if (bindable?.type === 'const') {
-            parsedBindingsMap.set(bindingId, {
-              scopePath,
-              result: { value: bindable.value },
-            });
-          } else if (bindable?.type === 'jsExpression') {
-            parsedBindingsMap.set(bindingId, {
-              scopePath,
-              expression: bindable.value,
-            });
-          }
+          parsedBindingsMap.set(bindingId, parseBinding(bindable, scopePath));
         }
       }
 
@@ -447,6 +455,13 @@ function parseBindings(
           scopePath,
           result: { value, loading: true },
         });
+      }
+
+      for (const configName of USE_DATA_QUERY_CONFIG_KEYS) {
+        const bindingId = `${elm.id}.config.${configName}`;
+        const scopePath = `${elm.name}.config.${configName}`;
+        const bindable = elm.attributes[configName];
+        parsedBindingsMap.set(bindingId, parseBinding(bindable, scopePath));
       }
     }
   }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/BindableEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/BindableEditor.tsx
@@ -1,34 +1,18 @@
-import { Stack, TextField } from '@mui/material';
+import { Stack } from '@mui/material';
 import * as React from 'react';
 import { BindableAttrValue, PropValueType, LiveBinding } from '@mui/toolpad-core';
 import { BindingEditor } from '../BindingEditor';
 import { WithControlledProp } from '../../../utils/types';
-
-function DefaultControl({ label, disabled, value, onChange }: RenderControlParams<any>) {
-  const handleChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(event.target.value);
-    },
-    [onChange],
-  );
-
-  return (
-    <TextField
-      fullWidth
-      value={value ?? ''}
-      disabled={disabled}
-      onChange={handleChange}
-      label={label}
-    />
-  );
-}
+import { getDefaultControl } from '../../propertyControls';
 
 function renderDefaultControl(params: RenderControlParams<any>) {
-  return <DefaultControl {...params} />;
+  const Control = getDefaultControl({ typeDef: params.propType });
+  return Control ? <Control {...params} /> : null;
 }
 
 export interface RenderControlParams<V> extends WithControlledProp<V> {
   label: string;
+  propType: PropValueType;
   disabled: boolean;
 }
 
@@ -75,6 +59,7 @@ export default function BindableEditor<V>({
       <React.Fragment>
         {renderControl({
           label,
+          propType,
           disabled: !!hasBinding,
           value: constValue,
           onChange: handlePropConstChange,

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
@@ -1,35 +1,11 @@
 import * as React from 'react';
-import {
-  ArgControlSpec,
-  ArgTypeDefinition,
-  BindableAttrValue,
-  PropValueType,
-} from '@mui/toolpad-core';
+import { ArgTypeDefinition, BindableAttrValue } from '@mui/toolpad-core';
 import { Alert } from '@mui/material';
 import * as appDom from '../../../appDom';
 import { useDomApi } from '../../DomLoader';
 import BindableEditor from './BindableEditor';
 import { usePageEditorState } from './PageEditorProvider';
-import propertyControls from '../../propertyControls';
-
-function getDefaultControl(typeDef: PropValueType): ArgControlSpec | null {
-  switch (typeDef.type) {
-    case 'string':
-      return typeDef.enum ? { type: 'select' } : { type: 'string' };
-    case 'number':
-      return { type: 'number' };
-    case 'boolean':
-      return { type: 'boolean' };
-    case 'object':
-      return { type: 'json' };
-    case 'array':
-      return { type: 'json' };
-    case 'event':
-      return { type: 'event' };
-    default:
-      return null;
-  }
-}
+import { getDefaultControl } from '../../propertyControls';
 
 export interface NodeAttributeEditorProps {
   node: appDom.AppDomNode;
@@ -59,9 +35,8 @@ export default function NodeAttributeEditor({
   const { bindings, pageState } = usePageEditorState();
   const liveBinding = bindings[bindingId];
   const globalScope = pageState;
-
-  const controlSpec = argType.control ?? getDefaultControl(argType.typeDef);
-  const Control = controlSpec ? propertyControls[controlSpec.type] : null;
+  const propType = argType.typeDef;
+  const Control = getDefaultControl(argType);
 
   // NOTE: Doesn't make much sense to bind controlled props. In the future we might opt
   // to make them bindable to other controlled props only
@@ -73,14 +48,14 @@ export default function NodeAttributeEditor({
       globalScope={globalScope}
       label={argType.label || name}
       disabled={!isBindable}
-      propType={argType.typeDef}
-      renderControl={(params) => <Control nodeId={node.id} argType={argType} {...params} />}
+      propType={propType}
+      renderControl={(params) => <Control nodeId={node.id} {...params} propType={propType} />}
       value={propValue}
       onChange={handlePropChange}
     />
   ) : (
     <Alert severity="warning">
-      {`No control for '${name}' (type '${argType.typeDef.type}' ${
+      {`No control for '${name}' (type '${propType.type}' ${
         argType.control ? `, control: '${argType.control.type}'` : ''
       })`}
     </Alert>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -154,9 +154,11 @@ function ConnectionWrapper({ children, dataSourceId }: ConnectionWrapperProps) {
   }
 
   return (
-    <SplitPane split="vertical" allowResize size="50%">
-      {children}
-    </SplitPane>
+    <div style={{ flexGrow: 1, width: '100%' }}>
+      <SplitPane split="vertical" allowResize size="50%">
+        {children}
+      </SplitPane>
+    </div>
   );
 }
 interface QueryNodeEditorProps<Q, P> {
@@ -354,13 +356,18 @@ function QueryNodeEditorDialog<Q, P>({
           }}
         >
           <Box
-            sx={{ display: 'flex', flexDirection: 'row', minHeight: '500px', position: 'relative' }}
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              position: 'relative',
+              display: 'flex',
+            }}
           >
             <ConnectionWrapper dataSourceId={dataSourceId}>
               <Stack
                 sx={{
-                  flex: 1,
-                  minWidth: 0,
+                  width: '100%',
+                  height: '100%',
                   overflow: 'auto',
                 }}
               >
@@ -414,10 +421,8 @@ function QueryNodeEditorDialog<Q, P>({
               {dataSourceId === 'function' ? null : (
                 <Box
                   sx={{
-                    flex: 1,
-                    minWidth: 0,
-                    borderLeft: 1,
-                    borderColor: 'divider',
+                    width: '100%',
+                    height: '100%',
                     display: 'flex',
                     flexDirection: 'column',
                   }}

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -237,6 +237,16 @@ function QueryNodeEditorDialog<Q, P>({
     [],
   );
 
+  const handleEnabledChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setInput((existing) =>
+      update(existing, {
+        attributes: update(existing.attributes, {
+          enabled: appDom.createConst(event.target.checked),
+        }),
+      }),
+    );
+  }, []);
+
   const handleRefetchOnReconnectChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setInput((existing) =>
@@ -450,6 +460,15 @@ function QueryNodeEditorDialog<Q, P>({
           </Box>
 
           <Stack direction="row" alignItems="center" sx={{ pt: 2, px: 3, gap: 2 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={input.attributes.enabled?.value ?? true}
+                  onChange={handleEnabledChange}
+                />
+              }
+              label="Enabled"
+            />
             <FormControlLabel
               control={
                 <Checkbox

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -51,13 +51,6 @@ const LEGACY_DATASOURCE_QUERY_EDITOR_LAYOUT = new Set([
   'movies',
 ]);
 
-const LEGACY_DATASOURCE_QUERY_EDITOR_LAYOUT = new Set([
-  'rest',
-  'googleSheets',
-  'postgres',
-  'movies',
-]);
-
 export interface ConnectionSelectProps extends WithControlledProp<NodeId | null> {
   dataSource?: string;
   sx?: SxProps;

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -23,7 +23,7 @@ import * as React from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { LoadingButton } from '@mui/lab';
-import { NodeId } from '@mui/toolpad-core';
+import { BindableAttrValue, NodeId } from '@mui/toolpad-core';
 import invariant from 'invariant';
 import useLatest from '../../../utils/useLatest';
 import { usePageEditorState } from './PageEditorProvider';
@@ -36,12 +36,13 @@ import { omit, update } from '../../../utils/immutability';
 import client from '../../../api';
 import ErrorAlert from './ErrorAlert';
 import { JsExpressionEditor } from './JsExpressionEditor';
-import { useEvaluateLiveBindings } from '../useEvaluateLiveBinding';
+import { useEvaluateLiveBinding, useEvaluateLiveBindings } from '../useEvaluateLiveBinding';
 import { WithControlledProp } from '../../../utils/types';
 import { useDom, useDomApi } from '../../DomLoader';
 import { mapValues } from '../../../utils/collections';
 import { ConnectionContextProvider } from '../../../toolpadDataSources/context';
 import SplitPane from '../../../components/SplitPane';
+import BindableEditor from './BindableEditor';
 
 const LEGACY_DATASOURCE_QUERY_EDITOR_LAYOUT = new Set([
   'rest',
@@ -237,11 +238,11 @@ function QueryNodeEditorDialog<Q, P>({
     [],
   );
 
-  const handleEnabledChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleEnabledChange = React.useCallback((newValue: BindableAttrValue<boolean> | null) => {
     setInput((existing) =>
       update(existing, {
         attributes: update(existing.attributes, {
-          enabled: appDom.createConst(event.target.checked),
+          enabled: newValue || undefined,
         }),
       }),
     );
@@ -330,6 +331,11 @@ function QueryNodeEditorDialog<Q, P>({
   }, [onClose, isInputSaved]);
 
   const queryEditorContext = React.useMemo(() => ({ appId, connectionId }), [appId, connectionId]);
+
+  const liveEnabled = useEvaluateLiveBinding({
+    input: input.attributes.enabled || null,
+    globalScope: pageState,
+  });
 
   return (
     <Dialog fullWidth maxWidth="xl" open={open} onClose={handleClose}>
@@ -460,14 +466,14 @@ function QueryNodeEditorDialog<Q, P>({
           </Box>
 
           <Stack direction="row" alignItems="center" sx={{ pt: 2, px: 3, gap: 2 }}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={input.attributes.enabled?.value ?? true}
-                  onChange={handleEnabledChange}
-                />
-              }
+            <BindableEditor
+              liveBinding={liveEnabled}
+              globalScope={pageState}
+              server
               label="Enabled"
+              propType={{ type: 'boolean' }}
+              value={input.attributes.enabled ?? null}
+              onChange={handleEnabledChange}
             />
             <FormControlLabel
               control={

--- a/packages/toolpad-app/src/toolpad/propertyControls/RowIdFieldSelect.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/RowIdFieldSelect.tsx
@@ -1,23 +1,21 @@
-import { ArgTypeDefinition } from '@mui/toolpad-core';
+import { PropValueType } from '@mui/toolpad-core';
 import { GridColDef } from '@mui/x-data-grid-pro';
 import * as React from 'react';
 import { EditorProps } from '../../types';
 import { usePageEditorState } from '../AppEditor/PageEditor/PageEditorProvider';
 import SelectControl from './select';
 
-function ColumnSelect({ nodeId, argType, ...props }: EditorProps<string>) {
+function ColumnSelect({ nodeId, ...props }: EditorProps<string>) {
   const { bindings } = usePageEditorState();
   const columnsValue = nodeId && bindings[`${nodeId}.props.columns`];
   const definedColumns: GridColDef[] = columnsValue?.value;
 
-  const newArgType: ArgTypeDefinition = React.useMemo(() => {
+  const newPropType: PropValueType = React.useMemo(() => {
     const columnNames = definedColumns?.map((column) => column.field);
-    return {
-      ...argType,
-      typeDef: { type: 'string', enum: columnNames },
-    };
-  }, [argType, definedColumns]);
-  return <SelectControl nodeId={nodeId} argType={newArgType} {...props} />;
+    return { type: 'string', enum: columnNames };
+  }, [definedColumns]);
+
+  return <SelectControl nodeId={nodeId} {...props} propType={newPropType} />;
 }
 
 export default ColumnSelect;

--- a/packages/toolpad-app/src/toolpad/propertyControls/index.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/index.tsx
@@ -1,4 +1,4 @@
-import { ArgControlSpec } from '@mui/toolpad-core';
+import { ArgTypeDefinition, ArgControlSpec, PropValueType } from '@mui/toolpad-core';
 import string from './string';
 import boolean from './boolean';
 import number from './number';
@@ -27,5 +27,32 @@ const propTypeControls: {
   HorizontalAlign,
   VerticalAlign,
 };
+
+function getDefaultControlForType(propType: PropValueType): React.FC<EditorProps<any>> | null {
+  switch (propType.type) {
+    case 'string':
+      return propType.enum ? select : string;
+    case 'number':
+      return number;
+    case 'boolean':
+      return boolean;
+    case 'object':
+      return json;
+    case 'array':
+      return json;
+    case 'event':
+      return event;
+    default:
+      return null;
+  }
+}
+
+export function getDefaultControl(argType: ArgTypeDefinition): React.FC<EditorProps<any>> | null {
+  if (argType.control) {
+    return propTypeControls[argType.control.type] ?? getDefaultControlForType(argType.typeDef);
+  }
+
+  return getDefaultControlForType(argType.typeDef);
+}
 
 export default propTypeControls;

--- a/packages/toolpad-app/src/toolpad/propertyControls/json.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/json.tsx
@@ -18,7 +18,7 @@ const JsonEditor = lazyComponent(() => import('../../components/JsonEditor'), {
   fallback: <Skeleton variant="rectangular" height="100%" />,
 });
 
-function JsonPropEditor({ label, argType, value, onChange, disabled }: EditorProps<any>) {
+function JsonPropEditor({ label, propType, value, onChange, disabled }: EditorProps<any>) {
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
   const valueAsString = React.useMemo(() => JSON.stringify(value, null, 2), [value]);
@@ -43,9 +43,7 @@ function JsonPropEditor({ label, argType, value, onChange, disabled }: EditorPro
   }, [onChange, input]);
 
   const schemaUri =
-    argType.typeDef.type === 'object' || argType.typeDef.type === 'array'
-      ? argType.typeDef.schema
-      : undefined;
+    propType.type === 'object' || propType.type === 'array' ? propType.schema : undefined;
 
   useShortcut({ code: 'KeyS', metaKey: true, disabled: !dialogOpen }, handleSave);
 

--- a/packages/toolpad-app/src/toolpad/propertyControls/select.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/select.tsx
@@ -2,8 +2,8 @@ import { MenuItem, TextField } from '@mui/material';
 import * as React from 'react';
 import type { EditorProps } from '../../types';
 
-function SelectPropEditor({ label, argType, value, onChange, disabled }: EditorProps<string>) {
-  const items = argType.typeDef.type === 'string' ? argType.typeDef.enum ?? [] : [];
+function SelectPropEditor({ label, propType, value, onChange, disabled }: EditorProps<string>) {
+  const items = propType.type === 'string' ? propType.enum ?? [] : [];
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       onChange(event.target.value);

--- a/packages/toolpad-app/src/toolpadDataSources/function/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/function/client.tsx
@@ -186,67 +186,61 @@ function QueryEditor({
   };
 
   return (
-    <Box sx={{ height: 500, position: 'relative' }}>
-      <SplitPane split="vertical" size="50%" allowResize>
-        <SplitPane split="horizontal" size={85} primary="second" allowResize>
-          <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-            <Toolbar>
-              <LoadingButton startIcon={<PlayArrowIcon />} onClick={() => runPreview()}>
-                Preview
-              </LoadingButton>
-            </Toolbar>
-            <Box sx={{ flex: 1, minHeight: 0 }}>
-              <TypescriptEditor
-                value={value.query.module}
-                onChange={(newValue) => onChange({ ...value, query: { module: newValue } })}
-                extraLibs={extraLibs}
-              />
-            </Box>
-          </Box>
-
-          <Box sx={{ p: 2 }}>
-            <Typography>Parameters</Typography>
-            <ParametersEditor
-              value={params}
-              onChange={handleParamsChange}
-              globalScope={globalScope}
-              liveValue={paramsEditorLiveValue}
+    <SplitPane split="vertical" size="50%" allowResize>
+      <SplitPane split="horizontal" size={85} primary="second" allowResize>
+        <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+          <Toolbar>
+            <LoadingButton startIcon={<PlayArrowIcon />} onClick={() => runPreview()}>
+              Preview
+            </LoadingButton>
+          </Toolbar>
+          <Box sx={{ flex: 1, minHeight: 0 }}>
+            <TypescriptEditor
+              value={value.query.module}
+              onChange={(newValue) => onChange({ ...value, query: { module: newValue } })}
+              extraLibs={extraLibs}
             />
           </Box>
-        </SplitPane>
+        </Box>
 
-        <SplitPane split="horizontal" size="30%" minSize={30} primary="second" allowResize>
-          <Box sx={{ height: '100%', overflow: 'auto', mx: 1 }}>
-            {preview?.error ? (
-              <ErrorAlert error={preview?.error} />
-            ) : (
-              <JsonView src={preview?.data} />
-            )}
-          </Box>
-
-          <TabContext value={debuggerTab}>
-            <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
-              <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-                <TabList onChange={handleDebuggerTabChange} aria-label="Debugger">
-                  <Tab label="Console" value="console" />
-                  <Tab label="Network" value="network" />
-                </TabList>
-              </Box>
-              <DebuggerTabPanel value="console">
-                <Console sx={{ flex: 1 }} value={previewLogs} onChange={setPreviewLogs} />
-              </DebuggerTabPanel>
-              <DebuggerTabPanel value="network">
-                <HarViewer har={preview?.har} />
-              </DebuggerTabPanel>
-            </Box>
-          </TabContext>
-
-          {/*       <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
- <Console sx={{ flex: 1 }} value={previewLogs} onChange={setPreviewLogs} /> 
-          </Box> */}
-        </SplitPane>
+        <Box sx={{ p: 2 }}>
+          <Typography>Parameters</Typography>
+          <ParametersEditor
+            value={params}
+            onChange={handleParamsChange}
+            globalScope={globalScope}
+            liveValue={paramsEditorLiveValue}
+          />
+        </Box>
       </SplitPane>
-    </Box>
+
+      <SplitPane split="horizontal" size="30%" minSize={30} primary="second" allowResize>
+        <Box sx={{ height: '100%', overflow: 'auto', mx: 1 }}>
+          {preview?.error ? (
+            <ErrorAlert error={preview?.error} />
+          ) : (
+            <JsonView src={preview?.data} />
+          )}
+        </Box>
+
+        <TabContext value={debuggerTab}>
+          <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+              <TabList onChange={handleDebuggerTabChange} aria-label="Debugger">
+                <Tab label="Console" value="console" />
+                <Tab label="Network" value="network" />
+              </TabList>
+            </Box>
+            <DebuggerTabPanel value="console">
+              <Console sx={{ flex: 1 }} value={previewLogs} onChange={setPreviewLogs} />
+            </DebuggerTabPanel>
+            <DebuggerTabPanel value="network">
+              <HarViewer har={preview?.har} />
+            </DebuggerTabPanel>
+          </Box>
+        </TabContext>
+      </SplitPane>
+    </SplitPane>
   );
 }
 

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -8,6 +8,7 @@ import {
   BindableAttrValues,
   LiveBinding,
   NodeId,
+  PropValueType,
 } from '@mui/toolpad-core';
 
 import { PaletteMode } from '@mui/material';
@@ -21,7 +22,7 @@ export interface EditorProps<T> {
    */
   nodeId?: NodeId;
   label: string;
-  argType: ArgTypeDefinition;
+  propType: PropValueType;
   disabled?: boolean;
   value: T | undefined;
   onChange: (newValue: T) => void;

--- a/packages/toolpad-core/src/useDataQuery.ts
+++ b/packages/toolpad-core/src/useDataQuery.ts
@@ -37,9 +37,12 @@ export function useDataQuery(
   dataUrl: string,
   queryId: string | null,
   params: any,
-  options: Pick<
+  {
+    enabled = true,
+    ...options
+  }: Pick<
     UseQueryOptions<any, unknown, unknown, any[]>,
-    'refetchOnWindowFocus' | 'refetchOnReconnect' | 'refetchInterval'
+    'enabled' | 'refetchOnWindowFocus' | 'refetchOnReconnect' | 'refetchInterval'
   >,
 ): UseDataQuery {
   const {
@@ -50,7 +53,7 @@ export function useDataQuery(
     refetch,
   } = useQuery([dataUrl, queryId, params], () => queryId && fetchData(dataUrl, queryId, params), {
     ...options,
-    enabled: !!queryId,
+    enabled: !!queryId && enabled,
   });
 
   const { data } = responseData;
@@ -59,14 +62,14 @@ export function useDataQuery(
 
   const result: UseDataQuery = React.useMemo(
     () => ({
-      isLoading,
+      isLoading: isLoading && enabled,
       isFetching,
       error,
       data,
       rows,
       refetch,
     }),
-    [isLoading, isFetching, error, data, rows, refetch],
+    [isLoading, enabled, isFetching, error, data, rows, refetch],
   );
 
   return result;

--- a/packages/toolpad-core/src/useDataQuery.ts
+++ b/packages/toolpad-core/src/useDataQuery.ts
@@ -12,6 +12,11 @@ async function fetchData(dataUrl: string, queryId: string, params: any) {
   return res.json();
 }
 
+export type UseDataQueryConfig = Pick<
+  UseQueryOptions<any, unknown, unknown, any[]>,
+  'enabled' | 'refetchOnWindowFocus' | 'refetchOnReconnect' | 'refetchInterval'
+>;
+
 export interface UseDataQuery {
   isLoading: boolean;
   isFetching: boolean;
@@ -37,13 +42,7 @@ export function useDataQuery(
   dataUrl: string,
   queryId: string | null,
   params: any,
-  {
-    enabled = true,
-    ...options
-  }: Pick<
-    UseQueryOptions<any, unknown, unknown, any[]>,
-    'enabled' | 'refetchOnWindowFocus' | 'refetchOnReconnect' | 'refetchInterval'
-  >,
+  { enabled = true, ...options }: UseDataQueryConfig,
 ): UseDataQuery {
   const {
     isLoading,


### PR DESCRIPTION
This allows us to selectively disable fetching data based on criteria in the page, e.g. when the input is not ready, or invalid. This avoids showing an error message in the grid when the page is in this state. In a follow up we can make the "No rows" message configurable 
