### PR TITLE
Add tooling to facilitate integration testing

### DIFF
--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -26,6 +26,7 @@ function parseBuidEnvVars(env) {
     TOOLPAD_TARGET: target,
     TOOLPAD_DEMO: env.TOOLPAD_DEMO || '',
     TOOLPAD_VERSION: pkgJson.version,
+    TOOLPAD_CREATE_WITH_DOM: process.env.TOOLPAD_CREATE_WITH_DOM,
   };
 }
 

--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -872,3 +872,30 @@ export function fromLegacyQueryNode(node: QueryNode<any>): QueryNode<any> {
 
   return node;
 }
+
+/**
+ * Poor man's duplicate function
+ * In anticipation of https://github.com/mui/mui-toolpad/pull/658
+ */
+export function duplicate(dom: AppDom): AppDom {
+  const newIndices = new Map(Object.keys(dom.nodes).map((id) => [id, cuid()]));
+  return {
+    root: newIndices.get(dom.root) as NodeId,
+    nodes: Object.fromEntries(
+      Object.entries(dom.nodes).map(([oldId, node]) => {
+        const newId = newIndices.get(oldId) as NodeId;
+        const newNode = {
+          ...node,
+          parentId: node.parentId ? (newIndices.get(node.parentId) as NodeId) : null,
+          id: newId,
+        } as AppDomNode;
+        if (isQuery(newNode) && newNode.attributes.connectionId.value) {
+          newNode.attributes.connectionId.value = ref(
+            newIndices.get(deref(newNode.attributes.connectionId.value)) as NodeId,
+          );
+        }
+        return [newId, newNode];
+      }),
+    ),
+  };
+}

--- a/packages/toolpad-app/src/components/JsonView.tsx
+++ b/packages/toolpad-app/src/components/JsonView.tsx
@@ -24,12 +24,12 @@ const JsonViewRoot = styled('div')({
   fontFamily: 'Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace',
 });
 
