### PR TITLE
Put Toolpad user in charge of response parsing

### DIFF
--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -101,7 +101,6 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.8.2",
     "web-streams-polyfill": "^3.2.1",
-    "whatwg-mimetype": "^3.0.0",
     "whatwg-url": "^11.0.0"
   },
   "devDependencies": {
@@ -119,7 +118,6 @@
     "@types/react-dom": "^18.0.6",
     "@types/react-inspector": "^4.0.2",
     "@types/serialize-javascript": "^5.0.2",
-    "@types/whatwg-mimetype": "^2.1.1",
     "@types/whatwg-url": "^11.0.0",
     "ajv": "^8.11.0",
     "eslint": "8.23.0",

--- a/packages/toolpad-app/src/toolpadDataSources/TranformInput.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/TranformInput.tsx
@@ -1,4 +1,4 @@
-import { Stack, Grid, Checkbox, FormControlLabel, IconButton } from '@mui/material';
+import { Stack, Grid, Checkbox, FormControlLabel, IconButton, Tooltip } from '@mui/material';
 import * as React from 'react';
 
 import AutorenewIcon from '@mui/icons-material/Autorenew';
@@ -10,6 +10,8 @@ export interface TransformInputProps {
   onChange: (newValue: string) => void;
   enabled: boolean;
   onEnabledChange: (newValue: boolean) => void;
+  rawResponse: boolean;
+  onRawResponseChange: (newValue: boolean) => void;
   globalScope: Record<string, any>;
   loading: boolean;
   onUpdatePreview?: () => void;
@@ -20,10 +22,17 @@ export default function TransformInput({
   onChange,
   enabled,
   onEnabledChange,
+  rawResponse,
+  onRawResponseChange,
   globalScope,
   loading,
   onUpdatePreview,
 }: TransformInputProps) {
+  const handleRawResponseChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => onRawResponseChange(event.target.checked),
+    [onRawResponseChange],
+  );
+
   const handleTransformEnabledChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => onEnabledChange(event.target.checked),
     [onEnabledChange],
@@ -32,16 +41,33 @@ export default function TransformInput({
   return (
     <Grid item xs={6} md={12}>
       <Stack>
-        <FormControlLabel
-          label="Transform response"
-          control={
-            <Checkbox
-              checked={enabled}
-              onChange={handleTransformEnabledChange}
-              inputProps={{ 'aria-label': 'controlled' }}
+        <Stack direction="row" gap={1}>
+          <FormControlLabel
+            label="Transform response"
+            control={
+              <Checkbox
+                checked={enabled}
+                onChange={handleTransformEnabledChange}
+                inputProps={{ 'aria-label': 'controlled' }}
+              />
+            }
+          />
+          <Tooltip
+            title="Check to avoid automatically parsing the response based on the content"
+            describeChild
+          >
+            <FormControlLabel
+              label="Use the raw response"
+              control={
+                <Checkbox
+                  checked={rawResponse}
+                  onChange={handleRawResponseChange}
+                  inputProps={{ 'aria-label': 'controlled' }}
+                />
+              }
             />
-          }
-        />
+          </Tooltip>
+        </Stack>
 
         <Stack direction={'row'} spacing={2} width={'100%'}>
           <JsonView

--- a/packages/toolpad-app/src/toolpadDataSources/TranformInput.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/TranformInput.tsx
@@ -1,4 +1,4 @@
-import { Stack, Grid, Checkbox, FormControlLabel, IconButton, Tooltip } from '@mui/material';
+import { Stack, Grid, Checkbox, FormControlLabel, IconButton } from '@mui/material';
 import * as React from 'react';
 
 import AutorenewIcon from '@mui/icons-material/Autorenew';
@@ -10,8 +10,6 @@ export interface TransformInputProps {
   onChange: (newValue: string) => void;
   enabled: boolean;
   onEnabledChange: (newValue: boolean) => void;
-  rawResponse: boolean;
-  onRawResponseChange: (newValue: boolean) => void;
   globalScope: Record<string, any>;
   loading: boolean;
   onUpdatePreview?: () => void;
@@ -22,17 +20,10 @@ export default function TransformInput({
   onChange,
   enabled,
   onEnabledChange,
-  rawResponse,
-  onRawResponseChange,
   globalScope,
   loading,
   onUpdatePreview,
 }: TransformInputProps) {
-  const handleRawResponseChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => onRawResponseChange(event.target.checked),
-    [onRawResponseChange],
-  );
-
   const handleTransformEnabledChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => onEnabledChange(event.target.checked),
     [onEnabledChange],
@@ -41,33 +32,16 @@ export default function TransformInput({
   return (
     <Grid item xs={6} md={12}>
       <Stack>
-        <Stack direction="row" gap={1}>
-          <FormControlLabel
-            label="Transform response"
-            control={
-              <Checkbox
-                checked={enabled}
-                onChange={handleTransformEnabledChange}
-                inputProps={{ 'aria-label': 'controlled' }}
-              />
-            }
-          />
-          <Tooltip
-            title="Check to avoid automatically parsing the response based on the content"
-            describeChild
-          >
-            <FormControlLabel
-              label="Use the raw response"
-              control={
-                <Checkbox
-                  checked={rawResponse}
-                  onChange={handleRawResponseChange}
-                  inputProps={{ 'aria-label': 'controlled' }}
-                />
-              }
+        <FormControlLabel
+          label="Transform response"
+          control={
+            <Checkbox
+              checked={enabled}
+              onChange={handleTransformEnabledChange}
+              inputProps={{ 'aria-label': 'controlled' }}
             />
-          </Tooltip>
-        </Stack>
+          }
+        />
 
         <Stack direction={'row'} spacing={2} width={'100%'}>
           <JsonView

--- a/packages/toolpad-app/src/toolpadDataSources/rest/BodyEditor.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/BodyEditor.tsx
@@ -118,6 +118,8 @@ function RawBodyEditor({
           <React.Fragment>
             <TextField
               select
+              label="content-type"
+              sx={{ width: 200 }}
               value={value?.contentType.value}
               onChange={handleContentTypeChange}
               disabled={disabled}
@@ -227,7 +229,14 @@ export default function BodyEditor({
   const renderToolbar = React.useCallback<RenderBodyToolbar>(
     ({ actions } = {}) => (
       <BodyEditorToolbar>
-        <TextField select value={activeTab} onChange={handleTabChange} disabled={disabled}>
+        <TextField
+          label="body"
+          sx={{ width: 200 }}
+          select
+          value={activeTab}
+          onChange={handleTabChange}
+          disabled={disabled}
+        >
           <MenuItem value="raw">raw</MenuItem>
           <MenuItem value="urlEncoded">x-www-form-urlencoded</MenuItem>
         </TextField>

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -204,6 +204,13 @@ function QueryEditor({
     }));
   }, []);
 
+  const handleRawResponseChange = React.useCallback((rawResponse: boolean) => {
+    setInput((existing) => ({
+      ...existing,
+      query: { ...existing.query, rawResponse },
+    }));
+  }, []);
+
   const handleTransformChange = React.useCallback((transform: string) => {
     setInput((existing) => ({
       ...existing,
@@ -358,6 +365,8 @@ function QueryEditor({
                       onChange={handleTransformChange}
                       enabled={input.query.transformEnabled ?? false}
                       onEnabledChange={handleTransformEnabledChange}
+                      rawResponse={input.query.rawResponse ?? false}
+                      onRawResponseChange={handleRawResponseChange}
                       globalScope={{ data: preview?.untransformedData }}
                       loading={false}
                     />

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -14,7 +14,14 @@ import {
 import { Controller, useForm } from 'react-hook-form';
 import { TabContext, TabList } from '@mui/lab';
 import { ClientDataSource, ConnectionEditorProps, QueryEditorProps } from '../../types';
-import { FetchPrivateQuery, FetchQuery, FetchResult, RestConnectionParams, Body } from './types';
+import {
+  FetchPrivateQuery,
+  FetchQuery,
+  FetchResult,
+  RestConnectionParams,
+  Body,
+  ResponseType,
+} from './types';
 import { getAuthenticationHeaders, parseBaseUrl } from './shared';
 import BindableEditor, {
   RenderControlParams,
@@ -204,13 +211,6 @@ function QueryEditor({
     }));
   }, []);
 
-  const handleRawResponseChange = React.useCallback((rawResponse: boolean) => {
-    setInput((existing) => ({
-      ...existing,
-      query: { ...existing.query, rawResponse },
-    }));
-  }, []);
-
   const handleTransformChange = React.useCallback((transform: string) => {
     setInput((existing) => ({
       ...existing,
@@ -238,6 +238,16 @@ function QueryEditor({
       query: { ...existing.query, headers: newHeaders },
     }));
   }, []);
+
+  const handleResponseTypeChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setInput((existing) => ({
+        ...existing,
+        query: { ...existing.query, response: { kind: event.target.value } as ResponseType },
+      }));
+    },
+    [],
+  );
 
   const paramsEditorLiveValue = useEvaluateLiveBindingEntries({
     input: input.params,
@@ -332,6 +342,7 @@ function QueryEditor({
                       <Tab label="URL query" value="urlQuery" />
                       <Tab label="Body" value="body" />
                       <Tab label="Headers" value="headers" />
+                      <Tab label="Response" value="response" />
                       <Tab label="Transform" value="transform" />
                     </TabList>
                   </Box>
@@ -359,14 +370,30 @@ function QueryEditor({
                       liveValue={liveHeaders}
                     />
                   </TabPanel>
+                  <TabPanel disableGutters value="response">
+                    <TextField
+                      select
+                      label="response type"
+                      sx={{ width: 200, mt: 1 }}
+                      value={input.query.response?.kind || 'json'}
+                      onChange={handleResponseTypeChange}
+                    >
+                      <MenuItem value="raw">raw</MenuItem>
+                      <MenuItem value="json">JSON</MenuItem>
+                      <MenuItem value="csv" disabled>
+                        🚧 CSV
+                      </MenuItem>
+                      <MenuItem value="xml" disabled>
+                        🚧 XML
+                      </MenuItem>
+                    </TextField>
+                  </TabPanel>
                   <TabPanel disableGutters value="transform">
                     <TransformInput
                       value={input.query.transform ?? 'return data;'}
                       onChange={handleTransformChange}
                       enabled={input.query.transformEnabled ?? false}
                       onEnabledChange={handleTransformEnabledChange}
-                      rawResponse={input.query.rawResponse ?? false}
-                      onRawResponseChange={handleRawResponseChange}
                       globalScope={{ data: preview?.untransformedData }}
                       loading={false}
                     />

--- a/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
@@ -44,6 +44,28 @@ export type UrlEncodedBody = {
 
 export type Body = RawBody | UrlEncodedBody;
 
+export type RawResponseType = {
+  kind: 'raw';
+};
+
+export type JsonResponseType = {
+  kind: 'json';
+};
+
+export type CsvResponseType = {
+  kind: 'csv';
+  /**
+   * First row contains headers
+   */
+  headers: boolean;
+};
+
+export type XmlResponseType = {
+  kind: 'xml';
+};
+
+export type ResponseType = RawResponseType | JsonResponseType | CsvResponseType | XmlResponseType;
+
 export interface FetchQuery {
   /**
    * The URL of the rquest.
@@ -74,9 +96,9 @@ export interface FetchQuery {
    */
   readonly transform?: string;
   /**
-   * Don't parse the content automatically, always return the raw response.
+   * How to parse the response.
    */
-  readonly rawResponse?: boolean;
+  readonly response?: ResponseType;
 }
 
 export type FetchParams = {

--- a/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/types.ts
@@ -45,13 +45,38 @@ export type UrlEncodedBody = {
 export type Body = RawBody | UrlEncodedBody;
 
 export interface FetchQuery {
+  /**
+   * The URL of the rquest.
+   */
   readonly url: BindableAttrValue<string>;
+  /**
+   * The request method.
+   */
   readonly method: string;
+  /**
+   * Extra request headers.
+   */
   readonly headers: [string, BindableAttrValue<string>][];
+  /**
+   * Extra url query parameters.
+   */
   readonly searchParams?: [string, BindableAttrValue<string>][];
+  /**
+   * The request body.
+   */
   readonly body?: Body;
+  /**
+   * Run a custom transformer on the response.
+   */
   readonly transformEnabled?: boolean;
+  /**
+   * The custom transformer to run when enabled.
+   */
   readonly transform?: string;
+  /**
+   * Don't parse the content automatically, always return the raw response.
+   */
+  readonly rawResponse?: boolean;
 }
 
 export type FetchParams = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,11 +2951,6 @@
   resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz#2b8e60e33906459219aa587e9d1a612ae994cfe7"
   integrity sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==
 
-"@types/whatwg-mimetype@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@types/whatwg-mimetype/-/whatwg-mimetype-2.1.1.tgz#1b7b7aecaa3695209fd2f3a808dd5729973a52fa"
-  integrity sha512-ojnf89qt5AWnqsjyPqMLN8uVaxm5x23vxNQ1me6EPBOdJe1YYuIZUzg809MZUG8UU6HKhkr6ah4fi2WUvD0DFw==
-
 "@types/whatwg-url@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-11.0.0.tgz#5c42518a163a6867e14235223a1a558143bccbab"


### PR DESCRIPTION
- Put user in charge of how responses are parsed. 
- We default to json, but user can choose to use the raw response. 
- later on we could add csv and xml parsers as well.
- later on we could add a message when the `content-type` header doesn't match and direct users to the "response" tab.
- if for some reason users want to put the server in charge, we can always add a "detect" mode




https://user-images.githubusercontent.com/2109932/189864202-4000d7f6-76fc-4f17-8b66-a2c09de0dc6a.mov


