### PR TITLE
Use PostgreSQL as displayName instead of Postgres

### DIFF
--- a/packages/toolpad-app/src/toolpadDataSources/postgres/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/postgres/client.tsx
@@ -236,7 +236,7 @@ function getInitialQueryValue(): PostgresQuery {
 }
 
 const dataSource: ClientDataSource<PostgresConnectionParams, PostgresQuery> = {
-  displayName: 'Postgres',
+  displayName: 'PostgreSQL',
   ConnectionParamsInput,
   QueryEditor,
   getInitialQueryValue,


### PR DESCRIPTION
It's how they refer to themselves
https://www.postgresql.org/