### PR TITLE
Fix scrollbar when selection options

### DIFF
--- a/packages/toolpad-app/src/toolpad/propertyControls/SelectOptions.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/SelectOptions.tsx
@@ -189,7 +189,7 @@ function SelectOptionsPropEditor({
               ) : null}
               <TextField
                 fullWidth
-                sx={{ m: 1 }}
+                sx={{ my: 1 }}
                 variant="outlined"
                 inputRef={optionInputRef}
                 onKeyUp={handleOptionTextInput}


### PR DESCRIPTION
**Before** (most visible on Windows)

<img width="637" alt="Screenshot 2022-08-13 at 00 37 48" src="https://user-images.githubusercontent.com/3165635/184453298-d621f861-7299-41ac-abc8-d15e42c2682c.png">

**After**

<img width="639" alt="Screenshot 2022-08-13 at 00 37 27" src="https://user-images.githubusercontent.com/3165635/184453275-5983ba7e-f8e8-4fd2-9632-71b7be046365.png">

This seems to have been introduced in #443.

---

@bharatkashyap Could you configure your macOS to match how Windows behaves with a scrollbar? This way, you will experience [how most](https://www.notion.so/mui-org/Analytics-f2e2576203564e6c8dc3429cf305a36f#8a38433d21814a15acfb99ce2eac7d6b) of the developers will experience the interface

<img width="652" alt="Screenshot 2022-08-13 at 00 38 48" src="https://user-images.githubusercontent.com/3165635/184453349-b78c7c81-34b2-4902-8713-827cc6707e58.png">

