### PR TITLE
Improve drop area design

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeDropArea.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeDropArea.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { styled } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 
 import { FlowDirection } from '../../../../types';
 import * as appDom from '../../../../appDom';
@@ -102,10 +104,12 @@ const EmptySlot = styled('div')({
   border: '1px dashed green',
   color: 'green',
   display: 'flex',
-  fontSize: 20,
+  flexDirection: 'column',
   justifyContent: 'center',
   position: 'absolute',
   opacity: 0.75,
+  textAlign: 'center',
+  fontSize: 30,
 });
 
 function getChildNodeHighlightedZone(parentFlowDirection: FlowDirection): DropZone | null {
@@ -356,7 +360,10 @@ export default function NodeDropArea({
         }}
       />
       {isEmptySlot && slotRect ? (
-        <EmptySlot style={absolutePositionCss(slotRect)}>+</EmptySlot>
+        <EmptySlot style={absolutePositionCss(slotRect)}>
+          <AddCircleOutlineIcon fontSize="inherit" sx={{ marginBottom: 0.2 }} />
+          <Typography variant="caption">Drop component here</Typography>
+        </EmptySlot>
       ) : null}
     </React.Fragment>
   );

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeDropArea.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeDropArea.tsx
@@ -361,7 +361,7 @@ export default function NodeDropArea({
       />
       {isEmptySlot && slotRect ? (
         <EmptySlot style={absolutePositionCss(slotRect)}>
-          <AddCircleOutlineIcon fontSize="inherit" sx={{ marginBottom: 0.2 }} />
+          <AddCircleOutlineIcon fontSize="inherit" sx={{ mb: 0.2 }} />
           <Typography variant="caption">Drop component here</Typography>
         </EmptySlot>
       ) : null}

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -54,8 +54,7 @@ function PlaceholderWrapper(props: PlaceholderWrapperProps) {
   return (
     <div
       style={{
-        display: 'block',
-        minHeight: 40,
+        minHeight: 72,
         minWidth: 200,
       }}
     />


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/773

Improves the look of the drop areas so that it's more difficult for users to wrongly think they're buttons, and it's more obvious how they should work.

Empty page drop area:
<img width="1792" alt="Screen Shot 2022-08-25 at 18 21 00" src="https://user-images.githubusercontent.com/10789765/186729842-d688f27c-2b75-4293-8dd8-b7592c75ff23.png">

Empty component slot drop areas:
<img width="1792" alt="Screen Shot 2022-08-25 at 18 20 42" src="https://user-images.githubusercontent.com/10789765/186729552-01bd4656-d7b2-4261-896f-89d99cac6225.png">

