### PR TITLE
Improve handling of React keys in ComponentCatalog

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -161,10 +161,10 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
                     </ComponentCatalogItem>
                   );
                 })}
-              {FUTURE_COMPONENTS.map((futureComponent, i) => {
+              {FUTURE_COMPONENTS.map((futureComponent) => {
                 return (
                   <Link
-                    key={`futureComponent[${i}]`}
+                    key={`futureComponent.${futureComponent.displayName}`}
                     href={futureComponent.githubLink}
                     underline="none"
                     target="_blank"

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -16,18 +16,18 @@ import {
 
 interface FutureComponentSpec {
   displayName?: string;
-  githubLink: string;
+  url: string;
 }
 
 const FUTURE_COMPONENTS = new Map<string, FutureComponentSpec>([
-  ['Form', { githubLink: 'https://github.com/mui/mui-toolpad/issues/749' }],
-  ['Card', { githubLink: 'https://github.com/mui/mui-toolpad/issues/748' }],
-  ['Tabs', { githubLink: 'https://github.com/mui/mui-toolpad/issues/747' }],
-  ['Slider', { githubLink: 'https://github.com/mui/mui-toolpad/issues/746' }],
-  ['Switch', { githubLink: 'https://github.com/mui/mui-toolpad/issues/745' }],
-  ['RadioButton', { githubLink: 'https://github.com/mui/mui-toolpad/issues/744' }],
-  ['DatePicker', { githubLink: 'https://github.com/mui/mui-toolpad/issues/743' }],
-  ['Checkbox', { githubLink: 'https://github.com/mui/mui-toolpad/issues/742' }],
+  ['Form', { url: 'https://github.com/mui/mui-toolpad/issues/749' }],
+  ['Card', { url: 'https://github.com/mui/mui-toolpad/issues/748' }],
+  ['Tabs', { url: 'https://github.com/mui/mui-toolpad/issues/747' }],
+  ['Slider', { url: 'https://github.com/mui/mui-toolpad/issues/746' }],
+  ['Switch', { url: 'https://github.com/mui/mui-toolpad/issues/745' }],
+  ['RadioButton', { url: 'https://github.com/mui/mui-toolpad/issues/744' }],
+  ['DatePicker', { url: 'https://github.com/mui/mui-toolpad/issues/743' }],
+  ['Checkbox', { url: 'https://github.com/mui/mui-toolpad/issues/742' }],
 ]);
 
 const WIDTH_COLLAPSED = 50;
@@ -137,26 +137,18 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
                     </ComponentCatalogItem>
                   );
                 })}
-              {Array.from(
-                FUTURE_COMPONENTS.entries(),
-                ([key, { displayName = key, githubLink }]) => {
-                  return (
-                    <Link
-                      key={`futureComponent.${key}`}
-                      href={githubLink}
-                      underline="none"
-                      target="_blank"
-                    >
-                      <ComponentCatalogItem>
-                        <DragIndicatorIcon color="disabled" />
-                        {displayName}
-                        <Box sx={{ flex: 1 }} />
-                        🚧
-                      </ComponentCatalogItem>
-                    </Link>
-                  );
-                },
-              )}
+              {Array.from(FUTURE_COMPONENTS.entries(), ([key, { displayName = key, url }]) => {
+                return (
+                  <Link key={`futureComponent.${key}`} href={url} underline="none" target="_blank">
+                    <ComponentCatalogItem>
+                      <DragIndicatorIcon color="disabled" />
+                      {displayName}
+                      <Box sx={{ flex: 1 }} />
+                      🚧
+                    </ComponentCatalogItem>
+                  </Link>
+                );
+              })}
             </Box>
           </Box>
         </Collapse>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -137,7 +137,7 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
                     </ComponentCatalogItem>
                   );
                 })}
