### PR TITLE
Release workflow continuation

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -26,9 +26,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Publish release tag
-        uses: akhilerm/tag-push-action@v2.0.0
-        with:
-          src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
-          dst: docker.io/muicom/toolpad:${{ github.event.inputs.docker_tag }}
+#      - name: Publish release tag
+#        uses: akhilerm/tag-push-action@v2.0.0
+#        with:
+#          src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
+#          dst: docker.io/muicom/toolpad:${{ github.event.inputs.docker_tag }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -6,9 +6,11 @@ on:
       commit:
         type: string
         required: true
-      docker_tag:
+      version:
         type: string
         required: true
+      latest:
+        type: boolean
 
 jobs:
   docker-release:
@@ -18,8 +20,8 @@ jobs:
       - name: Debug
         run: |
           echo "commit: ${{ github.event.inputs.commit }}"
-          echo "docker tag: ${{ github.event.inputs.docker_tag }}"
-          echo "prerelease:  ${{ github.event.release.prerelease }}"
+          echo "docker tag: ${{ github.event.inputs.version }}"
+          echo "latest:  ${{ github.event.release.latest }}"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -31,4 +33,11 @@ jobs:
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
-          dst: docker.io/muicom/toolpad:${{ github.event.inputs.docker_tag }}
+          dst: docker.io/muicom/toolpad:${{ github.event.inputs.version }}
+
+      - name: Publish release tag
+        uses: akhilerm/tag-push-action@v2.0.0
+        if: ${{ github.event.inputs.latest }}
+        with:
+          src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
+          dst: docker.io/muicom/toolpad:latest-test

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -29,13 +29,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish release tag
+      - name: Publish version tag
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
           dst: docker.io/muicom/toolpad:${{ github.event.inputs.version }}
 
-      - name: Publish release tag
+      - name: Publish latest tag
         uses: akhilerm/tag-push-action@v2.0.0
         if: ${{ github.event.inputs.latest }}
         with:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Publish latest tag
         uses: akhilerm/tag-push-action@v2.0.0
-        if: ${{ github.event.inputs.latest }}
+        if: ${{ github.event.inputs.latest == 'true' }}
         with:
           src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
           dst: docker.io/muicom/toolpad:latest-test

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -26,8 +26,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-#      - name: Publish release tag
-#        uses: akhilerm/tag-push-action@v2.0.0
-#        with:
-#          src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
-#          dst: docker.io/muicom/toolpad:${{ github.event.inputs.docker_tag }}
+
+      - name: Publish release tag
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
+          dst: docker.io/muicom/toolpad:${{ github.event.inputs.docker_tag }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -2,7 +2,7 @@ name: 'Release Docker images'
 
 on:
   workflow_dispatch:
-    input:
+    inputs:
       commit:
         type: string
         required: true

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "commit: ${{ github.event.inputs.commit }}"
           echo "docker tag: ${{ github.event.inputs.version }}"
-          echo "latest:  ${{ github.event.release.latest }}"
+          echo "latest:  ${{ toJSON(github.event.release.latest) }}"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -40,4 +40,4 @@ jobs:
         if: ${{ github.event.inputs.latest == 'true' }}
         with:
           src: docker.io/muicom/toolpad:${{ github.event.inputs.commit }}
-          dst: docker.io/muicom/toolpad:latest-test
+          dst: docker.io/muicom/toolpad:latest


### PR DESCRIPTION
Review the whole file: https://github.com/mui/mui-toolpad/blob/3b275b3b462acbbfa0e7af6849530b97f4a6a167/.github/workflows/release-docker.yml

Implements the first step of https://github.com/mui/mui-toolpad/issues/725
It can be triggered manually from the github UI

Some commits got push to master without reviewing to get the action available in the github UI