### PR TITLE
Make network panel clearable 

### DIFF
--- a/packages/toolpad-app/src/components/Console.tsx
+++ b/packages/toolpad-app/src/components/Console.tsx
@@ -1,7 +1,6 @@
-import { darken, IconButton, lighten, styled, SxProps } from '@mui/material';
+import { darken, lighten, styled, SxProps } from '@mui/material';
 import clsx from 'clsx';
 import * as React from 'react';
-import DoDisturbIcon from '@mui/icons-material/DoDisturb';
 import Inspector, { InspectorProps } from 'react-inspector';
 import inspectorTheme from '../inspectorTheme';
 import { interleave } from '../utils/react';
@@ -13,7 +12,6 @@ export interface LogEntry {
 }
 
 const classes = {
-  header: 'Toolpad_ConsoleHeader',
   logEntriesContainer: 'Toolpad_ConsoleLogEntriesContainer',
   logEntries: 'Toolpad_ConsoleLogEntries',
   logEntry: 'Toolpad_ConsoleLogEntry',
@@ -37,11 +35,6 @@ const ConsoleRoot = styled('div')(({ theme }) => {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'stretch',
-
-    [`& .${classes.header}`]: {
-      padding: theme.spacing('2px', 1),
-      borderBottom: `1px solid ${theme.palette.divider}`,
-    },
 
     [`& .${classes.logEntriesContainer}`]: {
       flex: 1,
@@ -116,19 +109,11 @@ function ConsoleEntry({ entry }: ConsoleEntryProps) {
 interface ConsoleProps {
   sx?: SxProps;
   value?: LogEntry[];
-  onChange?: (logEntries: LogEntry[]) => void;
 }
 
-export default function Console({ value = [], onChange, sx }: ConsoleProps) {
+export default function Console({ value = [], sx }: ConsoleProps) {
   return (
     <ConsoleRoot sx={sx}>
-      <div className={classes.header}>
-        {onChange ? (
-          <IconButton disabled={value.length <= 0} onClick={() => onChange([])}>
-            <DoDisturbIcon />
-          </IconButton>
-        ) : null}
-      </div>
       <div className={classes.logEntriesContainer}>
         <div className={classes.logEntries}>
           {value.map((entry, i) => (

--- a/packages/toolpad-app/src/components/Devtools.tsx
+++ b/packages/toolpad-app/src/components/Devtools.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { TabPanel, TabContext, TabList } from '@mui/lab';
-import { Box, styled, SxProps, Tab } from '@mui/material';
+import { Box, IconButton, styled, SxProps, Tab } from '@mui/material';
 import { Har } from 'har-format';
+import DoDisturbIcon from '@mui/icons-material/DoDisturb';
 import Console, { LogEntry } from './Console';
 import lazyComponent from '../utils/lazyComponent';
 
@@ -11,12 +12,13 @@ const DebuggerTabPanel = styled(TabPanel)({ padding: 0, flex: 1, minHeight: 0 })
 
 export interface DevtoolsProps {
   log?: LogEntry[];
-  onLogChange?: (newLog: LogEntry[]) => void;
+  onLogClear?: () => void;
   har?: Har;
+  onHarClear?: () => void;
   sx?: SxProps;
 }
 
-export default function Devtools({ sx, log, onLogChange, har }: DevtoolsProps) {
+export default function Devtools({ sx, log, onLogClear, har, onHarClear }: DevtoolsProps) {
   const [activeTab, setActiveTab] = React.useState(() => {
     if (log) {
       return 'console';
@@ -26,27 +28,67 @@ export default function Devtools({ sx, log, onLogChange, har }: DevtoolsProps) {
     }
     return '';
   });
+
   const handleDebuggerTabChange = (event: React.SyntheticEvent, newValue: string) => {
     setActiveTab(newValue);
   };
 
+  const logLength = log?.length ?? 0;
+  const harLength = har?.log.entries.length ?? 0;
+
+  const clearEnabled: boolean = React.useMemo(() => {
+    switch (activeTab) {
+      case 'console':
+        return logLength > 0;
+      case 'network':
+        return harLength > 0;
+      default:
+        throw new Error(`Missing swotch case ${activeTab}`);
+    }
+  }, [activeTab, harLength, logLength]);
+
+  const handleClearClick = React.useCallback(() => {
+    switch (activeTab) {
+      case 'console':
+        return onLogClear?.();
+      case 'network':
+        return onHarClear?.();
+      default:
+        throw new Error(`Missing swotch case ${activeTab}`);
+    }
+  }, [activeTab, onHarClear, onLogClear]);
+
   return (
     <Box sx={{ ...sx, display: 'flex', flexDirection: 'column' }}>
       <TabContext value={activeTab}>
-        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Box
+          sx={{
+            borderBottom: 1,
+            borderColor: 'divider',
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            pr: 1,
+          }}
+        >
           <TabList onChange={handleDebuggerTabChange} aria-label="Debugger">
             {log ? <Tab label="Console" value="console" /> : null}
             {har ? <Tab label="Network" value="network" /> : null}
           </TabList>
+          {handleClearClick ? (
+            <IconButton disabled={!clearEnabled} onClick={handleClearClick}>
+              <DoDisturbIcon />
+            </IconButton>
+          ) : null}
         </Box>
         {log ? (
           <DebuggerTabPanel value="console">
-            <Console sx={{ flex: 1 }} value={log} onChange={onLogChange} />
+            <Console sx={{ flex: 1 }} value={log} />
           </DebuggerTabPanel>
         ) : null}
         {har ? (
           <DebuggerTabPanel value="network">
-            <HarViewer har={har} />
+            <HarViewer sx={{ flex: 1 }} value={har} />
           </DebuggerTabPanel>
         ) : null}
       </TabContext>

--- a/packages/toolpad-app/src/components/HarViewer.tsx
+++ b/packages/toolpad-app/src/components/HarViewer.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Har } from 'har-format';
 import { styled, SxProps } from '@mui/material';
 import 'perf-cascade/dist/perf-cascade.css';
+import { createHarLog } from '../utils/har';
 
 const HarViewerRoot = styled('div')({});
 
@@ -11,17 +12,17 @@ function fixLinks(elm: Element) {
 }
 
 export interface HarViewerProps {
-  har?: Har;
+  value?: Har;
   sx?: SxProps;
 }
 
-export default function HarViewer({ har, sx }: HarViewerProps) {
+export default function HarViewer({ value = createHarLog(), sx }: HarViewerProps) {
   const rootRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     const root = rootRef.current;
-    if (har && root) {
-      const svg = fromHar(har);
+    if (value && value.log.entries.length > 0 && root) {
+      const svg = fromHar(value);
       fixLinks(svg);
 
       const observer = new MutationObserver((entries) => {
@@ -46,7 +47,7 @@ export default function HarViewer({ har, sx }: HarViewerProps) {
       };
     }
     return () => {};
-  }, [har]);
+  }, [value]);
 
   return <HarViewerRoot ref={rootRef} sx={sx} />;
 }

--- a/packages/toolpad-app/src/server/har.spec.ts
+++ b/packages/toolpad-app/src/server/har.spec.ts
@@ -1,8 +1,8 @@
 import fetch from 'node-fetch';
-import { withHarInstrumentation } from '../server/har';
-import { createHarLog } from './har';
-import { streamToString } from './streams';
-import { startServer } from './tests';
+import { withHarInstrumentation } from './har';
+import { createHarLog } from '../utils/har';
+import { streamToString } from '../utils/streams';
+import { startServer } from '../utils/tests';
 
 describe('har', () => {
   test('headers in array form', async () => {

--- a/packages/toolpad-app/src/server/har.spec.ts
+++ b/packages/toolpad-app/src/server/har.spec.ts
@@ -1,6 +1,5 @@
 import fetch from 'node-fetch';
-import { withHarInstrumentation } from './har';
-import { createHarLog } from '../utils/har';
+import { createHarLog, withHarInstrumentation } from './har';
 import { streamToString } from '../utils/streams';
 import { startServer } from '../utils/tests';
 

--- a/packages/toolpad-app/src/server/har.ts
+++ b/packages/toolpad-app/src/server/har.ts
@@ -1,0 +1,29 @@
+import { withHar as withHarOriginal } from 'node-fetch-har';
+import fetch, { Request } from 'node-fetch';
+
+const withHarInstrumentation: typeof withHarOriginal = function withHar(fetchFn, options) {
+  const withHarFetch = withHarOriginal(fetchFn, options);
+
+  const patchedfetch = (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> => {
+    // node-fetch-har doesn't deal well with certain ways of passing parameters e.g. passing headers as [string, string][]
+    // We're normalizing them here to a format that we know it can handle correctly:
+    const req = new Request(...args);
+    const input = req.url;
+    return withHarFetch(input, {
+      agent: req.agent,
+      body: req.body,
+      compress: req.compress,
+      follow: req.follow,
+      headers: req.headers,
+      method: req.method,
+      redirect: req.redirect,
+    });
+  };
+
+  patchedfetch.isRedirect = fetch.isRedirect;
+
+  return patchedfetch;
+};
+
+export { createHarLog } from '../utils/har';
+export { withHarInstrumentation };

--- a/packages/toolpad-app/src/toolpadDataSources/function/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/function/client.tsx
@@ -15,8 +15,7 @@ import {
 import lazyComponent from '../../utils/lazyComponent';
 import ParametersEditor from '../../toolpad/AppEditor/PageEditor/ParametersEditor';
 import SplitPane from '../../components/SplitPane';
-import { useConnectionContext, usePrivateQuery } from '../context';
-import client from '../../api';
+import { usePrivateQuery } from '../context';
 import JsonView from '../../components/JsonView';
 import ErrorAlert from '../../toolpad/AppEditor/PageEditor/ErrorAlert';
 import { LogEntry } from '../../components/Console';
@@ -24,6 +23,8 @@ import MapEntriesEditor from '../../components/MapEntriesEditor';
 import { Maybe } from '../../utils/types';
 import { isSaveDisabled } from '../../utils/forms';
 import Devtools from '../../components/Devtools';
+import { createHarLog, mergeHar } from '../../utils/har';
+import useQueryPreview from '../useQueryPreview';
 
 const EVENT_INTERFACE_IDENTIFIER = 'ToolpadFunctionEvent';
 
@@ -120,39 +121,26 @@ function QueryEditor({
     liveParams[key],
   ]);
 
-  const { appId, connectionId } = useConnectionContext();
-  const [preview, setPreview] = React.useState<FunctionResult | null>(null);
+  const previewParams = React.useMemo(
+    () => Object.fromEntries(paramsEditorLiveValue.map(([key, binding]) => [key, binding.value])),
+    [paramsEditorLiveValue],
+  );
+
   const [previewLogs, setPreviewLogs] = React.useState<LogEntry[]>([]);
-
-  const cancelRunPreview = React.useRef<(() => void) | null>(null);
-  const runPreview = React.useCallback(() => {
-    let canceled = false;
-
-    cancelRunPreview.current?.();
-    cancelRunPreview.current = () => {
-      canceled = true;
-    };
-
-    const currentParams = Object.fromEntries(
-      paramsEditorLiveValue.map(([key, binding]) => [key, binding.value]),
-    );
-
-    client.query
-      .dataSourceFetchPrivate(appId, connectionId, {
-        kind: 'debugExec',
-        query: value.query,
-        params: currentParams,
-      } as FunctionPrivateQuery)
-      .then((result) => {
-        if (!canceled) {
-          setPreview(result);
-          setPreviewLogs((existing) => [...existing, ...result.logs]);
-        }
-      })
-      .finally(() => {
-        cancelRunPreview.current = null;
-      });
-  }, [appId, connectionId, paramsEditorLiveValue, value.query]);
+  const [previewHar, setPreviewHar] = React.useState(() => createHarLog());
+  const { preview, runPreview } = useQueryPreview<FunctionPrivateQuery, FunctionResult>(
+    {
+      kind: 'debugExec',
+      query: value.query,
+      params: previewParams,
+    },
+    {
+      onPreview(result) {
+        setPreviewLogs((existing) => [...existing, ...result.logs]);
+        setPreviewHar((existing) => mergeHar(createHarLog(), existing, result.har));
+      },
+    },
+  );
 
   const { data: secretsKeys = [] } = usePrivateQuery<FunctionPrivateQuery, string[]>({
     kind: 'secretsKeys',
@@ -176,6 +164,9 @@ function QueryEditor({
 
     return [{ content, filePath: 'file:///node_modules/@mui/toolpad/index.d.ts' }];
   }, [params, secretsKeys]);
+
+  const handleLogClear = React.useCallback(() => setPreviewLogs([]), []);
+  const handleHarClear = React.useCallback(() => setPreviewHar(createHarLog()), []);
 
   return (
     <SplitPane split="vertical" size="50%" allowResize>
@@ -218,8 +209,9 @@ function QueryEditor({
         <Devtools
           sx={{ width: '100%', height: '100%' }}
           log={previewLogs}
-          onLogChange={setPreviewLogs}
-          har={preview?.har}
+          onLogClear={handleLogClear}
+          har={previewHar}
+          onHarClear={handleHarClear}
         />
       </SplitPane>
     </SplitPane>

--- a/packages/toolpad-app/src/toolpadDataSources/function/execFunction.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/function/execFunction.ts
@@ -1,7 +1,6 @@
 import ivm from 'isolated-vm';
 import * as esbuild from 'esbuild';
 import type * as harFormat from 'har-format';
-import { createHarLog } from 'node-fetch-har';
 import * as fs from 'fs/promises';
 import fetch from 'node-fetch';
 import * as path from 'path';
@@ -9,7 +8,7 @@ import { FunctionResult } from './types';
 import { LogEntry } from '../../components/Console';
 import { FetchOptions } from './runtime/types';
 import projectRoot from '../../server/projectRoot';
-import { withHarInstrumentation } from '../../utils/har';
+import { withHarInstrumentation, createHarLog } from '../../server/har';
 
 async function fetchRuntimeModule() {
   const filePath = path.resolve(projectRoot, './src/toolpadDataSources/function/dist/index.js');

--- a/packages/toolpad-app/src/utils/har.spec.ts
+++ b/packages/toolpad-app/src/utils/har.spec.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
-import { createHarLog, withHarInstrumentation } from './har';
+import { withHarInstrumentation } from '../server/har';
+import { createHarLog } from './har';
 import { streamToString } from './streams';
 import { startServer } from './tests';
 

--- a/packages/toolpad-app/typings/node-fetch-har.d.ts
+++ b/packages/toolpad-app/typings/node-fetch-har.d.ts
@@ -7,5 +7,4 @@ declare module 'node-fetch-har' {
   }
 
   export function withHar(fetchFn: typeof fetch, options?: WithHarOptions): typeof fetch;
-  export function createHarLog(): Har;
 }


### PR DESCRIPTION
Devtools update, extracted from https://github.com/mui/mui-toolpad/pull/737
- Don't clear network panel on every invocation
- Add clear button to the right of the tabs area to save vertical space
- allow clearing the network panel

![Screenshot 2022-08-08 at 18 09 48](https://user-images.githubusercontent.com/2109932/183463356-f62b1760-d94e-4fbc-901c-384b17136f75.png)

