### PR TITLE
Preserve javascript semantics when dependencies fail

### DIFF
--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -457,8 +457,8 @@ function QueryNode({ node }: QueryNodeProps) {
     // Here we propagate the error and loading state to the data and rows prop prop
     // TODO: is there a straightforward way for us to generalize this behavior?
     setControlledBinding(`${node.id}.isLoading`, { value: isLoading });
+    setControlledBinding(`${node.id}.error`, { value: error });
     const deferredStatus = { loading: isLoading, error };
-    setControlledBinding(`${node.id}.error`, { ...deferredStatus, value: error });
     setControlledBinding(`${node.id}.data`, { ...deferredStatus, value: data });
     setControlledBinding(`${node.id}.rows`, { ...deferredStatus, value: rows });
   }, [node.id, queryResult, setControlledBinding]);


### PR DESCRIPTION
Currently when an underlying value in a binding expression fails or is loading, the whole expression evaluates to undefined. As can be seen in the following:

<img width="892" alt="Screenshot 2022-09-09 at 11 21 52" src="https://user-images.githubusercontent.com/2109932/189317976-ef697450-57c9-4c06-ab37-db7ef5cee893.png">

the second line is bound to the error message of a failing query
the third line is bound to the data of a failing query

Both of them show the default value "Text" of the Typography component. This PR corrects the behavior and makes sure we can bind to the error message, or the data (`undefined`) when a query fails. The error information is still preserved. 

<img width="856" alt="Screenshot 2022-09-09 at 11 29 15" src="https://user-images.githubusercontent.com/2109932/189318966-be4b48e8-0afa-4454-8738-ff4d6a9ab95d.png">


The runtime engine now tracks dependencies of expressions. We can build further on top of this to provide more insight into how the toolpad nodes are interconnected for https://github.com/mui/mui-toolpad/issues/523