### PR TITLE
Make sure to always assign the overlayroot

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -146,6 +146,8 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
         return undefined;
       }
 
+      setEditorOverlayRoot(contentWindow.document.getElementById(HTML_ID_EDITOR_OVERLAY));
+
       const observer = new MutationObserver(() => {
         setEditorOverlayRoot(contentWindow.document.getElementById(HTML_ID_EDITOR_OVERLAY));
       });


### PR DESCRIPTION
Even if the runtime has already fully rendered. Before it would only assign it in the mutation observer, but if the observer is called after the page had already fully rendered, the overlay root would never be initialized. Fixed after it suddenly started reproducing https://github.com/mui/mui-toolpad/issues/895 locally. 

Fixes https://github.com/mui/mui-toolpad/issues/895