### PR TITLE
Fix interferring monaco editor instances

### DIFF
--- a/packages/toolpad-app/src/components/JsonEditor.tsx
+++ b/packages/toolpad-app/src/components/JsonEditor.tsx
@@ -7,7 +7,7 @@ import type * as monaco from 'monaco-editor';
 import MonacoEditor, { MonacoEditorProps } from './MonacoEditor';
 
 export interface JsonEditorProps
-  extends Omit<MonacoEditorProps, 'language' | 'diagnostics' | 'extraLibs'> {
+  extends Omit<MonacoEditorProps, 'language' | 'diagnostics' | 'extraLibs' | 'compilerOptions'> {
   schemaUri?: string;
 }
 

--- a/packages/toolpad-app/src/components/JsonEditor.tsx
+++ b/packages/toolpad-app/src/components/JsonEditor.tsx
@@ -3,17 +3,17 @@
  */
 
 import * as React from 'react';
-import MonacoEditor, { MonacoEditorHandle, MonacoEditorProps } from './MonacoEditor';
+import type * as monaco from 'monaco-editor';
+import MonacoEditor, { MonacoEditorProps } from './MonacoEditor';
 
-export interface JsonEditorProps extends Omit<MonacoEditorProps, 'language'> {
+export interface JsonEditorProps
+  extends Omit<MonacoEditorProps, 'language' | 'diagnostics' | 'extraLibs'> {
   schemaUri?: string;
 }
 
 export default function JsonEditor({ schemaUri, ...props }: JsonEditorProps) {
-  const editorRef = React.useRef<MonacoEditorHandle>(null);
-
-  React.useEffect(() => {
-    editorRef.current?.monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+  const diagnostics = React.useMemo<monaco.languages.json.DiagnosticsOptions>(
+    () => ({
       validate: true,
       schemaRequest: 'error',
       enableSchemaRequest: true,
@@ -25,8 +25,9 @@ export default function JsonEditor({ schemaUri, ...props }: JsonEditorProps) {
             },
           ]
         : [],
-    });
-  }, [schemaUri]);
+    }),
+    [schemaUri],
+  );
 
-  return <MonacoEditor ref={editorRef} language="json" {...props} />;
+  return <MonacoEditor language="json" diagnostics={diagnostics} {...props} />;
 }

--- a/packages/toolpad-app/src/components/MonacoEditor.tsx
+++ b/packages/toolpad-app/src/components/MonacoEditor.tsx
@@ -71,27 +71,28 @@ window.MonacoEnvironment = {
   },
 } as monaco.Environment;
 
+function registerLanguage(
+  langId: string,
+  language: monaco.languages.IMonarchLanguage,
+  conf: monaco.languages.LanguageConfiguration,
+) {
+  monaco.languages.register({ id: langId });
+  monaco.languages.registerTokensProviderFactory(langId, {
+    create: async (): Promise<monaco.languages.IMonarchLanguage> => language,
+  });
+  monaco.languages.onLanguage(langId, async () => {
+    monaco.languages.setLanguageConfiguration(langId, conf);
+  });
+}
+
 /**
  * Monaco language services are singletons, we can't set language options per editor instance.
  * We're working around this limitiation by only considering diagnostics for the focused editor.
  * Unfocused editors will be configured with a syntax-coloring-only language which are registered below.
  * See https://github.com/microsoft/monaco-editor/issues/1105
  */
-monaco.languages.register({ id: 'jsonBasic' });
-monaco.languages.registerTokensProviderFactory('jsonBasic', {
-  create: async (): Promise<monaco.languages.IMonarchLanguage> => jsonBasicLanguage,
-});
-monaco.languages.onLanguage('jsonBasic', async () => {
-  monaco.languages.setLanguageConfiguration('jsonBasic', jsonBasicConf);
-});
-
-monaco.languages.register({ id: 'typescriptBasic' });
-monaco.languages.registerTokensProviderFactory('typescriptBasic', {
-  create: async (): Promise<monaco.languages.IMonarchLanguage> => typescriptBasicLanguage,
-});
-monaco.languages.onLanguage('typescriptBasic', async () => {
-  monaco.languages.setLanguageConfiguration('typescriptBasic', typescriptBasicConf);
-});
+registerLanguage('jsonBasic', jsonBasicLanguage, jsonBasicConf);
+registerLanguage('typescriptBasic', typescriptBasicLanguage, typescriptBasicConf);
 
 monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
   target: monaco.languages.typescript.ScriptTarget.Latest,

