### PR TITLE
Only overwrite the default value when a prop has a binding

### DIFF
--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -419,6 +419,7 @@ function parseBindings(
         const bindingId = `${elm.id}.props.${propName}`;
         const scopePath =
           componentId === PAGE_ROW_COMPONENT_ID ? undefined : `${elm.name}.${propName}`;
+
         if (argType) {
           parsedBindingsMap.set(bindingId, {
             scopePath,
@@ -441,7 +442,7 @@ function parseBindings(
               scopePath,
               result: { value: defaultValue },
             });
-          } else {
+          } else if (binding) {
             parsedBindingsMap.set(bindingId, parseBinding(binding, scopePath));
           }
         }


### PR DESCRIPTION
Fixes https://github.com/mui/mui-toolpad/issues/755

Introduced by https://github.com/mui/mui-toolpad/pull/696. The conditional is not equivalent, (the optional chaining introduces a hidden `else` case that wasn't accounted for).

We should add an integration test that guards basic editor functionality https://github.com/mui/mui-toolpad/issues/758