### PR TITLE
[core] Add release step for the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Please have a look at our general guidelines for sending pull requests [here](ht
    yarn release:changelog
    ```
 
-   Running this command requires a [Github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the `public_repo` scope.
+   Running this command requires a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the `public_repo` scope.
 
    Set `GITHUB_TOKEN` variable in `.env` file so to avoid passing it with command every time
 
@@ -106,25 +106,27 @@ Please have a look at our general guidelines for sending pull requests [here](ht
 
 1. Wait for the Docker build to finish. (You can find a job [here](https://app.circleci.com/pipelines/github/mui/mui-toolpad?branch=master))
 
-1. Release the Docker image using (requires Github authentication token):
+1. Release the Docker image using (requires GitHub authentication token):
 
    ```sh
    # add --prerelease if necessary
    yarn release:docker
    ```
 
-   This command runs a Github action that retags the Docker image of the release commit in `master` to the version being released and also to "latest", and pushes those new tags. During the release, no new Docker images are created.
+   This command runs a GitHub action that retags the Docker image of the release commit in `master` to the version being released and also to "latest", and pushes those new tags. During the release, no new Docker images are created.
 
-1. [Create a new Github release](https://github.com/mui/mui-toolpad/releases/new).
+1. Publish the documentation. The documentation must be updated on the `docs-latest` branch.
 
+   ```sh
+   git push upstream master:docs-latest -f
+   ```
+
+   You can follow the deployment process on the [Netlify Dashboard](https://app.netlify.com/sites/mui-toolpad-docs/deploys?filter=docs-latest). Once deployed, it will be accessible at https://mui-toolpad-docs.netlify.app/.
+
+1. [Create a new GitHub release](https://github.com/mui/mui-toolpad/releases/new).
    1. Use `<version number>` to **Choose a tag** (when you enter new version GH UI will pop a suggestion `Create new tag: *** on publish`)
-
    1. Use `<commit of merged PR>` as the **target**
-
    1. Use the cleaned changelog as the content of **Describe this release**
-
    1. Use `<version number>` as the **Release title**
-
    1. Mark as prerelease if necessary.
-
    1. **Publish release**


### PR DESCRIPTION
- As far as I know, we can't have https://mui.com/toolpad to map with https://github.com/mui/mui-toolpad/commits/master. This would lead to one structural problem: Documenting new features that developers can't use because not been released yet. There are also other considerations like making it harder to batch the release of PRs together, but it's probably secondary. I have changed the configuration in Netlify and now intend to document it.
- Github -> GitHub

---

As side note, I think that it would be better to move the release step to a different markdown than the contributing guide, the community doesn't care about how we release, at best, it's noise for them and worse, we overwhelm/confuse them. I would recommend the same pattern as https://github.com/mui/mui-x/blob/master/scripts/README.md.