### PR TITLE
Fix deleting newly placed components with Backspace key

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -783,6 +783,8 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
     ],
   );
 
+  const overlayRef = React.useRef<HTMLDivElement | null>(null);
+
   const handleNodeDrop = React.useCallback(
     (event: React.DragEvent<Element>) => {
       const cursorPos = canvasHostRef.current?.getViewCoordinates(event.clientX, event.clientY);
@@ -1011,14 +1013,19 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
         }
       }
 
-      api.dragEnd();
-
       if (selection) {
         deleteOrphanedLayoutComponents(draggedNode, dragOverNodeId);
       }
 
+      api.dragEnd();
+
       if (newNode) {
         api.select(newNode.id);
+
+        const overlayElement = overlayRef.current;
+        if (overlayElement) {
+          overlayElement.focus();
+        }
       }
     },
     [
@@ -1309,6 +1316,7 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
 
   return (
     <OverlayRoot
+      ref={overlayRef}
       className={clsx({
         [overlayClasses.nodeDrag]: isDraggingOver,
         [overlayClasses.resizeHorizontal]:


### PR DESCRIPTION
Fixes issue where it was not possible to delete a component from the editor with the "Backspace" key just after placing it, without clicking it first.
My solution to this issue was to refocus on the element that catches `keydown` events after placing a new element, because dragging it from outside the editor was moving the focus outside of it.

Closes https://github.com/mui/mui-toolpad/issues/752

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
