### PR TITLE
Allow intercepting the console on CanvasHost

### DIFF
--- a/packages/toolpad-app/src/runtime/evalJsBindings.ts
+++ b/packages/toolpad-app/src/runtime/evalJsBindings.ts
@@ -13,6 +13,7 @@ function evaluateCode(code: string, globalScope: Record<string, unknown>) {
 
   // eslint-disable-next-line no-underscore-dangle
   (iframe.contentWindow as any).__SCOPE = globalScope;
+  (iframe.contentWindow as any).console = window.console;
   return (iframe.contentWindow as any).eval(`with (window.__SCOPE) { ${code} }`);
 }
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -134,9 +134,7 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
         // eslint-disable-next-line no-underscore-dangle
       } else if (typeof frameWindow.__TOOLPAD_READY__ !== 'function') {
         // eslint-disable-next-line no-underscore-dangle
-        frameWindow.__TOOLPAD_READY__ = () => {
-          onReadyRef.current?.();
-        };
+        frameWindow.__TOOLPAD_READY__ = () => onReadyRef.current?.();
       }
 
       return () => {


### PR DESCRIPTION
Extracting from https://github.com/mui/mui-toolpad/pull/853
We will have to rethink the strategy of https://github.com/mui/mui-toolpad/pull/853 a bit as the Toolpad react application renders more than once, resulting in duplicate console messages. 