### PR TITLE
Make DataTable vertically resizeable

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeHud.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeHud.tsx
@@ -8,6 +8,7 @@ import {
   absolutePositionCss,
   Rectangle,
   RectangleEdge,
+  RECTANGLE_EDGE_BOTTOM,
   RECTANGLE_EDGE_LEFT,
   RECTANGLE_EDGE_RIGHT,
 } from '../../../utils/geometry';
@@ -67,6 +68,7 @@ const DraggableEdge = styled('div', {
   let dynamicStyles = {};
   if (edge === RECTANGLE_EDGE_RIGHT) {
     dynamicStyles = {
+      cursor: 'ew-resize',
       top: 0,
       right: -2,
       height: '100%',
@@ -75,16 +77,25 @@ const DraggableEdge = styled('div', {
   }
   if (edge === RECTANGLE_EDGE_LEFT) {
     dynamicStyles = {
+      cursor: 'ew-resize',
       top: 0,
       left: -2,
       height: '100%',
       width: 12,
     };
   }
+  if (edge === RECTANGLE_EDGE_BOTTOM) {
+    dynamicStyles = {
+      cursor: 'ns-resize',
+      bottom: -2,
+      height: 12,
+      left: 0,
+      width: '100%',
+    };
+  }
 
   return {
     ...dynamicStyles,
-    cursor: 'ew-resize',
     position: 'absolute',
     pointerEvents: 'initial',
     zIndex: 1,

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel.tsx
@@ -69,7 +69,8 @@ const overlayClasses = {
   nodeHud: 'Toolpad_NodeHud',
   container: 'Toolpad_Container',
   componentDragging: 'Toolpad_ComponentDragging',
-  resize: 'Toolpad_Resize',
+  resizeHorizontal: 'Toolpad_ResizeHorizontal',
+  resizeVertical: 'Toolpad_ResizeVertical',
   hudOverlay: 'Toolpad_HudOverlay',
 };
 
@@ -83,8 +84,11 @@ const OverlayRoot = styled('div')({
   [`&.${overlayClasses.componentDragging}`]: {
     cursor: 'copy',
   },
-  [`&.${overlayClasses.resize}`]: {
+  [`&.${overlayClasses.resizeHorizontal}`]: {
     cursor: 'ew-resize',
+  },
+  [`&.${overlayClasses.resizeVertical}`]: {
+    cursor: 'ns-resize',
   },
   [`.${overlayClasses.hudOverlay}`]: {
     position: 'absolute',
@@ -1508,7 +1512,10 @@ export default function RenderPanel({ className }: RenderPanelProps) {
           <OverlayRoot
             className={clsx({
               [overlayClasses.componentDragging]: isDraggingOver,
-              [overlayClasses.resize]: draggedEdge,
+              [overlayClasses.resizeHorizontal]:
+                draggedEdge === RECTANGLE_EDGE_LEFT || draggedEdge === RECTANGLE_EDGE_RIGHT,
+              [overlayClasses.resizeVertical]:
+                draggedEdge === RECTANGLE_EDGE_TOP || draggedEdge === RECTANGLE_EDGE_BOTTOM,
             })}
             // Need this to be able to capture key events
             tabIndex={0}

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -132,6 +132,7 @@ interface Selection {
 interface ToolpadDataGridProps extends Omit<DataGridProProps, 'columns' | 'rows' | 'error'> {
   rows?: GridRowsProp;
   columns?: GridColumns;
+  height?: number;
   rowIdField?: string;
   error?: Error | string;
   selection?: Selection | null;
@@ -142,6 +143,7 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
   {
     columns: columnsProp,
     rows: rowsProp,
+    height: heightProp,
     rowIdField: rowIdFieldProp,
     error: errorProp,
     selection,
@@ -250,24 +252,28 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
   const columns: GridColumns = columnsProp || EMPTY_COLUMNS;
 
   return (
-    <div ref={ref} style={{ height: 350, width: '100%' }}>
-      <DataGridPro
-        components={{ Toolbar: GridToolbar, LoadingOverlay: SkeletonLoadingOverlay }}
-        onColumnResize={handleResize}
-        onColumnOrderChange={handleColumnOrderChange}
-        rows={rows}
-        columns={columns}
-        key={rowIdFieldProp}
-        getRowId={getRowId}
-        onSelectionModelChange={onSelectionModelChange}
-        selectionModel={selectionModel}
-        error={errorProp}
-        componentsProps={{
-          errorOverlay: { message: typeof errorProp === 'string' ? errorProp : errorProp?.message },
-        }}
-        {...props}
-      />
-    </div>
+    <Box>
+      <div ref={ref} style={{ height: heightProp, minHeight: '100%', width: '100%' }}>
+        <DataGridPro
+          components={{ Toolbar: GridToolbar, LoadingOverlay: SkeletonLoadingOverlay }}
+          onColumnResize={handleResize}
+          onColumnOrderChange={handleColumnOrderChange}
+          rows={rows}
+          columns={columns}
+          key={rowIdFieldProp}
+          getRowId={getRowId}
+          onSelectionModelChange={onSelectionModelChange}
+          selectionModel={selectionModel}
+          error={errorProp}
+          componentsProps={{
+            errorOverlay: {
+              message: typeof errorProp === 'string' ? errorProp : errorProp?.message,
+            },
+          }}
+          {...props}
+        />
+      </div>
+    </Box>
   );
 });
 
@@ -275,6 +281,7 @@ export default createComponent(DataGridComponent, {
   errorProp: 'error',
   loadingPropSource: ['rows', 'columns'],
   loadingProp: 'loading',
+  resizableHeightProp: 'height',
   argTypes: {
     rows: {
       typeDef: { type: 'array', schema: '/schemas/DataGridRows.json' },
@@ -286,6 +293,10 @@ export default createComponent(DataGridComponent, {
     density: {
       typeDef: { type: 'string', enum: ['compact', 'standard', 'comfortable'] },
       defaultValue: 'compact',
+    },
+    height: {
+      typeDef: { type: 'number' },
+      defaultValue: 350,
     },
     sx: {
       typeDef: { type: 'object' },

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -223,6 +223,11 @@ export interface ComponentConfig<P> {
    */
   loadingProp?: keyof P & string;
   /**
+   * Designates a property as "the resizable height property". If Toolpad detects any vertical resizing of
+   * the component it will forward it to this property.
+   */
+  resizableHeightProp?: keyof P & string;
+  /**
    * Describes the individual properties for this component
    */
   argTypes: ArgTypeDefinitions<P>;


### PR DESCRIPTION
- Support vertically resizable components with `resizableHeightProp`
- Make DataGrid component resizable

https://user-images.githubusercontent.com/10789765/181601843-ea00c7ef-c9b0-4d68-8a10-8d02c747782d.mov
(cursor while dragging is wrong in the video but fixed already)

