### PR TITLE
[core] Improve Windows compatibility

### DIFF
--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -106,7 +106,7 @@ export default /** @type {import('next').NextConfig} */ ({
     {
       // Support global CSS in monaco-editor
       // Adapted from next-transpile-modules.
-      const extraCssIssuer = /\/node_modules\/monaco-editor\//;
+      const extraCssIssuer = /(\/|\\)node_modules(\/|\\)monaco-editor(\/|\\)/;
       const modulesPaths = [path.dirname(require.resolve('monaco-editor/package.json'))];
 
       config.module = config.module ?? {};


### PR DESCRIPTION
~A guess based on #1034~. Closes #1034. This is a common issue with Windows vs. Linux. I have seen this one a lot of times on Material UI, e.g. https://github.com/mui/material-ui/pull/32091

*I can no longer use Boot Camp with macOS to have a dual boot with Windows since I have an M1 (ARM architecture).*