### PR TITLE
[docs] Disable todo pages in docs

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -61,21 +61,21 @@ const pages: MuiPage[] = [
     pathname: '/toolpad/data-binding',
     icon: 'CodeIcon',
   },
-  {
-    pathname: '/toolpad/versioning-and-deploying',
-    title: 'Versioning & deploying [TODO]',
-    icon: 'ToggleOnIcon',
-    children: [
-      {
-        pathname: '/toolpad/versioning-and-deploying/releases',
-      },
-    ],
-  },
-  {
-    pathname: '/toolpad/faq',
-    title: 'FAQ [TODO]',
-    icon: 'ReaderIcon',
-  },
+  // {
+  //   pathname: '/toolpad/versioning-and-deploying',
+  //   title: 'Versioning & deploying [TODO]',
+  //   icon: 'ToggleOnIcon',
+  //   children: [
+  //     {
+  //       pathname: '/toolpad/versioning-and-deploying/releases',
+  //     },
+  //   ],
+  // },
+  // {
+  //   pathname: '/toolpad/faq',
+  //   title: 'FAQ [TODO]',
+  //   icon: 'ReaderIcon',
+  // },
 ];
 
 export default pages;


### PR DESCRIPTION
Disabling pages in navigation that aren't implemented yet

Before:

<img width="363" alt="image" src="https://user-images.githubusercontent.com/437214/192223841-4bc0e009-8b8c-49bc-b5d6-33621dea6ca5.png">

After:

<img width="333" alt="image" src="https://user-images.githubusercontent.com/437214/192223868-8be2ce6a-34fb-48e7-ae71-b38fa875eafa.png">