-              {Array.from(FUTURE_COMPONENTS.entries(), ([key, { displayName = key, url }]) => {
+              {Array.from(FUTURE_COMPONENTS, ([key, { displayName = key, url }]) => {
                 return (
                   <Link key={`futureComponent.${key}`} href={url} underline="none" target="_blank">
                     <ComponentCatalogItem>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -153,25 +153,23 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
                     </ComponentCatalogItem>
                   );
                 })}
-              {Object.entries(FUTURE_COMPONENTS).map(
-                ([name, { displayName = name, githubLink }]) => {
-                  return (
-                    <Link
-                      key={`futureComponent.${name}`}
-                      href={githubLink}
-                      underline="none"
-                      target="_blank"
-                    >
-                      <ComponentCatalogItem>
-                        <DragIndicatorIcon color="disabled" />
-                        {displayName}
-                        <Box sx={{ flex: 1 }} />
-                        🚧
-                      </ComponentCatalogItem>
-                    </Link>
-                  );
-                },
-              )}
+              {Object.entries(FUTURE_COMPONENTS).map(([key, { displayName = key, githubLink }]) => {
+                return (
+                  <Link
+                    key={`futureComponent.${key}`}
+                    href={githubLink}
+                    underline="none"
+                    target="_blank"
+                  >
+                    <ComponentCatalogItem>
+                      <DragIndicatorIcon color="disabled" />
+                      {displayName}
+                      <Box sx={{ flex: 1 }} />
+                      🚧
+                    </ComponentCatalogItem>
+                  </Link>
+                );
+              })}
             </Box>
           </Box>
         </Collapse>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -19,32 +19,16 @@ interface FutureComponentSpec {
   githubLink: string;
 }
 
-const FUTURE_COMPONENTS: Record<string, FutureComponentSpec> = {
-  Form: {
-    githubLink: 'https://github.com/mui/mui-toolpad/issues/749',
-  },
-  Card: {
-    githubLink: 'https://github.com/mui/mui-toolpad/issues/748',
-  },
-  Tabs: {
-    githubLink: 'https://github.com/mui/mui-toolpad/issues/747',
-  },
-  Slider: {
-    githubLink: 'https://github.com/mui/mui-toolpad/issues/746',
-  },
-  Switch: {
-    githubLink: 'https://github.com/mui/mui-toolpad/issues/745',
-  },
-  RadioButton: {
-    githubLink: 'https://github.com/mui/mui-toolpad/issues/744',
-  },
-  DatePicker: {
-    githubLink: 'https://github.com/mui/mui-toolpad/issues/743',
-  },
-  Checkbox: {
-    githubLink: 'https://github.com/mui/mui-toolpad/issues/742',
-  },
-};
+const FUTURE_COMPONENTS = new Map<string, FutureComponentSpec>([
+  ['Form', { githubLink: 'https://github.com/mui/mui-toolpad/issues/749' }],
+  ['Card', { githubLink: 'https://github.com/mui/mui-toolpad/issues/748' }],
+  ['Tabs', { githubLink: 'https://github.com/mui/mui-toolpad/issues/747' }],
+  ['Slider', { githubLink: 'https://github.com/mui/mui-toolpad/issues/746' }],
+  ['Switch', { githubLink: 'https://github.com/mui/mui-toolpad/issues/745' }],
+  ['RadioButton', { githubLink: 'https://github.com/mui/mui-toolpad/issues/744' }],
+  ['DatePicker', { githubLink: 'https://github.com/mui/mui-toolpad/issues/743' }],
+  ['Checkbox', { githubLink: 'https://github.com/mui/mui-toolpad/issues/742' }],
+]);
 
 const WIDTH_COLLAPSED = 50;
 
@@ -153,23 +137,26 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
                     </ComponentCatalogItem>
                   );
                 })}
