### PR TITLE
Validate the name when creating code components

### DIFF
--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -386,9 +386,31 @@ function createNodeInternal<T extends AppDomNodeType>(
   } as AppDomNodeOfType<T>;
 }
 
-function slugifyNodeName(dom: AppDom, nameCandidate: string, fallback: string): string {
+export function validateNodeName(input: string, identifier = 'input'): string | null {
+  const firstLetter = input[0];
+  if (!/[a-z_]/i.test(firstLetter)) {
+    return `${identifier} may not start with a "${firstLetter}"`;
+  }
+
+  const match = /([^a-z0-9_])/i.exec(input);
+
+  if (match) {
+    const invalidCharacter = match[1];
+    if (/\s/.test(invalidCharacter)) {
+      return `${identifier} may not contain spaces`;
+    }
+
+    return `${identifier} may not contain a "${invalidCharacter}"`;
+  }
+
+  return null;
+}
+
+export function slugifyNodeName(dom: AppDom, nameCandidate: string, fallback: string): string {
+  let slug = nameCandidate;
+  slug = slug.trim();
   // try to replace accents with relevant ascii
-  let slug = removeDiacritics(nameCandidate);
+  slug = removeDiacritics(slug);
   // replace spaces with camelcase
   slug = camelCase(...slug.split(/\s+/));
   // replace disallowed characters for js identifiers

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -62,7 +62,10 @@ export default function CreateCodeComponentDialog({
     event.target.select();
   }, []);
 
-  const inputErrorMsg = name ? appDom.validateNodeName(name, 'a code component name') : null;
+  const inputErrorMsg = React.useMemo(
+    () => (name ? appDom.validateNodeName(name, 'a code component name') : null),
+    [name],
+  );
   const isInvalid = !!inputErrorMsg;
 
   return (

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -62,7 +62,7 @@ export default function CreateCodeComponentDialog({
     event.target.select();
   }, []);
 
-  const inputErrorMsg = name ? appDom.validateNodeName(name) : null;
+  const inputErrorMsg = name ? appDom.validateNodeName(name, 'a code component name') : null;
   const isInvalid = !!inputErrorMsg;
 
   return (

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -62,6 +62,9 @@ export default function CreateCodeComponentDialog({
     event.target.select();
   }, []);
 
+  const inputErrorMsg = name ? appDom.validateNodeName(name) : null;
+  const isInvalid = !!inputErrorMsg;
+
   return (
     <Dialog {...props} onClose={onClose}>
       <DialogForm
@@ -90,13 +93,15 @@ export default function CreateCodeComponentDialog({
             label="name"
             value={name}
             onChange={(event) => setName(event.target.value)}
+            error={isInvalid}
+            helperText={inputErrorMsg}
           />
         </DialogContent>
         <DialogActions>
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!name}>
+          <Button type="submit" disabled={!name || isInvalid}>
             Create
           </Button>
         </DialogActions>


### PR DESCRIPTION
Proposing this as a solution for this dialog:

![Screenshot 2022-08-16 at 16 39 20](https://user-images.githubusercontent.com/2109932/184907660-c720a03a-ea91-4c80-927f-46c552f5d437.png)



Closes https://github.com/mui/mui-toolpad/issues/790