### PR TITLE
Disallow creating columns in single-child rows

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -661,12 +661,6 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
         ? hasFreeNodeSlots(activeDropNodeInfo)
         : false;
 
-      const isDraggingOverOnlyPageRowChild =
-        activeDropNodeParent &&
-        appDom.isElement(activeDropNodeParent) &&
-        isPageRow(activeDropNodeParent) &&
-        activeDropNodeSiblings.length === 0;
-
       const activeDropSlotParentProp = isDraggingOverPage
         ? 'children'
         : activeDropAreaId && getDropAreaParentProp(activeDropAreaId);
@@ -755,15 +749,20 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
         activeDropZone !== dragOverZone;
 
       if (activeDropZone && hasChangedDropArea && availableDropTargetIds.has(activeDropNodeId)) {
-        const newDragOverNodeId =
-          isDraggingOverOnlyPageRowChild &&
-          (activeDropZone === DROP_ZONE_TOP || activeDropZone === DROP_ZONE_BOTTOM)
-            ? activeDropNodeParent.id
-            : activeDropNodeId;
+        const isDraggingOverOnlyPageRowChildVerticalZones =
+          activeDropNodeParent &&
+          appDom.isElement(activeDropNodeParent) &&
+          isPageRow(activeDropNodeParent) &&
+          activeDropNodeSiblings.length === 0 &&
+          (activeDropZone === DROP_ZONE_TOP || activeDropZone === DROP_ZONE_BOTTOM);
 
         api.nodeDragOver({
-          nodeId: newDragOverNodeId,
-          parentProp: activeDropSlotParentProp || null,
+          nodeId: isDraggingOverOnlyPageRowChildVerticalZones
+            ? activeDropNodeParent.id
+            : activeDropNodeId,
+          parentProp: isDraggingOverOnlyPageRowChildVerticalZones
+            ? 'children'
+            : activeDropSlotParentProp || null,
           zone: activeDropZone as DropZone,
         });
       }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -749,20 +749,19 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
         activeDropZone !== dragOverZone;
 
       if (activeDropZone && hasChangedDropArea && availableDropTargetIds.has(activeDropNodeId)) {
-        const isDraggingOverPageRowOnlyChildVerticalZones =
+        const isDragOverParentPageRow =
           activeDropNodeParent &&
           appDom.isElement(activeDropNodeParent) &&
-          isPageRow(activeDropNodeParent) &&
+          isPageRow(activeDropNodeParent);
+
+        const hasDragOverParentRowOverride =
+          isDragOverParentPageRow &&
           activeDropNodeSiblings.length === 0 &&
           (activeDropZone === DROP_ZONE_TOP || activeDropZone === DROP_ZONE_BOTTOM);
 
         api.nodeDragOver({
-          nodeId: isDraggingOverPageRowOnlyChildVerticalZones
-            ? activeDropNodeParent.id
-            : activeDropNodeId,
-          parentProp: isDraggingOverPageRowOnlyChildVerticalZones
-            ? 'children'
-            : activeDropSlotParentProp || null,
+          nodeId: hasDragOverParentRowOverride ? activeDropNodeParent.id : activeDropNodeId,
+          parentProp: hasDragOverParentRowOverride ? 'children' : activeDropSlotParentProp || null,
           zone: activeDropZone as DropZone,
         });
       }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -749,7 +749,7 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
         activeDropZone !== dragOverZone;
 
       if (activeDropZone && hasChangedDropArea && availableDropTargetIds.has(activeDropNodeId)) {
-        const isDraggingOverOnlyPageRowChildVerticalZones =
+        const isDraggingOverPageRowOnlyChildVerticalZones =
           activeDropNodeParent &&
           appDom.isElement(activeDropNodeParent) &&
           isPageRow(activeDropNodeParent) &&
@@ -757,10 +757,10 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
           (activeDropZone === DROP_ZONE_TOP || activeDropZone === DROP_ZONE_BOTTOM);
 
         api.nodeDragOver({
-          nodeId: isDraggingOverOnlyPageRowChildVerticalZones
+          nodeId: isDraggingOverPageRowOnlyChildVerticalZones
             ? activeDropNodeParent.id
             : activeDropNodeId,
-          parentProp: isDraggingOverOnlyPageRowChildVerticalZones
+          parentProp: isDraggingOverPageRowOnlyChildVerticalZones
             ? 'children'
             : activeDropSlotParentProp || null,
           zone: activeDropZone as DropZone,


### PR DESCRIPTION
Disallow dropping an element in the top or bottom zones of another element if the target element is the only child of a row - make it so that if the user tries to do that, the element is added in a new row above or below, instead of creating a new column with both elements.
This solves issues such as a difficult to predict behavior when placing elements in the root level of a page, where it's possible to create unnecessary columns without realizing it.

**Video**: 
Before (red) - cursor position shifts a lot, as element can be placed in new column with the element, or in the root  page directly
After (green) - cursor position is much more stable and predictable, as element can only be placed in root page directly

https://user-images.githubusercontent.com/10789765/182689525-54b449ac-23a0-455d-8751-4376fdeedaa4.mov


