### PR TITLE
Update screen after every render

### DIFF
--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -37,9 +37,14 @@ export default function AppCanvas({ basename }: AppCanvasProps) {
   const [state, setState] = React.useState<AppCanvasState | null>(null);
 
   const appRootRef = React.useRef<HTMLDivElement>();
-  const appRootCleanupRef = React.useRef(() => {});
+  const appRootCleanupRef = React.useRef<() => void>();
   const onAppRoot = React.useCallback((appRoot: HTMLDivElement) => {
-    appRootCleanupRef.current();
+    appRootCleanupRef.current?.();
+    appRootCleanupRef.current = undefined;
+
+    if (!appRoot) {
+      return;
+    }
 
     appRootRef.current = appRoot;
 
@@ -67,6 +72,7 @@ export default function AppCanvas({ basename }: AppCanvasProps) {
   // Notify host after every render
   React.useEffect(() => {
     if (appRootRef.current) {
+      // Only notify screen updates if the approot is rendered
       handleScreenUpdate();
     }
   });

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -69,6 +69,14 @@ export default function AppCanvas({ basename }: AppCanvasProps) {
     };
   }, []);
 
+  React.useEffect(
+    () => () => {
+      appRootCleanupRef.current?.();
+      appRootCleanupRef.current = undefined;
+    },
+    [],
+  );
+
   // Notify host after every render
   React.useEffect(() => {
     if (appRootRef.current) {


### PR DESCRIPTION
Make sure we also call screenupdate after every React render in the runtime. We used to do this before https://github.com/mui/mui-toolpad/pull/858 but it looks like it might have caused https://github.com/mui/mui-toolpad/issues/895