### PR TITLE
Add default control to BindableEditor

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/BindableEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/BindableEditor.tsx
@@ -1,34 +1,18 @@
-import { Stack, TextField } from '@mui/material';
+import { Stack } from '@mui/material';
 import * as React from 'react';
 import { BindableAttrValue, PropValueType, LiveBinding } from '@mui/toolpad-core';
 import { BindingEditor } from '../BindingEditor';
 import { WithControlledProp } from '../../../utils/types';
-
-function DefaultControl({ label, disabled, value, onChange }: RenderControlParams<any>) {
-  const handleChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(event.target.value);
-    },
-    [onChange],
-  );
-
-  return (
-    <TextField
-      fullWidth
-      value={value ?? ''}
-      disabled={disabled}
-      onChange={handleChange}
-      label={label}
-    />
-  );
-}
+import { getDefaultControl } from '../../propertyControls';
 
 function renderDefaultControl(params: RenderControlParams<any>) {
-  return <DefaultControl {...params} />;
+  const Control = getDefaultControl({ typeDef: params.propType });
+  return Control ? <Control {...params} /> : null;
 }
 
 export interface RenderControlParams<V> extends WithControlledProp<V> {
   label: string;
+  propType: PropValueType;
   disabled: boolean;
 }
 
@@ -75,6 +59,7 @@ export default function BindableEditor<V>({
       <React.Fragment>
         {renderControl({
           label,
+          propType,
           disabled: !!hasBinding,
           value: constValue,
           onChange: handlePropConstChange,

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
@@ -1,35 +1,11 @@
 import * as React from 'react';
-import {
-  ArgControlSpec,
-  ArgTypeDefinition,
-  BindableAttrValue,
-  PropValueType,
-} from '@mui/toolpad-core';
+import { ArgTypeDefinition, BindableAttrValue } from '@mui/toolpad-core';
 import { Alert } from '@mui/material';
 import * as appDom from '../../../appDom';
 import { useDomApi } from '../../DomLoader';
 import BindableEditor from './BindableEditor';
 import { usePageEditorState } from './PageEditorProvider';
-import propertyControls from '../../propertyControls';
-
-function getDefaultControl(typeDef: PropValueType): ArgControlSpec | null {
-  switch (typeDef.type) {
-    case 'string':
-      return typeDef.enum ? { type: 'select' } : { type: 'string' };
-    case 'number':
-      return { type: 'number' };
-    case 'boolean':
-      return { type: 'boolean' };
-    case 'object':
-      return { type: 'json' };
-    case 'array':
-      return { type: 'json' };
-    case 'event':
-      return { type: 'event' };
-    default:
-      return null;
-  }
-}
+import { getDefaultControl } from '../../propertyControls';
 
 export interface NodeAttributeEditorProps {
   node: appDom.AppDomNode;
@@ -59,9 +35,8 @@ export default function NodeAttributeEditor({
   const { bindings, pageState } = usePageEditorState();
   const liveBinding = bindings[bindingId];
   const globalScope = pageState;
-
-  const controlSpec = argType.control ?? getDefaultControl(argType.typeDef);
-  const Control = controlSpec ? propertyControls[controlSpec.type] : null;
+  const propType = argType.typeDef;
+  const Control = getDefaultControl(argType);
 
   // NOTE: Doesn't make much sense to bind controlled props. In the future we might opt
   // to make them bindable to other controlled props only
@@ -73,14 +48,14 @@ export default function NodeAttributeEditor({
       globalScope={globalScope}
       label={argType.label || name}
       disabled={!isBindable}
-      propType={argType.typeDef}
-      renderControl={(params) => <Control nodeId={node.id} argType={argType} {...params} />}
+      propType={propType}
+      renderControl={(params) => <Control nodeId={node.id} {...params} propType={propType} />}
       value={propValue}
       onChange={handlePropChange}
     />
   ) : (
     <Alert severity="warning">
-      {`No control for '${name}' (type '${argType.typeDef.type}' ${
+      {`No control for '${name}' (type '${propType.type}' ${
         argType.control ? `, control: '${argType.control.type}'` : ''
       })`}
     </Alert>

--- a/packages/toolpad-app/src/toolpad/propertyControls/RowIdFieldSelect.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/RowIdFieldSelect.tsx
@@ -1,23 +1,21 @@
-import { ArgTypeDefinition } from '@mui/toolpad-core';
+import { PropValueType } from '@mui/toolpad-core';
 import { GridColDef } from '@mui/x-data-grid-pro';
 import * as React from 'react';
 import { EditorProps } from '../../types';
 import { usePageEditorState } from '../AppEditor/PageEditor/PageEditorProvider';
 import SelectControl from './select';
 
-function ColumnSelect({ nodeId, argType, ...props }: EditorProps<string>) {
+function ColumnSelect({ nodeId, ...props }: EditorProps<string>) {
   const { bindings } = usePageEditorState();
   const columnsValue = nodeId && bindings[`${nodeId}.props.columns`];
   const definedColumns: GridColDef[] = columnsValue?.value;
 
-  const newArgType: ArgTypeDefinition = React.useMemo(() => {
+  const newPropType: PropValueType = React.useMemo(() => {
     const columnNames = definedColumns?.map((column) => column.field);
-    return {
-      ...argType,
-      typeDef: { type: 'string', enum: columnNames },
-    };
-  }, [argType, definedColumns]);
-  return <SelectControl nodeId={nodeId} argType={newArgType} {...props} />;
+    return { type: 'string', enum: columnNames };
+  }, [definedColumns]);
+
+  return <SelectControl nodeId={nodeId} {...props} propType={newPropType} />;
 }
 
 export default ColumnSelect;

--- a/packages/toolpad-app/src/toolpad/propertyControls/index.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/index.tsx
@@ -1,4 +1,4 @@
-import { ArgControlSpec } from '@mui/toolpad-core';
+import { ArgTypeDefinition, ArgControlSpec, PropValueType } from '@mui/toolpad-core';
 import string from './string';
 import boolean from './boolean';
 import number from './number';
@@ -27,5 +27,32 @@ const propTypeControls: {
   HorizontalAlign,
   VerticalAlign,
 };
+
+function getDefaultControlForType(propType: PropValueType): React.FC<EditorProps<any>> | null {
+  switch (propType.type) {
+    case 'string':
+      return propType.enum ? select : string;
+    case 'number':
+      return number;
+    case 'boolean':
+      return boolean;
+    case 'object':
+      return json;
+    case 'array':
+      return json;
+    case 'event':
+      return event;
+    default:
+      return null;
+  }
+}
+
+export function getDefaultControl(argType: ArgTypeDefinition): React.FC<EditorProps<any>> | null {
+  if (argType.control) {
+    return propTypeControls[argType.control.type] ?? getDefaultControlForType(argType.typeDef);
+  }
+
+  return getDefaultControlForType(argType.typeDef);
+}
 
 export default propTypeControls;

--- a/packages/toolpad-app/src/toolpad/propertyControls/json.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/json.tsx
@@ -18,7 +18,7 @@ const JsonEditor = lazyComponent(() => import('../../components/JsonEditor'), {
   fallback: <Skeleton variant="rectangular" height="100%" />,
 });
 
-function JsonPropEditor({ label, argType, value, onChange, disabled }: EditorProps<any>) {
+function JsonPropEditor({ label, propType, value, onChange, disabled }: EditorProps<any>) {
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
   const valueAsString = React.useMemo(() => JSON.stringify(value, null, 2), [value]);
@@ -43,9 +43,7 @@ function JsonPropEditor({ label, argType, value, onChange, disabled }: EditorPro
   }, [onChange, input]);
 
   const schemaUri =
-    argType.typeDef.type === 'object' || argType.typeDef.type === 'array'
-      ? argType.typeDef.schema
-      : undefined;
+    propType.type === 'object' || propType.type === 'array' ? propType.schema : undefined;
 
   useShortcut({ code: 'KeyS', metaKey: true, disabled: !dialogOpen }, handleSave);
 

--- a/packages/toolpad-app/src/toolpad/propertyControls/select.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/select.tsx
@@ -2,8 +2,8 @@ import { MenuItem, TextField } from '@mui/material';
 import * as React from 'react';
 import type { EditorProps } from '../../types';
 
-function SelectPropEditor({ label, argType, value, onChange, disabled }: EditorProps<string>) {
-  const items = argType.typeDef.type === 'string' ? argType.typeDef.enum ?? [] : [];
+function SelectPropEditor({ label, propType, value, onChange, disabled }: EditorProps<string>) {
+  const items = propType.type === 'string' ? propType.enum ?? [] : [];
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       onChange(event.target.value);

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -1,7 +1,6 @@
 import type * as React from 'react';
 import { NextApiRequest, NextApiResponse } from 'next';
 import {
-  ArgTypeDefinition,
   SlotType,
   RuntimeError,
   ComponentConfig,

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -8,6 +8,7 @@ import {
   BindableAttrValues,
   LiveBinding,
   NodeId,
+  PropValueType,
 } from '@mui/toolpad-core';
 
 import { PaletteMode } from '@mui/material';
@@ -21,7 +22,7 @@ export interface EditorProps<T> {
    */
   nodeId?: NodeId;
   label: string;
-  argType: ArgTypeDefinition;
+  propType: PropValueType;
   disabled?: boolean;
   value: T | undefined;
   onChange: (newValue: T) => void;


### PR DESCRIPTION
Generalize the default control logic from the `NodeAttributeEditor` to the `BindableEditor` that it wraps so that we can use the logic more broadly.

extracted from https://github.com/mui/mui-toolpad/pull/696 to review in isolation