--- a/packages/toolpad-app/src/components/MonacoEditor.tsx
+++ b/packages/toolpad-app/src/components/MonacoEditor.tsx
@@ -107,10 +107,35 @@ monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
   typeRoots: ['node_modules/@types'],
 });
 
-monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+const JSON_DEFAULT_DIAGNOSTICS_OPTIONS: monaco.languages.json.DiagnosticsOptions = {};
+
+monaco.languages.json.jsonDefaults.setDiagnosticsOptions(JSON_DEFAULT_DIAGNOSTICS_OPTIONS);
+
+const TYPESCRIPT_DEFAULT_DIAGNOSTICS_OPTIONS: monaco.languages.typescript.DiagnosticsOptions = {
   noSemanticValidation: false,
   noSyntaxValidation: false,
-});
+};
+
+monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions(
+  TYPESCRIPT_DEFAULT_DIAGNOSTICS_OPTIONS,
+);
+
+const TYPESCRIPT_DEFAULT_COMPILER_OPTIONS: monaco.languages.typescript.CompilerOptions = {
+  target: monaco.languages.typescript.ScriptTarget.Latest,
+  allowNonTsExtensions: true,
+  moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+  module: monaco.languages.typescript.ModuleKind.CommonJS,
+  noEmit: true,
+  esModuleInterop: true,
+  jsx: monaco.languages.typescript.JsxEmit.React,
+  reactNamespace: 'React',
+  allowJs: true,
+  typeRoots: ['node_modules/@types'],
+};
+
+monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
+  TYPESCRIPT_DEFAULT_COMPILER_OPTIONS,
+);
 
 const classes = {
   monacoHost: 'Toolpad_MonacoEditorMonacoHost',
@@ -181,16 +206,19 @@ export type MonacoEditorProps = MonacoEditorBaseProps &
     | {
         language?: 'typescript' | undefined;
         diagnostics?: monaco.languages.typescript.DiagnosticsOptions;
+        compilerOptions?: monaco.languages.typescript.CompilerOptions | undefined;
         extraLibs?: ExtraLib[];
       }
     | {
         language: 'json';
         diagnostics?: monaco.languages.json.DiagnosticsOptions;
+        compilerOptions?: undefined;
         extraLibs?: undefined;
       }
     | {
         language: 'css';
         diagnostics?: undefined;
+        compilerOptions?: undefined;
         extraLibs?: undefined;
       }
   );
@@ -202,6 +230,7 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
     sx,
     language = 'typescript',
     diagnostics,
+    compilerOptions,
     extraLibs,
     onFocus,
     onBlur,
@@ -232,18 +261,24 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
     if (language === 'json') {
       if (isFocused) {
         monaco.editor.setModelLanguage(model, 'json');
-        monaco.languages.json.jsonDefaults.setDiagnosticsOptions(
-          (diagnostics as monaco.languages.json.DiagnosticsOptions) || {},
-        );
+        monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+          ...JSON_DEFAULT_DIAGNOSTICS_OPTIONS,
+          ...(diagnostics as monaco.languages.json.DiagnosticsOptions),
+        });
       } else {
         monaco.editor.setModelLanguage(model, 'jsonBasic');
       }
     } else if (language === 'typescript') {
       if (isFocused) {
         monaco.editor.setModelLanguage(model, 'typescript');
-        monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions(
-          (diagnostics as monaco.languages.typescript.DiagnosticsOptions) || {},
-        );
+        monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+          ...TYPESCRIPT_DEFAULT_DIAGNOSTICS_OPTIONS,
+          ...(diagnostics as monaco.languages.typescript.DiagnosticsOptions),
+        });
+        monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+          ...TYPESCRIPT_DEFAULT_COMPILER_OPTIONS,
+          ...compilerOptions,
+        });
         monaco.languages.typescript.typescriptDefaults.setExtraLibs(extraLibs || []);
       } else {
         monaco.editor.setModelLanguage(model, 'typescriptBasic');
@@ -251,7 +286,7 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
     } else {
       monaco.editor.setModelLanguage(model, language);
     }
