### PR TITLE
Allow scrolling the page when over the monaco editor

### DIFF
--- a/packages/toolpad-app/src/components/MonacoEditor.tsx
+++ b/packages/toolpad-app/src/components/MonacoEditor.tsx
@@ -280,15 +280,17 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
 
     const extraOptions: EditorOptions = {
       readOnly: disabled,
+      scrollbar: {
+        alwaysConsumeMouseWheel: false,
+        ...options?.scrollbar,
+      },
       ...options,
     };
 
     let instance = instanceRef.current;
 
     if (instance) {
-      if (extraOptions) {
-        instance.updateOptions(extraOptions);
-      }
+      instance.updateOptions(extraOptions);
 
       const model = instance.getModel();
       if (typeof value === 'string' && model) {


### PR DESCRIPTION
monaco editor swallows all scroll events by default, This doesn't work well when it's inlined in a body that scrolls as it interrupts the scroll when hovering the editor.