### PR TITLE
Make sure the application isn't saved during mounting

### DIFF
--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -268,13 +268,13 @@ export default function DomProvider({ appId, children }: DomContextProps) {
   });
   const api = React.useMemo(() => createDomApi(dispatch), []);
 
-  const lastSavedDom = React.useRef<appDom.AppDom | null>(null);
+  const savedDom = React.useRef<appDom.AppDom | null>(state.dom);
   const handleSave = React.useCallback(() => {
-    if (!state.dom || lastSavedDom.current === state.dom) {
+    if (!state.dom || savedDom.current === state.dom) {
       return;
     }
 
-    lastSavedDom.current = state.dom;
+    savedDom.current = state.dom;
     dispatch({ type: 'DOM_SAVING' });
 
     client.mutation

--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -268,13 +268,13 @@ export default function DomProvider({ appId, children }: DomContextProps) {
   });
   const api = React.useMemo(() => createDomApi(dispatch), []);
 
-  const savedDom = React.useRef<appDom.AppDom | null>(state.dom);
+  const lastSavedDom = React.useRef<appDom.AppDom | null>(state.dom);
   const handleSave = React.useCallback(() => {
-    if (!state.dom || savedDom.current === state.dom) {
+    if (!state.dom || lastSavedDom.current === state.dom) {
       return;
     }
 
-    savedDom.current = state.dom;
+    lastSavedDom.current = state.dom;
     dispatch({ type: 'DOM_SAVING' });
 
     client.mutation


### PR DESCRIPTION
Initial dom is compared with `null`, which triggers an update. Solution: instead, initialize the ref that stores last saved application with the initial application, this makes it not detect a difference.

Fixes https://github.com/mui/mui-toolpad/issues/709