### PR TITLE
Force node 16 on render.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/react-dom": "18.0.5"
   },
   "engines": {
-    "npm": "please-use-yarn"
+    "npm": "please-use-yarn",
+    "node": ">=16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@types/react-dom": "18.0.5"
   },
   "engines": {
-    "npm": "please-use-yarn",
-    "node": ">=16"
+    "npm": "please-use-yarn"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -12,6 +12,8 @@ services:
     plan: starter plus
     pullRequestPreviewsEnabled: true
     envVars:
+      - key: NODE_VERSION
+        value: '16.17.0'
       - key: TOOLPAD_DATABASE_URL
         fromDatabase:
           name: toolpad-db


### PR DESCRIPTION
`String.prototype.replaceAll` is only available on node >=v15, we're already using 16 for the docker image
Closes https://github.com/mui/mui-toolpad/issues/876