### PR TITLE
Add property for child rectangle in DOM node info

### DIFF
--- a/packages/toolpad-app/src/pageViewState.ts
+++ b/packages/toolpad-app/src/pageViewState.ts
@@ -1,6 +1,7 @@
 import { FiberNode, Hook } from 'react-devtools-inline';
 import { NodeId, RUNTIME_PROP_NODE_ID, RUNTIME_PROP_SLOTS, SlotType } from '@mui/toolpad-core';
 import { NodeFiberHostProps } from '@mui/toolpad-core/runtime';
+import invariant from 'invariant';
 import { PageViewState, NodesInfo, NodeInfo, FlowDirection } from './types';
 import { getRelativeBoundingRect, getRelativeOuterRect } from './utils/geometry';
 
@@ -21,11 +22,16 @@ function getNodeViewInfo(
     const rect = getRelativeOuterRect(viewElm, elm);
     const props = fiber.child?.memoizedProps ?? {};
 
+    const innerElm = elm.firstElementChild;
+    invariant(innerElm, 'Node has no inner element');
+    const innerRect = getRelativeOuterRect(viewElm, innerElm);
+
     return {
       nodeId,
       error: fiberHostProps.nodeError,
       componentConfig: fiberHostProps.componentConfig,
       rect,
+      innerRect,
       slots: {},
       props,
     };

--- a/packages/toolpad-app/src/pageViewState.ts
+++ b/packages/toolpad-app/src/pageViewState.ts
@@ -1,9 +1,12 @@
 import { FiberNode, Hook } from 'react-devtools-inline';
 import { NodeId, RUNTIME_PROP_NODE_ID, RUNTIME_PROP_SLOTS, SlotType } from '@mui/toolpad-core';
 import { NodeFiberHostProps } from '@mui/toolpad-core/runtime';
-import invariant from 'invariant';
 import { PageViewState, NodesInfo, NodeInfo, FlowDirection } from './types';
-import { getRelativeBoundingRect, getRelativeOuterRect } from './utils/geometry';
+import {
+  getContainerInnerRect,
+  getRelativeBoundingRect,
+  getRelativeOuterRect,
+} from './utils/geometry';
 
 declare global {
   interface Window {
@@ -20,11 +23,8 @@ function getNodeViewInfo(
 ): NodeInfo | null {
   if (nodeId) {
     const rect = getRelativeOuterRect(viewElm, elm);
+    const innerRect = getContainerInnerRect(elm);
     const props = fiber.child?.memoizedProps ?? {};
-
-    const innerElm = elm.firstElementChild;
-    invariant(innerElm, 'Node has no inner element');
-    const innerRect = getRelativeOuterRect(viewElm, innerElm);
 
     return {
       nodeId,

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -345,7 +345,9 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
             justifyContent: boundLayoutProps.horizontalAlign,
           }}
         >
-          <Component {...props} />
+          <div>
+            <Component {...props} />
+          </div>
         </Box>
       )}
     </NodeRuntimeWrapper>

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -345,9 +345,7 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
             justifyContent: boundLayoutProps.horizontalAlign,
           }}
         >
-          <div>
-            <Component {...props} />
-          </div>
+          <Component {...props} />
         </Box>
       )}
     </NodeRuntimeWrapper>

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -50,6 +50,7 @@ export interface NodeInfo {
   nodeId: NodeId;
   error?: RuntimeError | null;
   rect?: Rectangle;
+  innerRect?: Rectangle;
   slots?: SlotsState;
   componentConfig?: ComponentConfig<unknown>;
   props: { [key: string]: unknown };

--- a/packages/toolpad-app/src/utils/geometry.ts
+++ b/packages/toolpad-app/src/utils/geometry.ts
@@ -140,6 +140,37 @@ export function getRelativeOuterRect(containerElm: Element, childElm: Element): 
   };
 }
 
+export function getContainerInnerRect(containerElm: Element): Rectangle {
+  const containerElmChildren = containerElm.children;
+  const containerChildRects = [...containerElmChildren].map((child) =>
+    child.getBoundingClientRect(),
+  );
+  const containerChildCorners = containerChildRects
+    .map((rect) => [
+      {
+        x: rect.x,
+        y: rect.y,
+      },
+      {
+        x: rect.x + rect.width,
+        y: rect.y + rect.height,
+      },
+    ])
+    .flat();
+
+  const minX = Math.min(...containerChildCorners.map((corner) => corner.x));
+  const minY = Math.min(...containerChildCorners.map((corner) => corner.y));
+  const maxX = Math.max(...containerChildCorners.map((corner) => corner.x));
+  const maxY = Math.max(...containerChildCorners.map((corner) => corner.y));
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+}
+
 export function rectContainsPoint(rect: Rectangle, x: number, y: number): boolean {
   return rect.x <= x && rect.x + rect.width >= x && rect.y <= y && rect.y + rect.height >= y;
 }

--- a/packages/toolpad-app/src/utils/geometry.ts
+++ b/packages/toolpad-app/src/utils/geometry.ts
@@ -158,10 +158,13 @@ export function getContainerInnerRect(containerElm: Element): Rectangle {
     ])
     .flat();
 
-  const minX = Math.min(...containerChildCorners.map((corner) => corner.x));
-  const minY = Math.min(...containerChildCorners.map((corner) => corner.y));
-  const maxX = Math.max(...containerChildCorners.map((corner) => corner.x));
-  const maxY = Math.max(...containerChildCorners.map((corner) => corner.y));
+  const cornerXs = containerChildCorners.map((corner) => corner.x);
+  const cornerYs = containerChildCorners.map((corner) => corner.y);
+
+  const minX = Math.min(...cornerXs);
+  const minY = Math.min(...cornerYs);
+  const maxX = Math.max(...cornerXs);
+  const maxY = Math.max(...cornerYs);
 
   return {
     x: minX,


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/712

Include an `innerRect` property with the exact position and dimensions of a component, excluding its box container.
This will be useful later for showing a better UI for resizing, for example, and closes this issue I had open along with the other PR.