### PR TITLE
[core] Don't build on render for docs changes

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -21,11 +21,15 @@ services:
           name: toolpad-db
           property: connectionString
       - fromGroup: toolpad-settings
+    ignoredPaths:
+     - docs/**
 
 databases:
   - name: toolpad-db
     ipAllowList: []
     plan: starter
+    ignoredPaths:
+     - docs/**
 
 envVarGroups:
   - name: toolpad-settings


### PR DESCRIPTION
For example, we shouldn't need https://github.com/mui/mui-toolpad/pull/1053#issuecomment-1257644551 when making a change in the docs.

The setting used is documented here: https://render.com/docs/blueprint-spec#build-filters.