### PR TITLE
Add console to component editor

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
@@ -140,6 +140,8 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
 
   const frameDocument = frameRef.current?.contentDocument;
 
+  
+
   const { Component: GeneratedComponent, error: compileError } = useCodeComponent(input);
 
   const CodeComponent: ToolpadComponent<any> = useLatest(GeneratedComponent) || Noop;
@@ -163,7 +165,18 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
           args: [compileError.stack],
         },
       ]
-    : [];
+    : [
+      {
+        timestamp: new Date().getTime(),
+          level: 'info',
+          // TODO: how to format this part?
+          args: ['testing'],
+      }
+    ];
+
+  const handleEditorChange = (newValue: string) => {
+    if (newValue) {setInput(newValue || '')}
+  }
 
   return (
     <React.Fragment>
@@ -175,7 +188,7 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
           <SplitPane split="vertical" allowResize size="50%">
             <TypescriptEditor
               value={input}
-              onChange={(newValue) => setInput(newValue || '')}
+              onChange={handleEditorChange}
               extraLibs={extraLibs}
             />
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Box, Button, Stack, styled, Toolbar, Typography } from '@mui/material';
+import { Box, Button, Stack, styled, Toolbar, Typography, Tab } from '@mui/material';
+import { TabList } from '@mui/lab';
 import { useParams } from 'react-router-dom';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
@@ -22,6 +23,7 @@ import ErrorAlert from '../PageEditor/ErrorAlert';
 import lazyComponent from '../../../utils/lazyComponent';
 import CenteredSpinner from '../../../components/CenteredSpinner';
 import SplitPane from '../../../components/SplitPane';
+import Console, { LogEntry } from '../../../components/Console';
 
 const TypescriptEditor = lazyComponent(() => import('../../../components/TypescriptEditor'), {
   noSsr: true,
@@ -148,6 +150,21 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
     [argTypes],
   );
 
+  if (compileError?.stack) {
+    console.log('error', compileError.stack);
+  }
+
+  const consoleLogs = compileError
+    ? [
+        {
+          timestamp: new Date().getTime(),
+          level: 'error',
+          // TODO: how to format this part?
+          args: [compileError.stack],
+        },
+      ]
+    : [];
+
   return (
     <React.Fragment>
       <Stack sx={{ height: '100%' }}>
@@ -162,7 +179,22 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
               extraLibs={extraLibs}
             />
 
-            <CanvasFrame ref={frameRef} title="Code component sandbox" onLoad={onLoad} />
+            <SplitPane split="horizontal" allowResize size="70%">
+              <CanvasFrame ref={frameRef} title="Code component sandbox" onLoad={onLoad} />
+
+              <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
+                <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                  <Tab label="Console" value="console" disabled />
+                </Box>
+                <Console
+                  sx={{ flex: 1 }}
+                  value={consoleLogs}
+                  onChange={() => {
+                    debugger;
+                  }}
+                />
+              </Box>
+            </SplitPane>
           </SplitPane>
         </Box>
         <Toolbar

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -94,6 +94,9 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
         // eslint-disable-next-line no-underscore-dangle
         frameWindow.__TOOLPAD_READY__ = () => onReadyRef.current?.();
       }
+
+      console.log('regular from app')
+      frameRef.current.contentWindow.console.log = (value) => {console.warn('nope', value)}
     }, []);
 
     const [contentWindow, setContentWindow] = React.useState<Window | null>(null);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

![image](https://user-images.githubusercontent.com/437214/181786514-d57cf6a1-6cdc-4b16-a99c-ce150e92458a.png)

@Janpot I've reached this point and decided to ask for your tips - do you know from top of your head how to convert component error to the error that could properly be displayed using our `Console` component? (I will continue on Monday to investigate that anyways)

The code piece that I'm talking about is here: https://github.com/mui/mui-toolpad/compare/add-console-to-component-editor?expand=1#diff-c62a305cf2c4d3061151e7204bb22074517a13b09120560ca43f13e86cbd04a6R163

Closes https://github.com/mui/mui-toolpad/issues/663