### PR TITLE
[core] Add default data to DataGrid, Image, Select components

### DIFF
--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -154,6 +154,11 @@ export function inferColumns(rows: GridRowsProp): SerializableGridColumns {
   return Object.entries(firstRow).map(([field, value]) => {
     return {
       field,
+      headerName:
+        // turn field into a human readable name by capitalizing the first letter and replacing camel case with spaces
+        field[0].toUpperCase() + field.slice(1).replace(/([A-Z])/g, ' $1'),
+      // Add minimum width to the columns
+      width: 150,
       type: inferColumnType(value),
     };
   });
@@ -167,7 +172,52 @@ export function parseColumns(columns: SerializableGridColumns): GridColumns {
   }));
 }
 
-const EMPTY_ROWS: GridRowsProp = [];
+const DEFAULT_COLUMNS: (Omit<GridColDef, 'type'> & { type: string })[] = [
+  { field: 'id', headerName: 'ID', type: 'number', width: 90 },
+  {
+    field: 'firstName',
+    headerName: 'First name',
+    type: 'string',
+    width: 150,
+    editable: true,
+  },
+  {
+    field: 'lastName',
+    headerName: 'Last name',
+    type: 'string',
+    width: 150,
+    editable: true,
+  },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    width: 110,
+    editable: true,
+  },
+  {
+    field: 'fullName',
+    headerName: 'Full name',
+    description: 'This column has a value getter and is not sortable.',
+    type: 'string',
+    sortable: false,
+    width: 160,
+    valueGetter: (params: GridValueGetterParams) =>
+      `${params.row.firstName || ''} ${params.row.lastName || ''}`,
+  },
+];
+
+const DEFAULT_ROWS: GridRowsProp = [
+  { id: 1, lastName: 'Snow', firstName: 'Jon', age: 35 },
+  { id: 2, lastName: 'Lannister', firstName: 'Cersei', age: 42 },
+  { id: 3, lastName: 'Lannister', firstName: 'Jaime', age: 45 },
+  { id: 4, lastName: 'Stark', firstName: 'Arya', age: 16 },
+  { id: 5, lastName: 'Targaryen', firstName: 'Daenerys', age: null },
+  { id: 6, lastName: 'Melisandre', firstName: null, age: 150 },
+  { id: 7, lastName: 'Clifford', firstName: 'Ferrara', age: 44 },
+  { id: 8, lastName: 'Frances', firstName: 'Rossini', age: 36 },
+  { id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
+];
 
 interface Selection {
   id?: any;
@@ -242,7 +292,7 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
   );
   React.useEffect(() => handleColumnOrderChange.clear(), [handleColumnOrderChange]);
 
-  const rowsInput = rowsProp || EMPTY_ROWS;
+  const rowsInput = rowsProp || DEFAULT_ROWS;
 
   const hasExplicitRowId: boolean = React.useMemo(() => {
     const hasRowIdField: boolean = !!(rowIdFieldProp && rowIdFieldProp !== 'id');
@@ -256,10 +306,14 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
   );
 
   const columnsInitRef = React.useRef(false);
-  const hasColumnsDefined = columnsProp && columnsProp.length > 0;
+  const isUsingDefaultData = rows === DEFAULT_ROWS;
+  const columns: GridColumns = React.useMemo(
+    () => (columnsProp ? parseColumns(columnsProp) : DEFAULT_COLUMNS),
+    [columnsProp],
+  );
 
   React.useEffect(() => {
-    if (!nodeRuntime || hasColumnsDefined || rows.length <= 0 || columnsInitRef.current) {
+    if (!nodeRuntime || isUsingDefaultData || rows.length <= 0 || columnsInitRef.current) {
       return;
     }
 
@@ -272,7 +326,7 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
     nodeRuntime.updateAppDomConstProp('columns', inferredColumns);
 
     columnsInitRef.current = true;
-  }, [hasColumnsDefined, rows, nodeRuntime, hasExplicitRowId]);
+  }, [isUsingDefaultData, rows, nodeRuntime, hasExplicitRowId]);
 
   const getRowId = React.useCallback(
     (row: any) => {
@@ -291,11 +345,6 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
   const selectionModel = React.useMemo(
     () => (selection?.id ? [selection.id] : []),
     [selection?.id],
-  );
-
-  const columns: GridColumns = React.useMemo(
-    () => (columnsProp ? parseColumns(columnsProp) : []),
-    [columnsProp],
   );
 
   const apiRef = useGridApiRef();
@@ -341,15 +390,18 @@ export default createComponent(DataGridComponent, {
   argTypes: {
     rows: {
       typeDef: { type: 'array', schema: '/schemas/DataGridRows.json' },
+      defaultValue: DEFAULT_ROWS,
     },
     columns: {
       typeDef: { type: 'array', schema: '/schemas/DataGridColumns.json' },
       control: { type: 'GridColumns' },
+      defaultValue: DEFAULT_COLUMNS,
     },
     rowIdField: {
       typeDef: { type: 'string' },
       control: { type: 'RowIdFieldSelect' },
       label: 'Id field',
+      defaultValue: 'id',
     },
     selection: {
       typeDef: { type: 'object' },

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -219,6 +219,8 @@ const DEFAULT_ROWS: GridRowsProp = [
   { id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
 ];
 
+const EMPTY_ROWS: GridRowsProp = [];
+
 interface Selection {
   id?: any;
 }
@@ -292,12 +294,11 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
   );
   React.useEffect(() => handleColumnOrderChange.clear(), [handleColumnOrderChange]);
 
-  const rowsInput = rowsProp || DEFAULT_ROWS;
+  const rowsInput = rowsProp || EMPTY_ROWS;
 
   const hasExplicitRowId: boolean = React.useMemo(() => {
     const hasRowIdField: boolean = !!(rowIdFieldProp && rowIdFieldProp !== 'id');
-    const parsedRows = rowsInput;
-    return parsedRows.length === 0 || hasRowIdField || !!parsedRows[0].id;
+    return rowsInput.length === 0 || hasRowIdField || !!rowsInput[0].id;
   }, [rowIdFieldProp, rowsInput]);
 
   const rows: GridRowsProp = React.useMemo(

--- a/packages/toolpad-components/src/Image.tsx
+++ b/packages/toolpad-components/src/Image.tsx
@@ -12,6 +12,8 @@ export interface ImageProps {
   fit: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
 }
 
+const DEFAULT_IMG_SRC = 'https://mui.com/static/branding/mui-x/Mocktable-dark.png';
+
 function Image({ sx: sxProp, src, width, height, alt, loading: loadingProp, fit }: ImageProps) {
   const sx: SxProps = React.useMemo(
     () => ({
@@ -58,6 +60,7 @@ export default createComponent(Image, {
   argTypes: {
     src: {
       typeDef: { type: 'string' },
+      defaultValue: DEFAULT_IMG_SRC,
     },
     alt: {
       typeDef: { type: 'string' },

--- a/packages/toolpad-components/src/Image.tsx
+++ b/packages/toolpad-components/src/Image.tsx
@@ -12,7 +12,8 @@ export interface ImageProps {
   fit: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
 }
 
-const DEFAULT_IMG_SRC = 'https://mui.com/static/branding/mui-x/Mocktable-dark.png';
+const DEFAULT_IMG_SRC =
+  'https://images.unsplash.com/photo-1663436031310-f40198ba736e?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80';
 
 function Image({ sx: sxProp, src, width, height, alt, loading: loadingProp, fit }: ImageProps) {
   const sx: SxProps = React.useMemo(

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -11,6 +11,11 @@ export type SelectProps = TextFieldProps & {
   options: (string | SelectOption)[];
 };
 
+const DEFAULT_OPTIONS = {
+  options: ['January', 'February', 'March', 'April', 'May', 'June'],
+  label: 'Months',
+};
+
 function Select({ options, value, defaultValue, fullWidth, sx, ...rest }: SelectProps) {
   return (
     <TextField
@@ -40,7 +45,7 @@ export default createComponent(Select, {
     options: {
       typeDef: { type: 'array', schema: '/schemas/SelectOptions.json' },
       control: { type: 'SelectOptions' },
-      defaultValue: [],
+      defaultValue: DEFAULT_OPTIONS.options,
     },
     value: {
       typeDef: { type: 'string' },
@@ -51,11 +56,11 @@ export default createComponent(Select, {
     },
     defaultValue: {
       typeDef: { type: 'string' },
-      defaultValue: '',
+      defaultValue: DEFAULT_OPTIONS.options[0],
     },
     label: {
       typeDef: { type: 'string' },
-      defaultValue: '',
+      defaultValue: DEFAULT_OPTIONS.label,
     },
     variant: {
       typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -12,8 +12,21 @@ export type SelectProps = TextFieldProps & {
 };
 
 const DEFAULT_OPTIONS = {
-  options: ['January', 'February', 'March', 'April', 'May', 'June'],
-  label: 'Months',
+  options: [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ],
+  label: 'Month',
 };
 
 function Select({ options, value, defaultValue, fullWidth, sx, ...rest }: SelectProps) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Closes #841 
- Visual demonstration <!-- Screenshot/Video link -->

- The DataGrid will have default data (similar to this https://mui.com/x/react-data-grid/#mit-version  in the demos). 

- It will automatically re-infer columns if the rows are changed from the default ones, but not after that (To match the current behaviour)

- Added some clean up of the columns (adding a readable `headerName` and a default minimum width)

https://user-images.githubusercontent.com/19550456/191744094-c35166ef-b291-4b0d-b832-8d9304868efc.mov

- The Image and Select will have default data as well

https://user-images.githubusercontent.com/19550456/191744162-8558ca87-b31f-4f4b-bf00-e5bcff069d32.mov



