### PR TITLE
Add AbortController to function runtime

### DIFF
--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -50,6 +50,7 @@
     "@types/prettier": "^2.4.3",
     "@types/react-dom": "^18.0.5",
     "@types/whatwg-url": "^8.2.2",
+    "abort-controller": "^3.0.0",
     "arg": "^5.0.1",
     "basic-auth": "^2.0.1",
     "clsx": "^1.2.0",

--- a/packages/toolpad-app/src/toolpadDataSources/QueryInputPanel.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/QueryInputPanel.tsx
@@ -10,7 +10,7 @@ export interface QueryInputPanelProps {
 
 export default function QueryInputPanel({ children, onRunPreview }: QueryInputPanelProps) {
   return (
-    <Box sx={{ height: '100%', overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+    <Box sx={{ height: '100%', overflow: 'auto' }}>
       <Toolbar>
         <LoadingButton startIcon={<PlayArrowIcon />} onClick={onRunPreview}>
           Preview

--- a/packages/toolpad-app/src/toolpadDataSources/QueryInputPanel.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/QueryInputPanel.tsx
@@ -10,7 +10,7 @@ export interface QueryInputPanelProps {
 
 export default function QueryInputPanel({ children, onRunPreview }: QueryInputPanelProps) {
   return (
-    <Box sx={{ height: '100%', overflow: 'auto' }}>
+    <Box sx={{ height: '100%', overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
       <Toolbar>
         <LoadingButton startIcon={<PlayArrowIcon />} onClick={onRunPreview}>
           Preview

--- a/packages/toolpad-app/src/toolpadDataSources/function/runtime/abortController.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/function/runtime/abortController.ts
@@ -1,0 +1,1 @@
+import 'abort-controller/polyfill';

--- a/packages/toolpad-app/src/toolpadDataSources/function/runtime/fetch.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/function/runtime/fetch.ts
@@ -14,8 +14,8 @@ import { ToolpadFunctionRuntimeBridge, FetchOptions } from './types';
 const TOOLPAD_BRIDGE: ToolpadFunctionRuntimeBridge = (global as any).TOOLPAD_BRIDGE;
 
 /* 
-TODO: Add Blob support. e.g. Satisfy the following invariant:
-
+TODO: Add Blob support? i.e. Satisfy the following invariant:
+We may not need it, given that's it's not part of https://wintercg.org/
 invariant(
   'FileReader' in global &&
     'Blob' in global &&
@@ -38,6 +38,7 @@ invariant('FormData' in global, 'FormData is required');
 invariant('Symbol' in global && 'iterator' in Symbol, 'Iterable is required');
 invariant('URLSearchParams' in global, 'URLSearchParams is required');
 invariant('AbortController' in global, 'AbortController is required');
+invariant('ReadableStream' in global, 'ReadableStream is required');
 
 function isDataView(obj: unknown): obj is DataView {
   return !!obj && obj instanceof DataView;

--- a/packages/toolpad-app/src/toolpadDataSources/function/runtime/fetch.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/function/runtime/fetch.ts
@@ -15,7 +15,7 @@ const TOOLPAD_BRIDGE: ToolpadFunctionRuntimeBridge = (global as any).TOOLPAD_BRI
 
 /* 
 TODO: Add Blob support? i.e. Satisfy the following invariant:
-We may not need it, given that's it's not part of https://wintercg.org/
+We may not need it, given that it's not part of https://wintercg.org/
 invariant(
   'FileReader' in global &&
     'Blob' in global &&

--- a/packages/toolpad-app/src/toolpadDataSources/function/runtime/fetch.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/function/runtime/fetch.ts
@@ -1,34 +1,43 @@
 /**
  * Implementation adapted from https://github.com/github/fetch/blob/master/fetch.js
  */
+import './abortController';
 import './domException';
 import './formData';
 import './headers';
 import './url';
 import './web-streams';
 import { formDataToBlob } from 'formdata-polyfill/esm.min';
+import invariant from 'invariant';
 import { ToolpadFunctionRuntimeBridge, FetchOptions } from './types';
 
 const TOOLPAD_BRIDGE: ToolpadFunctionRuntimeBridge = (global as any).TOOLPAD_BRIDGE;
 
-/*
+/* 
+TODO: Add Blob support. e.g. Satisfy the following invariant:
+
+invariant(
   'FileReader' in global &&
-  'Blob' in global &&
-  (function () {
-    try {
-      new Blob();
-      return true;
-    } catch (e) {
-      return false;
-    }
-  })()
-*/
+    'Blob' in global &&
+    (() => {
+      try {
+        // eslint-disable-next-line no-new
+        new Blob();
+        return true;
+      } catch (e) {
+        return false;
+      }
+    })(),
+  'Blob is required',
+); */
 const SUPPORTS_BLOB = false;
 
-/*
-  abortController: 'AbortController' in global
-*/
-const SUPPORTS_ABORTCONTROLLER = false;
+invariant('DOMException' in global, 'DOMException is required');
+invariant('ArrayBuffer' in global, 'ArrayBuffer is required');
+invariant('FormData' in global, 'FormData is required');
+invariant('Symbol' in global && 'iterator' in Symbol, 'Iterable is required');
+invariant('URLSearchParams' in global, 'URLSearchParams is required');
+invariant('AbortController' in global, 'AbortController is required');
 
 function isDataView(obj: unknown): obj is DataView {
   return !!obj && obj instanceof DataView;
@@ -258,11 +267,8 @@ class Request extends Body {
       options.signal ||
       this.signal ||
       (() => {
-        if (SUPPORTS_ABORTCONTROLLER) {
-          const ctrl = new AbortController();
-          return ctrl.signal;
-        }
-        return null;
+        const ctrl = new AbortController();
+        return ctrl.signal;
       })();
     this.referrer = null;
 

--- a/packages/toolpad-app/src/toolpadDataSources/function/runtime/url.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/function/runtime/url.ts
@@ -1,6 +1,10 @@
 // whatwg-url depends on TextEndoder/TextDecoder
 import './textEncoding';
 import { URL, URLSearchParams } from 'whatwg-url';
+import invariant from 'invariant';
+
+invariant('TextEncoder' in global, 'TextEncoder is required');
+invariant('TextDecoder' in global, 'TextDecoder is required');
 
 // @ts-expect-error Can't turn off @types/node which gets pulled in automatically
 // https://github.com/microsoft/TypeScript/issues/37053


### PR DESCRIPTION
Also add a few runtime checks that verify whether the required APIs are globally available. Some polyfills depend on other polyfills.