### PR TITLE
Code component console logging

### DIFF
--- a/packages/toolpad-app/src/runtime/ComponentsContext.tsx
+++ b/packages/toolpad-app/src/runtime/ComponentsContext.tsx
@@ -7,6 +7,7 @@ import {
   createComponent,
 } from '@mui/toolpad-core';
 import * as ReactIs from 'react-is';
+import { fireEvent } from '@mui/toolpad-core/runtime';
 import * as appDom from '../appDom';
 import { getToolpadComponents } from '../toolpadComponents';
 import { ensureToolpadComponent } from './loadCodeComponent';
@@ -81,6 +82,10 @@ export default function ComponentsContext({ dom, children }: ComponentsContextPr
 
     return result;
   }, [dom, modules]);
+
+  React.useEffect(() => {
+    fireEvent({ type: 'componentsLoaded', components });
+  }, [components]);
 
   return <ComponentsContextProvider value={components}>{children}</ComponentsContextProvider>;
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box, CircularProgress, styled } from '@mui/material';
+import { Box, CircularProgress, styled, SxProps } from '@mui/material';
 import { NodeId, RuntimeEvent } from '@mui/toolpad-core';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
@@ -44,6 +44,7 @@ export interface EditorCanvasHostProps {
   onRuntimeEvent?: (event: RuntimeEvent) => void;
   onScreenUpdate?: () => void;
   overlay?: React.ReactNode;
+  sx?: SxProps;
 }
 
 const CanvasRoot = styled('div')({
@@ -60,7 +61,7 @@ const CanvasFrame = styled('iframe')({
 
 export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
   function EditorCanvasHost(
-    { appId, className, pageNodeId, dom, overlay, onRuntimeEvent, onScreenUpdate },
+    { appId, className, pageNodeId, dom, overlay, onRuntimeEvent, onScreenUpdate, sx },
     forwardedRef,
   ) {
     const frameRef = React.useRef<HTMLIFrameElement>(null);
@@ -188,7 +189,7 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
     }, [appRoot, onScreenUpdate]);
 
     return (
-      <CanvasRoot className={className}>
+      <CanvasRoot className={className} sx={sx}>
         <Box
           sx={{
             position: 'absolute',

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderPanel.tsx
@@ -48,6 +48,7 @@ export default function RenderPanel({ className }: RenderPanelProps) {
 
   const handleRuntimeEvent = React.useCallback(
     (event: RuntimeEvent) => {
+      // eslint-disable-next-line default-case
       switch (event.type) {
         case 'propUpdated': {
           const node = appDom.getNode(dom, event.nodeId as NodeId, 'element');
@@ -79,12 +80,9 @@ export default function RenderPanel({ className }: RenderPanelProps) {
         }
         case 'pageNavigationRequest': {
           navigate(`../pages/${event.pageNodeId}`);
+          // eslint-disable-next-line no-useless-return
           return;
         }
-        default:
-          throw new Error(
-            `received unrecognized event "${(event as RuntimeEvent).type}" from editor runtime`,
-          );
       }
     },
     [dom, domApi, api, navigate],

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -211,7 +211,8 @@ export type RuntimeEvent =
       bindings: LiveBindings;
     }
   | { type: 'afterRender' }
-  | { type: 'pageNavigationRequest'; pageNodeId: NodeId };
+  | { type: 'pageNavigationRequest'; pageNodeId: NodeId }
+  | { type: 'componentsLoaded'; components: ToolpadComponents };
 
 export interface ComponentConfig<P> {
   /**


### PR DESCRIPTION
- [x] run code components preview in an iframe in its own react root. We'll be reusing our Application preview for this to be able to align as close as possible.
- [ ] intercept console messages
- [ ] add console to code component editor

Fixes https://github.com/mui/mui-toolpad/issues/663