### PR TITLE
Prevent resizing row child element completely over adjacent element

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -1137,9 +1137,14 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
 
           const minGridColumnWidth = overlayGridRef.current.getMinColumnWidth();
 
+          const previousSibling = appDom.getSiblingBeforeNode(dom, draggedNode, 'children');
+          const previousSiblingInfo = previousSibling && nodesInfo[previousSibling.id];
+          const previousSiblingRect = previousSiblingInfo?.rect;
+
           if (
             draggedEdge === RECTANGLE_EDGE_LEFT &&
-            cursorPos.x > parentRect.x + minGridColumnWidth &&
+            cursorPos.x >
+              Math.max(parentRect.x, previousSiblingRect?.x || 0) + minGridColumnWidth &&
             cursorPos.x < draggedNodeRect.x + draggedNodeRect.width - minGridColumnWidth
           ) {
             const updatedTransformScale =
@@ -1148,10 +1153,20 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
             resizePreviewElement.style.transformOrigin = '100% 50%';
             resizePreviewElement.style.transform = `scaleX(${updatedTransformScale})`;
           }
+
+          const nextSibling = appDom.getSiblingAfterNode(dom, draggedNode, 'children');
+          const nextSiblingInfo = nextSibling && nodesInfo[nextSibling.id];
+          const nextSiblingRect = nextSiblingInfo?.rect;
+
           if (
             draggedEdge === RECTANGLE_EDGE_RIGHT &&
             cursorPos.x > draggedNodeRect.x + minGridColumnWidth &&
-            cursorPos.x < parentRect.x + parentRect.width - minGridColumnWidth
+            cursorPos.x <
+              Math.min(
+                parentRect.x + parentRect.width,
+                nextSiblingRect ? nextSiblingRect?.x + nextSiblingRect?.width : 0,
+              ) -
+                minGridColumnWidth
           ) {
             const updatedTransformScale = snappedToGridCursorRelativePosX / draggedNodeRect.width;
 


### PR DESCRIPTION
Previously it was possible to, while resizing an element horizontally, extend it completely over the element next to it - which leads to bugs and weird behavior.
This PR limits the resizing to the width of one column in the adjacent element.

Video ("before" in blue, "after" in red):

https://user-images.githubusercontent.com/10789765/182672426-d5ab35b5-1a7a-496b-8e70-1243b669cab6.mov


