### PR TITLE
Props panel sections

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
@@ -28,7 +28,7 @@ const ComponentEditorRoot = styled('div')(({ theme }) => ({
     margin: theme.spacing(0, 0),
   },
   [`& .${classes.sectionHeading}`]: {
-    margin: theme.spacing(0, 0),
+    margin: theme.spacing(0, 0, -0.5, 0),
   },
 }));
 
@@ -57,7 +57,7 @@ function ComponentPropsEditor<P>({ componentConfig, node }: ComponentPropsEditor
     <React.Fragment>
       {hasLayoutControls ? (
         <React.Fragment>
-          <Typography variant="subtitle2" className={classes.sectionHeading}>
+          <Typography variant="overline" className={classes.sectionHeading}>
             Layout:
           </Typography>
           {hasLayoutHorizontalControls ? (
@@ -83,7 +83,7 @@ function ComponentPropsEditor<P>({ componentConfig, node }: ComponentPropsEditor
         </React.Fragment>
       ) : null}
       <Divider sx={{ mt: 1 }} />
-      <Typography variant="subtitle2" className={classes.sectionHeading}>
+      <Typography variant="overline" className={classes.sectionHeading}>
         Properties:
       </Typography>
       {(Object.entries(componentConfig.argTypes) as ExactEntriesOf<ArgTypeDefinitions<P>>).map(

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
@@ -1,4 +1,4 @@
-import { Stack, styled, Typography } from '@mui/material';
+import { Stack, styled, Typography, Divider } from '@mui/material';
 import * as React from 'react';
 import { ArgTypeDefinition, ArgTypeDefinitions, ComponentConfig } from '@mui/toolpad-core';
 import { ExactEntriesOf } from '../../../utils/types';
@@ -20,11 +20,15 @@ import {
 
 const classes = {
   control: 'Toolpad_Control',
+  sectionHeading: 'Toolpad_ControlsSectionHeading',
 };
 
-const ComponentPropsEditorRoot = styled('div')(({ theme }) => ({
+const ComponentEditorRoot = styled('div')(({ theme }) => ({
   [`& .${classes.control}`]: {
-    margin: theme.spacing(1, 0),
+    margin: theme.spacing(0, 0),
+  },
+  [`& .${classes.sectionHeading}`]: {
+    margin: theme.spacing(0, 0),
   },
 }));
 
@@ -50,10 +54,10 @@ function ComponentPropsEditor<P>({ componentConfig, node }: ComponentPropsEditor
   const hasLayoutControls = hasLayoutHorizontalControls || hasLayoutVerticalControls;
 
   return (
-    <ComponentPropsEditorRoot>
+    <React.Fragment>
       {hasLayoutControls ? (
         <React.Fragment>
-          <Typography variant="subtitle2" sx={{ mt: 1 }}>
+          <Typography variant="subtitle2" className={classes.sectionHeading}>
             Layout:
           </Typography>
           {hasLayoutHorizontalControls ? (
@@ -78,7 +82,8 @@ function ComponentPropsEditor<P>({ componentConfig, node }: ComponentPropsEditor
           ) : null}
         </React.Fragment>
       ) : null}
-      <Typography variant="subtitle2" sx={{ mt: hasLayoutControls ? 2 : 1 }}>
+      <Divider sx={{ mt: 1 }} />
+      <Typography variant="subtitle2" className={classes.sectionHeading}>
         Properties:
       </Typography>
       {(Object.entries(componentConfig.argTypes) as ExactEntriesOf<ArgTypeDefinitions<P>>).map(
@@ -94,7 +99,7 @@ function ComponentPropsEditor<P>({ componentConfig, node }: ComponentPropsEditor
             </div>
           ) : null,
       )}
-    </ComponentPropsEditorRoot>
+    </React.Fragment>
   );
 }
 
@@ -115,11 +120,12 @@ function SelectedNodeEditor({ node }: SelectedNodeEditorProps) {
       <Typography variant="subtitle1">
         Component: {component?.displayName || '<unknown>'}
       </Typography>
-      <Typography variant="subtitle2" sx={{ mb: 2 }}>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
         ID: {node.id}
       </Typography>
       <NodeNameEditor node={node} />
       {nodeError ? <ErrorAlert error={nodeError} /> : null}
+      <Divider sx={{ mt: 1 }} />
       {node ? (
         <React.Fragment>
           <ComponentPropsEditor componentConfig={componentConfig} node={node} />
@@ -142,13 +148,13 @@ export default function ComponentEditor({ className }: ComponentEditorProps) {
   const selectedNode = selection ? appDom.getNode(dom, selection) : null;
 
   return (
-    <div className={className}>
+    <ComponentEditorRoot className={className}>
       {selectedNode && appDom.isElement(selectedNode) ? (
         // Add key to make sure it mounts every time selected node changes
         <SelectedNodeEditor key={selectedNode.id} node={selectedNode} />
       ) : (
         <PageOptionsPanel />
       )}
-    </div>
+    </ComponentEditorRoot>
   );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
@@ -80,9 +80,9 @@ function ComponentPropsEditor<P>({ componentConfig, node }: ComponentPropsEditor
               />
             </div>
           ) : null}
+          <Divider sx={{ mt: 1 }} />
         </React.Fragment>
       ) : null}
-      <Divider sx={{ mt: 1 }} />
       <Typography variant="overline" className={classes.sectionHeading}>
         Properties:
       </Typography>

--- a/packages/toolpad-app/src/toolpad/propertyControls/HorizontalAlign.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/HorizontalAlign.tsx
@@ -22,7 +22,7 @@ function HorizontalAlignPropEditor({
 
   return (
     <Box>
-      <Typography>{label}:</Typography>
+      <Typography variant="body2">{label}:</Typography>
       <ToggleButtonGroup
         exclusive
         disabled={disabled}

--- a/packages/toolpad-app/src/toolpad/propertyControls/VerticalAlign.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/VerticalAlign.tsx
@@ -19,7 +19,7 @@ function VerticalAlignPropEditor({
 
   return (
     <Box>
-      <Typography>{label}:</Typography>
+      <Typography variant="body2">{label}:</Typography>
       <ToggleButtonGroup
         exclusive
         disabled={disabled}

--- a/packages/toolpad-components/src/Button.tsx
+++ b/packages/toolpad-components/src/Button.tsx
@@ -13,28 +13,28 @@ function Button({ content, ...rest }: ButtonProps) {
 export default createComponent(Button, {
   layoutDirection: 'both',
   argTypes: {
+    onClick: {
+      typeDef: { type: 'event' },
+    },
     content: {
       typeDef: { type: 'string' },
       defaultValue: 'Button Text',
-    },
-    onClick: {
-      typeDef: { type: 'event' },
     },
     variant: {
       typeDef: { type: 'string', enum: ['contained', 'outlined', 'text'] },
       defaultValue: 'contained',
     },
-    disabled: {
-      typeDef: { type: 'boolean' },
-    },
-    fullWidth: {
-      typeDef: { type: 'boolean' },
-    },
     color: {
       typeDef: { type: 'string', enum: ['primary', 'secondary'] },
       defaultValue: 'primary',
     },
+    fullWidth: {
+      typeDef: { type: 'boolean' },
+    },
     loading: {
+      typeDef: { type: 'boolean' },
+    },
+    disabled: {
       typeDef: { type: 'boolean' },
     },
     sx: {

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -338,6 +338,16 @@ export default createComponent(DataGridComponent, {
       typeDef: { type: 'array', schema: '/schemas/DataGridColumns.json' },
       control: { type: 'GridColumns' },
     },
+    rowIdField: {
+      typeDef: { type: 'string' },
+      control: { type: 'RowIdFieldSelect' },
+      label: 'Id field',
+    },
+    selection: {
+      typeDef: { type: 'object' },
+      onChangeProp: 'onSelectionChange',
+      defaultValue: null,
+    },
     density: {
       typeDef: { type: 'string', enum: ['compact', 'standard', 'comfortable'] },
       defaultValue: 'compact',
@@ -346,21 +356,11 @@ export default createComponent(DataGridComponent, {
       typeDef: { type: 'number' },
       defaultValue: 350,
     },
-    sx: {
-      typeDef: { type: 'object' },
-    },
-    selection: {
-      typeDef: { type: 'object' },
-      onChangeProp: 'onSelectionChange',
-      defaultValue: null,
-    },
     loading: {
       typeDef: { type: 'boolean' },
     },
-    rowIdField: {
-      typeDef: { type: 'string' },
-      control: { type: 'RowIdFieldSelect' },
-      label: 'Id field',
+    sx: {
+      typeDef: { type: 'object' },
     },
   },
 });

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -31,23 +31,10 @@ export default createComponent(Select, {
   loadingPropSource: ['value', 'options'],
   loadingProp: 'disabled',
   argTypes: {
-    label: {
-      typeDef: { type: 'string' },
-      defaultValue: '',
-    },
-    disabled: {
-      typeDef: { type: 'boolean' },
-    },
-    variant: {
-      typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
-      defaultValue: 'outlined',
-    },
-    fullWidth: {
-      typeDef: { type: 'boolean' },
-    },
-    size: {
-      typeDef: { type: 'string', enum: ['small', 'medium'] },
-      defaultValue: 'small',
+    options: {
+      typeDef: { type: 'array', schema: '/schemas/SelectOptions.json' },
+      control: { type: 'SelectOptions' },
+      defaultValue: [],
     },
     value: {
       typeDef: { type: 'string' },
@@ -55,10 +42,23 @@ export default createComponent(Select, {
       onChangeHandler: (event: React.ChangeEvent<HTMLSelectElement>) => event.target.value,
       defaultValue: '',
     },
-    options: {
-      typeDef: { type: 'array', schema: '/schemas/SelectOptions.json' },
-      control: { type: 'SelectOptions' },
-      defaultValue: [],
+    label: {
+      typeDef: { type: 'string' },
+      defaultValue: '',
+    },
+    variant: {
+      typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
+      defaultValue: 'outlined',
+    },
+    size: {
+      typeDef: { type: 'string', enum: ['small', 'medium'] },
+      defaultValue: 'small',
+    },
+    fullWidth: {
+      typeDef: { type: 'boolean' },
+    },
+    disabled: {
+      typeDef: { type: 'boolean' },
     },
     sx: {
       typeDef: { type: 'object' },

--- a/packages/toolpad-components/src/Stack.tsx
+++ b/packages/toolpad-components/src/Stack.tsx
@@ -3,13 +3,6 @@ import { createComponent } from '@mui/toolpad-core';
 
 export default createComponent(Stack, {
   argTypes: {
-    gap: {
-      typeDef: { type: 'number' },
-      defaultValue: 2,
-    },
-    margin: {
-      typeDef: { type: 'number' },
-    },
     direction: {
       typeDef: {
         type: 'string',
@@ -30,6 +23,13 @@ export default createComponent(Stack, {
         enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
       },
       defaultValue: 'start',
+    },
+    gap: {
+      typeDef: { type: 'number' },
+      defaultValue: 2,
+    },
+    margin: {
+      typeDef: { type: 'number' },
     },
     children: {
       typeDef: { type: 'element' },

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -18,6 +18,12 @@ function TextField(props: TextFieldProps) {
 export default createComponent(TextField, {
   layoutDirection: 'both',
   argTypes: {
+    value: {
+      typeDef: { type: 'string' },
+      onChangeProp: 'onChange',
+      onChangeHandler: (event: React.ChangeEvent<HTMLInputElement>) => event.target.value,
+      defaultValue: '',
+    },
     label: {
       typeDef: { type: 'string' },
     },
@@ -25,21 +31,15 @@ export default createComponent(TextField, {
       typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },
       defaultValue: 'outlined',
     },
-    disabled: {
-      typeDef: { type: 'boolean' },
-    },
-    fullWidth: {
-      typeDef: { type: 'boolean' },
-    },
     size: {
       typeDef: { type: 'string', enum: ['small', 'normal'] },
       defaultValue: 'small',
     },
-    value: {
-      typeDef: { type: 'string' },
-      onChangeProp: 'onChange',
-      onChangeHandler: (event: React.ChangeEvent<HTMLInputElement>) => event.target.value,
-      defaultValue: '',
+    fullWidth: {
+      typeDef: { type: 'boolean' },
+    },
+    disabled: {
+      typeDef: { type: 'boolean' },
     },
     sx: {
       typeDef: { type: 'object' },


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/819

- Separate component name/id section from layout properties section and component properties section - by using dividers, spacing and trying to improve the typography hierarchy a bit
- Reordered properties of each component to try to make them a bit more logical - if we want to split them more and categorize them in groups we can probably do it separately as I mentioned in the issue (https://github.com/mui/mui-toolpad/issues/819)

Component with layout props:

<img width="1792" alt="Screen Shot 2022-08-26 at 16 13 05" src="https://user-images.githubusercontent.com/10789765/186937501-13fe28c8-a02b-4cf9-8234-d922bd46dfa4.png">

Component without layout props:

<img width="1792" alt="Screen Shot 2022-08-26 at 16 13 12" src="https://user-images.githubusercontent.com/10789765/186937473-b727502f-09bb-4b82-9310-f264aabbb39e.png">

