### PR TITLE
[security] Improve the HTTP headers for security

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -14,6 +14,5 @@
   # Force the browser to trust the Content-Type header
   # https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff
   X-Content-Type-Options: nosniff
-  # Disable it (default) as it can cause security issues.
-  X-XSS-Protection: 0
+  X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -57,19 +57,46 @@ const regexEqual = (x, y) => {
   );
 };
 
+const securityHeaders = [
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=31536000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+  {
+    // Force the browser to trust the Content-Type header
+    // https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-XSS-Protection',
+    value: '1; mode=block',
+  },
+  {
+    key: 'X-XSS-Protection',
+    value: '1; mode=block',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+];
+
 const NEVER = () => false;
 
 export default /** @type {import('next').NextConfig} */ ({
   reactStrictMode: true,
-
+  poweredByHeader: false,
   eslint: {
     // We're running this as part of the monorepo eslint
     ignoreDuringBuilds: true,
   },
-
   // build-time env vars
   env: parseBuidEnvVars(process.env),
-
   /**
    * @param {import('webpack').Configuration} config
    */
@@ -124,7 +151,6 @@ export default /** @type {import('next').NextConfig} */ ({
 
     return config;
   },
-
   async redirects() {
     return [
       {
@@ -134,7 +160,6 @@ export default /** @type {import('next').NextConfig} */ ({
       },
     ];
   },
-
   async rewrites() {
     return [
       {
@@ -142,5 +167,13 @@ export default /** @type {import('next').NextConfig} */ ({
         destination: '/api/health-check',
       },
     ];
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ]
   },
 });

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -60,10 +60,6 @@ const regexEqual = (x, y) => {
 // See https://nextjs.org/docs/advanced-features/security-headers
 const securityHeaders = [
   {
-    key: 'Strict-Transport-Security',
-    value: 'max-age=31536000; includeSubDomains; preload',
-  },
-  {
     key: 'X-Frame-Options',
     value: 'SAMEORIGIN',
   },

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -161,7 +161,7 @@ export default /** @type {import('next').NextConfig} */ ({
       },
     ];
   },
-  async headers() {
+  headers: async () => {
     return [
       {
         source: '/:path*',

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -57,6 +57,7 @@ const regexEqual = (x, y) => {
   );
 };
 
+// See https://nextjs.org/docs/advanced-features/security-headers
 const securityHeaders = [
   {
     key: 'Strict-Transport-Security',

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -74,10 +74,6 @@ const securityHeaders = [
     value: '1; mode=block',
   },
   {
-    key: 'X-XSS-Protection',
-    value: '1; mode=block',
-  },
-  {
     key: 'Referrer-Policy',
     value: 'strict-origin-when-cross-origin',
   },


### PR DESCRIPTION
I'm working on improving the perceived security of MUI to solve some of the friction that we have with the sales on MUI X. Some companies are using https://www.riskrecon.com/:

<img width="341" alt="Screenshot 2022-09-17 at 00 43 36" src="https://user-images.githubusercontent.com/3165635/190827272-40047a36-32b8-422b-b088-3fa0c87aa9b9.png">

we are the worst. In this PR, I'm going after:

<img width="1092" alt="Screenshot 2022-09-17 at 00 44 35" src="https://user-images.githubusercontent.com/3165635/190827255-d7503ea6-49d6-4592-8ae8-c3866ae3b824.png">

This PR implements most of https://nextjs.org/docs/advanced-features/security-headers.