-export interface JsonViewProps {
+export interface JsonViewProps extends ObjectInspectorProps {
   src: unknown;
   sx?: SxProps;
 }
 
-export default function JsonView({ src, sx }: JsonViewProps) {
+export default function JsonView({ src, sx, ...props }: JsonViewProps) {
   // TODO: elaborate on this to show a nice default, but avoid expanding massive amount of objects
   const expandPaths = Array.isArray(src) ? ['$', '$.0', '$.1', '$.2', '$.3', '$.4'] : undefined;
   return (
@@ -40,6 +40,7 @@ export default function JsonView({ src, sx }: JsonViewProps) {
         expandPaths={expandPaths}
         data={src}
         theme={inspectorTheme}
+        {...props}
       />
     </JsonViewRoot>
   );

--- a/packages/toolpad-app/src/config.ts
+++ b/packages/toolpad-app/src/config.ts
@@ -22,7 +22,18 @@ import { RUNTIME_CONFIG_WINDOW_PROPERTY } from './constants';
  */
 
 // These are inlined at build time
-export type BuildEnvVars = Record<'TOOLPAD_TARGET' | 'TOOLPAD_DEMO' | 'TOOLPAD_VERSION', string>;
+export type BuildEnvVars = Record<
+  // Identifier for the product line (CE, EE, Cloud, ...)
+  | 'TOOLPAD_TARGET'
+  // Whether Toolpad is running in Ddemo mode
+  | 'TOOLPAD_DEMO'
+  // The current Toolpad version
+  | 'TOOLPAD_VERSION'
+  // Enable input field for seeding a dom in the app creation dialog
+  // (For testing purposes)
+  | 'TOOLPAD_CREATE_WITH_DOM',
+  string
+>;
 
 // These are set at runtime and passed to the browser.
 // Do not add secrets

--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -178,13 +178,17 @@ function createDefaultDom(): appDom.AppDom {
   return dom;
 }
 
-export async function createApp(name: string): Promise<App> {
+export interface CreateAppOptions {
+  dom?: appDom.AppDom | null;
+}
+
+export async function createApp(name: string, opts: CreateAppOptions = {}): Promise<App> {
   return prisma.$transaction(async () => {
     const app = await prisma.app.create({
       data: { name },
     });
 
-    const dom = createDefaultDom();
+    const dom = opts.dom ? appDom.duplicate(opts.dom) : createDefaultDom();
 
     await saveDom(app.id, dom);
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -97,6 +97,8 @@ function AppMenu() {
           <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
             <JsonView src={dom} expandPaths={[]} expandLevel={5} />
           </Box>
+
+          {/* TODO: build overflow behavior into JsonView and add optional "copy source" button in there */}
           <Tooltip title="Copy the source">
             <IconButton
               onClick={handleCopyToClipboard}

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -93,7 +93,7 @@ function AppMenu() {
         maxWidth="sm"
       >
         <DialogTitle id={dialogTitleId}>Application DOM</DialogTitle>
-        <DialogContent sx={{ position: 'relative' }}>
+        <DialogContent sx={{ position: 'relative', display: 'flex' }}>
           <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
             <JsonView src={dom} expandPaths={[]} expandLevel={5} />
           </Box>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -1,12 +1,125 @@
-import { styled, SxProps, Typography, Tooltip, Skeleton, Box, Divider } from '@mui/material';
+import {
+  styled,
+  SxProps,
+  Typography,
+  Tooltip,
+  Skeleton,
+  Box,
+  Divider,
+  IconButton,
+  Menu,
+  MenuItem,
+  DialogTitle,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Snackbar,
+} from '@mui/material';
 import * as React from 'react';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import HierarchyExplorer from './HierarchyExplorer';
 import client from '../../api';
+import { useDom } from '../DomLoader';
+import JsonView from '../../components/JsonView';
 
 const PagePanelRoot = styled('div')({
   display: 'flex',
   flexDirection: 'column',
 });
+
+function AppMenu() {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleAppMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleAppMenuClose = () => {
+    setAnchorEl(null);
+  };
+  const buttonId = React.useId();
+  const menuId = React.useId();
+  const dialogTitleId = React.useId();
+
+  const [viewDomDialogOpen, setViewDomDialogOpen] = React.useState(false);
+  const [copySnackbarOpen, setCopySnackbarOpen] = React.useState(false);
+
+  const dom = useDom();
+
+  const handleViewDomClick = React.useCallback(() => {
+    handleAppMenuClose();
+    setViewDomDialogOpen(true);
+  }, []);
+
+  const handleViewDomDialogClose = React.useCallback(() => setViewDomDialogOpen(false), []);
+
+  const handleCopyToClipboard = React.useCallback(() => {
+    window.navigator.clipboard.writeText(JSON.stringify(dom, null, 2));
+    setCopySnackbarOpen(true);
+  }, [dom]);
+
+  const handleCopySnackbarClose = React.useCallback(() => setCopySnackbarOpen(false), []);
+
+  return (
+    <React.Fragment>
+      <IconButton
+        id={buttonId}
+        aria-controls={open ? menuId : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleAppMenuClick}
+      >
+        <MoreVertIcon />
+      </IconButton>
+
+      <Menu
+        id={menuId}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleAppMenuClose}
+        MenuListProps={{
+          'aria-labelledby': buttonId,
+        }}
+      >
+        <MenuItem onClick={handleViewDomClick}>View DOM</MenuItem>
+      </Menu>
+
+      <Dialog
+        open={viewDomDialogOpen}
+        onClose={handleViewDomDialogClose}
+        aria-labelledby={dialogTitleId}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle id={dialogTitleId}>Application DOM</DialogTitle>
+        <DialogContent sx={{ position: 'relative' }}>
+          <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+            <JsonView src={dom} expandPaths={[]} expandLevel={5} />
+          </Box>
+          <Tooltip title="Copy the source">
+            <IconButton
+              onClick={handleCopyToClipboard}
+              sx={{ position: 'absolute', top: 8, right: 36 }}
+            >
+              <ContentCopyIcon />
+            </IconButton>
+          </Tooltip>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleViewDomDialogClose}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={copySnackbarOpen}
+        autoHideDuration={6000}
+        onClose={handleCopySnackbarClose}
+        message="DOM Copied to clipboard"
+      />
+    </React.Fragment>
+  );
+}
 
 export interface ComponentPanelProps {
   appId: string;
@@ -19,14 +132,25 @@ export default function PagePanel({ appId, className, sx }: ComponentPanelProps)
 
   return (
     <PagePanelRoot className={className} sx={sx}>
-      <Box sx={{ px: 2, py: 1 }}>
+      <Box
+        sx={{
+          pl: 2,
+          pr: 1,
+          py: 1,
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         {isLoading ? (
-          <Skeleton variant="text" />
+          <Skeleton variant="text" width={70} />
         ) : (
           <Tooltip title={app?.name || ''} enterDelay={500}>
             <Typography noWrap>{app?.name}</Typography>
           </Tooltip>
         )}
+        <AppMenu />
       </Box>
       <Divider />
       <HierarchyExplorer appId={appId} />

--- a/packages/toolpad-app/src/toolpad/Home.tsx
+++ b/packages/toolpad-app/src/toolpad/Home.tsx
@@ -42,6 +42,14 @@ export interface CreateAppDialogProps {
 
 function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
   const [name, setName] = React.useState('');
+
+  const [dom, setDom] = React.useState('');
+
+  const handleDomChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => setDom(event.target.value),
+    [],
+  );
+
   const createAppMutation = client.useMutation('createApp', {
     onSuccess: (app) => {
       window.location.href = `/_toolpad/app/${app.id}/editor`;
@@ -54,7 +62,7 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
         <DialogForm
           onSubmit={(event) => {
             event.preventDefault();
-            createAppMutation.mutate([name]);
+            createAppMutation.mutate([name, { dom: dom.trim() ? JSON.parse(dom) : null }]);
           }}
         >
           <DialogTitle>Create a new MUI Toolpad App</DialogTitle>
@@ -72,6 +80,15 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
                 setName(event.target.value);
               }}
             />
+            {process.env.TOOLPAD_CREATE_WITH_DOM ? (
+              <TextField
+                label="seed DOM"
+                fullWidth
+                multiline
+                value={dom}
+                onChange={handleDomChange}
+              />
+            ) : null}
           </DialogContent>
           <DialogActions>
             <Button

--- a/packages/toolpad-app/src/toolpad/Home.tsx
+++ b/packages/toolpad-app/src/toolpad/Home.tsx
@@ -85,6 +85,7 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
                 label="seed DOM"
                 fullWidth
                 multiline
+                maxRows={10}
                 value={dom}
                 onChange={handleDomChange}
               />


### PR DESCRIPTION
* [x] a hidden way to seed a new application with a DOM structure for an application. We'll use this in playwright to seed an application, the application must be started with `TOOLPAD_CREATE_WITH_DOM` env variable to get access to this functionality. We can expand this to a user facing feature in the future.
* [x] a way to view and copy the dom for an application. Shall we put this under a feature flag as well? The main purpose of these tools at the moment are to facilitate setting up tests. We can use this to create apps that we want to run integration tests on.

https://user-images.githubusercontent.com/2109932/184403241-9bc35431-a39e-44ed-9e7f-60ae7dae955f.mov