-              {Object.entries(FUTURE_COMPONENTS).map(([key, { displayName = key, githubLink }]) => {
-                return (
-                  <Link
-                    key={`futureComponent.${key}`}
-                    href={githubLink}
-                    underline="none"
-                    target="_blank"
-                  >
-                    <ComponentCatalogItem>
-                      <DragIndicatorIcon color="disabled" />
-                      {displayName}
-                      <Box sx={{ flex: 1 }} />
-                      🚧
-                    </ComponentCatalogItem>
-                  </Link>
-                );
-              })}
+              {Array.from(
+                FUTURE_COMPONENTS.entries(),
+                ([key, { displayName = key, githubLink }]) => {
+                  return (
+                    <Link
+                      key={`futureComponent.${key}`}
+                      href={githubLink}
+                      underline="none"
+                      target="_blank"
+                    >
+                      <ComponentCatalogItem>
+                        <DragIndicatorIcon color="disabled" />
+                        {displayName}
+                        <Box sx={{ flex: 1 }} />
+                        🚧
+                      </ComponentCatalogItem>
+                    </Link>
+                  );
+                },
+              )}
             </Box>
           </Box>
         </Collapse>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog.tsx
@@ -15,44 +15,36 @@ import {
 } from '../../../toolpadComponents';
 
 interface FutureComponentSpec {
-  displayName: string;
+  displayName?: string;
   githubLink: string;
 }
 
-const FUTURE_COMPONENTS: FutureComponentSpec[] = [
-  {
-    displayName: 'Form',
+const FUTURE_COMPONENTS: Record<string, FutureComponentSpec> = {
+  Form: {
     githubLink: 'https://github.com/mui/mui-toolpad/issues/749',
   },
-  {
-    displayName: 'Card',
+  Card: {
     githubLink: 'https://github.com/mui/mui-toolpad/issues/748',
   },
-  {
-    displayName: 'Tabs',
+  Tabs: {
     githubLink: 'https://github.com/mui/mui-toolpad/issues/747',
   },
-  {
-    displayName: 'Slider',
+  Slider: {
     githubLink: 'https://github.com/mui/mui-toolpad/issues/746',
   },
-  {
-    displayName: 'Switch',
+  Switch: {
     githubLink: 'https://github.com/mui/mui-toolpad/issues/745',
   },
-  {
-    displayName: 'RadioButton',
+  RadioButton: {
     githubLink: 'https://github.com/mui/mui-toolpad/issues/744',
   },
-  {
-    displayName: 'DatePicker',
+  DatePicker: {
     githubLink: 'https://github.com/mui/mui-toolpad/issues/743',
   },
-  {
-    displayName: 'Checkbox',
+  Checkbox: {
     githubLink: 'https://github.com/mui/mui-toolpad/issues/742',
   },
-];
+};
 
 const WIDTH_COLLAPSED = 50;
 
@@ -161,23 +153,25 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
                     </ComponentCatalogItem>
                   );
                 })}
-              {FUTURE_COMPONENTS.map((futureComponent) => {
-                return (
-                  <Link
-                    key={`futureComponent.${futureComponent.displayName}`}
-                    href={futureComponent.githubLink}
-                    underline="none"
-                    target="_blank"
-                  >
-                    <ComponentCatalogItem>
-                      <DragIndicatorIcon color="disabled" />
-                      {futureComponent.displayName}
-                      <Box sx={{ flex: 1 }} />
-                      🚧
-                    </ComponentCatalogItem>
-                  </Link>
-                );
-              })}
+              {Object.entries(FUTURE_COMPONENTS).map(
+                ([name, { displayName = name, githubLink }]) => {
+                  return (
+                    <Link
+                      key={`futureComponent.${name}`}
+                      href={githubLink}
+                      underline="none"
+                      target="_blank"
+                    >
+                      <ComponentCatalogItem>
+                        <DragIndicatorIcon color="disabled" />
+                        {displayName}
+                        <Box sx={{ flex: 1 }} />
+                        🚧
+                      </ComponentCatalogItem>
+                    </Link>
+                  );
+                },
+              )}
             </Box>
           </Box>
         </Collapse>


### PR DESCRIPTION
Refactor component catalog to guarantee unique future component keys

Continuation of https://github.com/mui/mui-toolpad/pull/774 (which was auto-merged)

Also rename `githubLink` to `url`. It doesn't matter where the url points, so let's use a more generic name.