### PR TITLE
Refactor har generation utilities for reuse

### DIFF
--- a/packages/toolpad-app/src/toolpadDataSources/function/runtime/types.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/function/runtime/types.ts
@@ -3,7 +3,7 @@ import type * as ivm from 'isolated-vm';
 export interface FetchOptions {
   headers: [string, string][];
   method: string;
-  mode?: string;
+  mode?: RequestMode;
   body?: string;
 }
 

--- a/packages/toolpad-app/src/utils/har.spec.ts
+++ b/packages/toolpad-app/src/utils/har.spec.ts
@@ -1,0 +1,46 @@
+import fetch from 'node-fetch';
+import { createHarLog, withHarInstrumentation } from './har';
+import { streamToString } from './streams';
+import { startServer } from './tests';
+
+describe('har', () => {
+  test('headers in array form', async () => {
+    const { port, stopServer } = await startServer(async (req, res) => {
+      res.write(
+        JSON.stringify({
+          body: await streamToString(req),
+          method: req.method,
+          headers: req.headers,
+        }),
+      );
+      res.end();
+    });
+
+    try {
+      const har = createHarLog();
+      const instruentedfetch = withHarInstrumentation(fetch, { har });
+
+      const res = await instruentedfetch(`http://localhost:${port}`, {
+        headers: [['foo', 'bar']],
+        method: 'POST',
+        body: 'baz',
+      });
+
+      expect(res.ok).toBeTruthy();
+
+      const body = await res.json();
+
+      expect(body).toEqual(
+        expect.objectContaining({
+          body: 'baz',
+          method: 'POST',
+          headers: expect.objectContaining({
+            foo: 'bar',
+          }),
+        }),
+      );
+    } finally {
+      await stopServer();
+    }
+  });
+});

--- a/packages/toolpad-app/src/utils/har.ts
+++ b/packages/toolpad-app/src/utils/har.ts
@@ -1,0 +1,30 @@
+import { withHar as withHarOriginal } from 'node-fetch-har';
+import fetch, { Request } from 'node-fetch';
+
+const withHarInstrumentation: typeof withHarOriginal = function withHar(fetchFn, options) {
+  const withHarFetch = withHarOriginal(fetchFn, options);
+
+  const patchedfetch = (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> => {
+    // node-fetch-har doesn't deal well with certain ways of passing parameters e.g. passing headers as [string, string][]
+    // We're normalizing them here to a format that we know it can handle correctly:
+    const req = new Request(...args);
+    const input = req.url;
+    return withHarFetch(input, {
+      agent: req.agent,
+      body: req.body,
+      compress: req.compress,
+      follow: req.follow,
+      headers: req.headers,
+      method: req.method,
+      redirect: req.redirect,
+    });
+  };
+
+  patchedfetch.isRedirect = fetch.isRedirect;
+
+  return patchedfetch;
+};
+
+export { createHarLog } from 'node-fetch-har';
+export type { WithHarOptions } from 'node-fetch-har';
+export { withHarInstrumentation };

--- a/packages/toolpad-app/src/utils/streams.ts
+++ b/packages/toolpad-app/src/utils/streams.ts
@@ -1,0 +1,10 @@
+import { Readable } from 'stream';
+
+export function streamToString(stream: Readable) {
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    stream.on('error', (err) => reject(err));
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+  });
+}

--- a/packages/toolpad-app/src/utils/tests.ts
+++ b/packages/toolpad-app/src/utils/tests.ts
@@ -1,0 +1,31 @@
+import * as http from 'http';
+import getPort from 'get-port';
+
+export async function startServer(handler?: http.RequestListener) {
+  const server = http.createServer(handler);
+  const port = await getPort({ port: 3000 });
+  let app: http.Server | undefined;
+  await new Promise((resolve, reject) => {
+    app = server.listen(port);
+    app.once('listening', resolve);
+    app.once('error', reject);
+  });
+  return {
+    port,
+    async stopServer() {
+      await new Promise<void>((resolve, reject) => {
+        if (app) {
+          app.close((err) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
+        } else {
+          resolve();
+        }
+      });
+    },
+  };
+}

--- a/packages/toolpad-app/typings/node-fetch-har.d.ts
+++ b/packages/toolpad-app/typings/node-fetch-har.d.ts
@@ -1,10 +1,11 @@
 declare module 'node-fetch-har' {
   import { Har } from 'har-format';
+  import fetch from 'node-fetch';
 
   export interface WithHarOptions {
     har?: Har;
   }
 
-  export function withHar(fetch: typeof fetch, options?: WithHarOptions): typeof fetch;
+  export function withHar(fetchFn: typeof fetch, options?: WithHarOptions): typeof fetch;
   export function createHarLog(): Har;
 }


### PR DESCRIPTION
We'll need this for instrumentation of the fetch dataSource
The lib we use isn't dealing well with all inputs fetch accepts. Extracting a wrapper that corrects this. To be reused in the rest datasource.
Also add a test case for the behavior it tries to correct