### PR TITLE
Rename parseError to errorFrom

### DIFF
--- a/packages/toolpad-app/src/runtime/evalJsBindings.ts
+++ b/packages/toolpad-app/src/runtime/evalJsBindings.ts
@@ -1,6 +1,6 @@
 import { set } from 'lodash-es';
 import { mapValues } from '../utils/collections';
-import { parseError } from '../utils/errors';
+import { errorFrom } from '../utils/errors';
 
 let iframe: HTMLIFrameElement;
 function evaluateCode(code: string, globalScope: Record<string, unknown>) {
@@ -28,7 +28,7 @@ export function evaluateExpression(
     const value = evaluateCode(code, globalScope);
     return { value };
   } catch (rawError) {
-    const error = parseError(rawError);
+    const error = errorFrom(rawError);
     if (error?.message === TOOLPAD_LOADING_MARKER) {
       return { loading: true };
     }

--- a/packages/toolpad-app/src/runtime/loadModule.tsx
+++ b/packages/toolpad-app/src/runtime/loadModule.tsx
@@ -1,7 +1,7 @@
 import { transform, TransformResult } from 'sucrase';
 import { codeFrameColumns } from '@babel/code-frame';
 import { findImports, isAbsoluteUrl } from '../utils/strings';
-import { parseError } from '../utils/errors';
+import { errorFrom } from '../utils/errors';
 import muiMaterialExports from './muiExports';
 
 async function resolveValues(input: Map<string, Promise<unknown>>): Promise<Map<string, unknown>> {
@@ -61,7 +61,7 @@ export default async function loadModule(src: string): Promise<any> {
       transforms: ['jsx', 'typescript', 'imports'],
     });
   } catch (rawError) {
-    const err = parseError(rawError);
+    const err = errorFrom(rawError);
     if ((err as any).loc) {
       err.message = [err.message, codeFrameColumns(src, { start: (err as any).loc })].join('\n\n');
     }

--- a/packages/toolpad-app/src/toolpad/Home.tsx
+++ b/packages/toolpad-app/src/toolpad/Home.tsx
@@ -48,7 +48,7 @@ import useLocalStorageState from '../utils/useLocalStorageState';
 import ErrorAlert from './AppEditor/PageEditor/ErrorAlert';
 import { ConfirmDialog } from '../components/SystemDialogs';
 import config from '../config';
-import { parseError } from '../utils/errors';
+import { errorFrom } from '../utils/errors';
 
 export interface CreateAppDialogProps {
   open: boolean;
@@ -193,7 +193,7 @@ function AppNameEditable({ app, editing, setEditing, loading }: AppNameEditableP
           await client.mutation.updateApp(app.id, name);
           await client.invalidateQueries('getApps');
         } catch (rawError) {
-          setAppRenameError(parseError(rawError));
+          setAppRenameError(errorFrom(rawError));
           setEditing(true);
         }
       }

--- a/packages/toolpad-app/src/toolpadDataSources/postgres/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/postgres/server.ts
@@ -1,6 +1,6 @@
 import { Client, QueryConfig } from 'pg';
 import { ServerDataSource } from '../../types';
-import { parseError } from '../../utils/errors';
+import { errorFrom } from '../../utils/errors';
 import { Maybe } from '../../utils/types';
 import {
   PostgresConnectionParams,
@@ -62,7 +62,7 @@ async function execBase(
       data: res.rows,
     };
   } catch (rawError) {
-    const error = parseError(rawError);
+    const error = errorFrom(rawError);
     error.message = parseErrorMessage(error.message, paramEntries);
     return {
       data: [],
@@ -103,7 +103,7 @@ async function execPrivate(
         await client.query('SELECT * FROM version();');
         return { error: null };
       } catch (rawError) {
-        const err = parseError(rawError);
+        const err = errorFrom(rawError);
         return { error: err.message };
       }
     }

--- a/packages/toolpad-app/src/toolpadDataSources/rest/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/server.ts
@@ -17,7 +17,7 @@ import { removePrefix } from '../../utils/strings';
 import { Maybe } from '../../utils/types';
 import { getAuthenticationHeaders, HTTP_NO_BODY, parseBaseUrl } from './shared';
 import applyTransform from '../../server/applyTransform';
-import { parseError } from '../../utils/errors';
+import { errorFrom } from '../../utils/errors';
 
 async function resolveBindable(
   bindable: BindableAttrValue<string>,
@@ -190,7 +190,7 @@ async function execBase(
       data = await applyTransform(fetchQuery.transform, untransformedData);
     }
   } catch (rawError) {
-    error = parseError(rawError);
+    error = errorFrom(rawError);
   }
 
   return { data, untransformedData, error, har };

--- a/packages/toolpad-app/src/utils/errors.ts
+++ b/packages/toolpad-app/src/utils/errors.ts
@@ -1,7 +1,7 @@
 import { hasOwnProperty } from './collections';
 import { truncate } from './strings';
 
-export function parseError(maybeError: unknown): Error {
+export function errorFrom(maybeError: unknown): Error {
   if (maybeError instanceof Error) {
     return maybeError;
   }


### PR DESCRIPTION
Pulled out of https://github.com/mui/mui-toolpad/pull/943 in an effort to declutter it a bit

This just renames it since its behavior is closer to `Array.from` but for `Error` objects. Want to reserve the name `parseError` something that sits closer to the inverse of https://github.com/mui/mui-toolpad/pull/943 's `serializeError`