-  }, [isFocused, language, diagnostics, extraLibs]);
+  }, [isFocused, language, diagnostics, extraLibs, compilerOptions]);
 
   React.useEffect(() => {
     invariant(rootRef.current, 'Ref not attached');

--- a/packages/toolpad-app/src/components/TypescriptEditor.tsx
+++ b/packages/toolpad-app/src/components/TypescriptEditor.tsx
@@ -3,31 +3,22 @@
  */
 
 import * as React from 'react';
-import MonacoEditor, { MonacoEditorHandle, MonacoEditorProps } from './MonacoEditor';
+import type * as monaco from 'monaco-editor';
+import MonacoEditor, { MonacoEditorProps } from './MonacoEditor';
 
-export interface TypescriptEditorProps extends Omit<MonacoEditorProps, 'language'> {
+export interface TypescriptEditorProps extends Omit<MonacoEditorProps, 'language' | 'diagnostics'> {
   value: string;
   onChange: (newValue: string) => void;
-  extraLibs?: { content: string; filePath?: string }[];
   functionBody?: boolean;
 }
 
-export default function TypescriptEditor({
-  extraLibs,
-  functionBody,
-  ...props
-}: TypescriptEditorProps) {
-  const editorRef = React.useRef<MonacoEditorHandle>(null);
-
-  React.useEffect(() => {
-    editorRef.current?.monaco.languages.typescript.typescriptDefaults.setExtraLibs(extraLibs || []);
-  }, [extraLibs]);
-
-  React.useEffect(() => {
-    editorRef.current?.monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+export default function TypescriptEditor({ functionBody, ...props }: TypescriptEditorProps) {
+  const diagnostics = React.useMemo<monaco.languages.typescript.DiagnosticsOptions>(
+    () => ({
       diagnosticCodesToIgnore: functionBody ? [1108] : [],
-    });
-  }, [functionBody]);
+    }),
+    [functionBody],
+  );
 
-  return <MonacoEditor ref={editorRef} language="typescript" {...props} />;
+  return <MonacoEditor language="typescript" diagnostics={diagnostics} {...props} />;
 }

--- a/packages/toolpad-app/typings/monaco-editor.d.ts
+++ b/packages/toolpad-app/typings/monaco-editor.d.ts
@@ -1,0 +1,13 @@
+declare module 'monaco-editor/esm/vs/basic-languages/javascript/javascript' {
+  import type * as monaco from 'monaco-editor';
+
+  export const conf: monaco.languages.LanguageConfiguration;
+  export const language: monaco.languages.IMonarchLanguage;
+}
+
+declare module 'monaco-editor/esm/vs/basic-languages/typescript/typescript' {
+  import type * as monaco from 'monaco-editor';
+
+  export const conf: monaco.languages.LanguageConfiguration;
+  export const language: monaco.languages.IMonarchLanguage;
+}


### PR DESCRIPTION
monaco-editor can't set typescript options on a per-instance basis. This PR presents a workaround by reserving the `typescript` language for the focused editor only and have a `typescriptBasic` language with syntax highlighting only for non-focused editor instances. The trade-off is that errors in non-focused editors won't be shown underlined.

See https://github.com/microsoft/monaco-editor/issues/1105 for more background

Fixes https://github.com/mui/mui-toolpad/issues/704