### PR TITLE
[core] Fix buildFilter property in render.yml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -21,8 +21,9 @@ services:
           name: toolpad-db
           property: connectionString
       - fromGroup: toolpad-settings
-    ignoredPaths:
-     - docs/**
+    buildFilter:
+      ignoredPaths:
+        - docs/**
 
 databases:
   - name: toolpad-db

--- a/render.yaml
+++ b/render.yaml
@@ -24,6 +24,7 @@ services:
     buildFilter:
       ignoredPaths:
         - docs/**
+        - '**/*.spec.ts'
 
 databases:
   - name: toolpad-db


### PR DESCRIPTION
I believe it should live under a `buildFilter` property, like [this sample](https://render.com/docs/monorepo-support#example-blueprint-spec-1).