### PR TITLE
Make sure old style references are backwards compatible

### DIFF
--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -822,6 +822,13 @@ export function deref(nodeRef: NodeReference): NodeId;
 export function deref(nodeRef: null | undefined): null;
 export function deref(nodeRef: Maybe<NodeReference>): NodeId | null;
 export function deref(nodeRef: Maybe<NodeReference>): NodeId | null {
+  if (typeof nodeRef === 'string') {
+    // This branch provides backwards compatibility for old style string refs
+    // TODO: remove this branch and replace with a migration after the functionality is in place .
+    //       See https://github.com/mui/mui-toolpad/pull/776
+    //       In migration '1' we should update all query connectionId and navigate action pageId.
+    return nodeRef;
+  }
   if (nodeRef) {
     return nodeRef.$$ref;
   }


### PR DESCRIPTION
TheseSome properties that used to be represented by a string `'xyz'` are now represented by a `{ $$ref: 'xyz' }`. This allows us to detect them in our data structure and treat them as their own datatype. There was no backwards compatibility put in place and we can't do migrations yet, so this will fix older apps that are now broken 