### PR TITLE
Fix missing jsx key warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,10 +53,13 @@ module.exports = {
           "Please use `condition ? <Jsx /> : null`. Otherwise, there is a chance of rendering '0' instead of '' in some cases. Context: https://stackoverflow.com/q/53048037",
       },
     ],
+    // Turning react/jsx-key back on.
+    // https://github.com/airbnb/javascript/blob/5155aa5fc1ea9bb2c6493a06ddbd5c7a05414c86/packages/eslint-config-airbnb/rules/react.js#L94
+    'react/jsx-key': ['error', { checkKeyMustBeforeSpread: true, warnOnDuplicates: true }],
   },
   overrides: [
     {
-      files: ['./packages/toolpad-app/**/*'],
+      files: ['packages/toolpad-app/**/*'],
       extends: ['plugin:@next/next/recommended'],
       rules: {
         '@next/next/no-html-link-for-pages': ['error', 'packages/toolpad-app/pages/'],

--- a/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
@@ -63,7 +63,7 @@ function PropertiesEditor({ argTypes, value, onChange }: PropertiesEditorProps) 
       {Object.entries(argTypes).map(([name, argType]) => {
         invariant(argType, 'argType not defined');
         return (
-          <ErrorBoundary fallback={<div>{name}</div>} resetKeys={[argType]}>
+          <ErrorBoundary key={name} fallback={<div>{name}</div>} resetKeys={[argType]}>
             <PropertyEditor
               name={name}
               argType={argType}


### PR DESCRIPTION
Fix missing key warning, and debug why eslint isn't catching this