### PR TITLE
Prevent node HUD from getting cut-off

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
@@ -59,7 +59,7 @@ const NodeHudWrapper = styled('div', {
     color: 'white',
     fontSize: 11,
     padding: `0 0 0 8px`,
-    height: `${HUD_HEIGHT}px`,
+    height: HUD_HEIGHT,
     zIndex: 1,
     ...(hudPosition === HUD_POSITION_TOP
       ? { top: 0, transform: 'translate(0, -100%)' }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
@@ -15,6 +15,7 @@ import {
 import { useDom } from '../../../DomLoader';
 import { useToolpadComponent } from '../../toolpadComponents';
 import { getElementNodeComponentId } from '../../../../toolpadComponents';
+import { usePageEditorState } from '../PageEditorProvider';
 
 const HUD_POSITION_TOP = 'top';
 const HUD_POSITION_BOTTOM = 'bottom';
@@ -129,7 +130,6 @@ interface NodeHudProps {
   onDelete?: React.MouseEventHandler<HTMLElement>;
   isResizing?: boolean;
   resizePreviewElementRef: React.MutableRefObject<HTMLDivElement | null>;
-  hudPosition?: HudPosition;
 }
 
 export default function NodeHud({
@@ -143,12 +143,19 @@ export default function NodeHud({
   onDelete,
   isResizing = false,
   resizePreviewElementRef,
-  hudPosition = HUD_POSITION_TOP,
 }: NodeHudProps) {
   const dom = useDom();
+  const { viewState } = usePageEditorState();
+
+  const { nodes: nodesInfo } = viewState;
 
   const componentId = appDom.isElement(node) ? getElementNodeComponentId(node) : '';
   const component = useToolpadComponent(dom, componentId);
+
+  const nodeInfo = nodesInfo[node.id];
+  const nodeRect = nodeInfo?.rect;
+
+  const hudPosition = nodeRect && nodeRect.y > 32 ? HUD_POSITION_TOP : HUD_POSITION_BOTTOM;
 
   return (
     <NodeHudWrapper

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
@@ -19,6 +19,8 @@ import { getElementNodeComponentId } from '../../../../toolpadComponents';
 const HUD_POSITION_TOP = 'top';
 const HUD_POSITION_BOTTOM = 'bottom';
 
+const HUD_HEIGHT = 30; // px
+
 type HudPosition = typeof HUD_POSITION_TOP | typeof HUD_POSITION_BOTTOM;
 
 const nodeHudClasses = {
@@ -57,6 +59,7 @@ const NodeHudWrapper = styled('div', {
     color: 'white',
     fontSize: 11,
     padding: `0 0 0 8px`,
+    height: `${HUD_HEIGHT}px`,
     zIndex: 1,
     ...(hudPosition === HUD_POSITION_TOP
       ? { top: 0, transform: 'translate(0, -100%)' }
@@ -148,7 +151,7 @@ export default function NodeHud({
   const componentId = appDom.isElement(node) ? getElementNodeComponentId(node) : '';
   const component = useToolpadComponent(dom, componentId);
 
-  const hudPosition = rect.y > 32 ? HUD_POSITION_TOP : HUD_POSITION_BOTTOM;
+  const hudPosition = rect.y > HUD_HEIGHT ? HUD_POSITION_TOP : HUD_POSITION_BOTTOM;
 
   return (
     <NodeHudWrapper

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
@@ -16,13 +16,22 @@ import { useDom } from '../../../DomLoader';
 import { useToolpadComponent } from '../../toolpadComponents';
 import { getElementNodeComponentId } from '../../../../toolpadComponents';
 
+const HUD_POSITION_TOP = 'top';
+const HUD_POSITION_BOTTOM = 'bottom';
+
+type HudPosition = typeof HUD_POSITION_TOP | typeof HUD_POSITION_BOTTOM;
+
 const nodeHudClasses = {
   allowNodeInteraction: 'NodeHud_AllowNodeInteraction',
   selected: 'NodeHud_Selected',
   selectionHint: 'NodeHud_SelectionHint',
 };
 
-const NodeHudWrapper = styled('div')({
+const NodeHudWrapper = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'hudPosition',
+})<{
+  hudPosition: HudPosition;
+}>(({ hudPosition }) => ({
   // capture mouse events
   pointerEvents: 'initial',
   position: 'absolute',
@@ -30,11 +39,11 @@ const NodeHudWrapper = styled('div')({
   userSelect: 'none',
   [`.${nodeHudClasses.selected}`]: {
     position: 'absolute',
-    top: 0,
-    left: 0,
     height: '100%',
     width: '100%',
     outline: '1px solid red',
+    left: 0,
+    top: 0,
   },
   [`.${nodeHudClasses.selectionHint}`]: {
     // capture mouse events
@@ -48,17 +57,16 @@ const NodeHudWrapper = styled('div')({
     color: 'white',
     fontSize: 11,
     padding: `0 0 0 8px`,
-    // TODO: figure out positioning of this selectionhint, perhaps it should
-    //   - prefer top right, above the component
-    //   - if that appears out of bound of the editor, show it bottom or left
     zIndex: 1,
-    transform: `translate(0, -100%)`,
+    ...(hudPosition === HUD_POSITION_TOP
+      ? { top: 0, transform: 'translate(0, -100%)' }
+      : { bottom: 0, transform: 'translate(0, 100%)' }),
   },
   [`&.${nodeHudClasses.allowNodeInteraction}`]: {
     // block pointer-events so we can interact with the selection
     pointerEvents: 'none',
   },
-});
+}));
 
 const DraggableEdge = styled('div', {
   shouldForwardProp: (prop) => prop !== 'edge',
@@ -121,6 +129,7 @@ interface NodeHudProps {
   onDelete?: React.MouseEventHandler<HTMLElement>;
   isResizing?: boolean;
   resizePreviewElementRef: React.MutableRefObject<HTMLDivElement | null>;
+  hudPosition?: HudPosition;
 }
 
 export default function NodeHud({
@@ -134,6 +143,7 @@ export default function NodeHud({
   onDelete,
   isResizing = false,
   resizePreviewElementRef,
+  hudPosition = HUD_POSITION_TOP,
 }: NodeHudProps) {
   const dom = useDom();
 
@@ -147,6 +157,7 @@ export default function NodeHud({
       className={clsx({
         [nodeHudClasses.allowNodeInteraction]: isInteractive,
       })}
+      hudPosition={hudPosition}
     >
       {isSelected ? (
         <React.Fragment>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
@@ -15,7 +15,6 @@ import {
 import { useDom } from '../../../DomLoader';
 import { useToolpadComponent } from '../../toolpadComponents';
 import { getElementNodeComponentId } from '../../../../toolpadComponents';
-import { usePageEditorState } from '../PageEditorProvider';
 
 const HUD_POSITION_TOP = 'top';
 const HUD_POSITION_BOTTOM = 'bottom';
@@ -145,17 +144,11 @@ export default function NodeHud({
   resizePreviewElementRef,
 }: NodeHudProps) {
   const dom = useDom();
-  const { viewState } = usePageEditorState();
-
-  const { nodes: nodesInfo } = viewState;
 
   const componentId = appDom.isElement(node) ? getElementNodeComponentId(node) : '';
   const component = useToolpadComponent(dom, componentId);
 
-  const nodeInfo = nodesInfo[node.id];
-  const nodeRect = nodeInfo?.rect;
-
-  const hudPosition = nodeRect && nodeRect.y > 32 ? HUD_POSITION_TOP : HUD_POSITION_BOTTOM;
+  const hudPosition = rect.y > 32 ? HUD_POSITION_TOP : HUD_POSITION_BOTTOM;
 
   return (
     <NodeHudWrapper

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -1365,8 +1365,6 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
 
         const isResizing = Boolean(draggedEdge) && node.id === draggedNodeId;
 
-        const hasBottomHud = nodeRect.y <= 32;
-
         return (
           <React.Fragment key={node.id}>
             {!isPageNode ? (
@@ -1391,7 +1389,6 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
                 onDelete={handleNodeDelete(node.id)}
                 isResizing={isResizing}
                 resizePreviewElementRef={resizePreviewElementRef}
-                hudPosition={hasBottomHud ? 'bottom' : 'top'}
               />
             ) : null}
             <DragAndDropNode

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -1365,6 +1365,8 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
 
         const isResizing = Boolean(draggedEdge) && node.id === draggedNodeId;
 
+        const hasBottomHud = nodeRect.y <= 32;
+
         return (
           <React.Fragment key={node.id}>
             {!isPageNode ? (
@@ -1389,6 +1391,7 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
                 onDelete={handleNodeDelete(node.id)}
                 isResizing={isResizing}
                 resizePreviewElementRef={resizePreviewElementRef}
+                hudPosition={hasBottomHud ? 'bottom' : 'top'}
               />
             ) : null}
             <DragAndDropNode


### PR DESCRIPTION
In the top row, every node's HUD was being cut-off, as the following image shows:

<img width="1792" alt="Screen Shot 2022-08-10 at 19 55 45" src="https://user-images.githubusercontent.com/10789765/183994960-00138fd9-bc8a-4814-8df3-8933ec6cedd7.png">

This PR fixes the issue by showing the HUD at the bottom when there is not enough space for it at the top.

https://user-images.githubusercontent.com/10789765/183995142-4ba5b6ca-d230-4046-9026-88c3a7eb1f8d.mov


