### PR TITLE
[website] Fix logo dimension

### DIFF
--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -24,13 +24,12 @@ export default function Hero() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: { xs: 'center', md: 'center' },
-            '& > *': { mr: 1, height: 28 },
           }}
         >
-          <IconImage name="product-toolpad" />
-          <span style={{ display: 'flex', alignItems: 'center', color: 'blue.500' }}>
+          <IconImage name="product-toolpad" width="28" height="28" sx={{ mr: 1 }} />
+          <Box component="span" sx={{ mr: 2 }}>
             MUI Toolpad
-          </span>
+          </Box>
         </Typography>
         <Typography variant="h1" sx={{ my: 2 }}>
           Low-code


### PR DESCRIPTION
Closes #884

This one is weird, I don't get why I can only reproduce it with the production environment.

- https://mui.com/toolpad/ 

<img width="360" alt="Screenshot 2022-09-03 at 19 43 28" src="https://user-images.githubusercontent.com/3165635/188282291-0fa9dbe3-7321-4645-9a4b-ed906c229d5b.png">

- https://master--mui-toolpad-docs.netlify.app/toolpad/

<img width="358" alt="Screenshot 2022-09-03 at 19 43 44" src="https://user-images.githubusercontent.com/3165635/188282297-fc17071c-ea66-40d6-9395-5b43ade81b43.png">

I'm using the opportunity to simplify the logic, e.g. there are inline styles with broken styles. I'm also improving the perceived horizontal centering (not the same as the geometric horizontal center).