### PR TITLE
Allow empty argTypes object in component config

### DIFF
--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -20,7 +20,8 @@
     "waitForDb": "ts-node ./scripts/waitForDb.ts",
     "dev:function-runtime": "yarn build:function-runtime --watch",
     "waitForApp": "ts-node --esm ./scripts/waitForApp.mts",
-    "prisma-detect-drift": "prisma migrate diff --exit-code --from-migrations ./prisma/migrations --to-schema-datamodel ./prisma/schema.prisma --shadow-database-url \"$TOOLPAD_SHADOW_DATABASE_URL\""
+    "prisma-detect-drift": "prisma migrate diff --exit-code --from-migrations ./prisma/migrations --to-schema-datamodel ./prisma/schema.prisma --shadow-database-url \"$TOOLPAD_SHADOW_DATABASE_URL\"",
+    "check-types": "tsc --noEmit"
   },
   "files": [
     "prisma",

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -193,7 +193,7 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
   );
 
   const componentConfig = Component[TOOLPAD_COMPONENT];
-  const { argTypes, errorProp, loadingProp, loadingPropSource } = componentConfig;
+  const { argTypes = {}, errorProp, loadingProp, loadingPropSource } = componentConfig;
 
   const isLayoutNode = isPageNode || (isElementNode && isPageLayoutComponent(node));
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
@@ -198,7 +198,7 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
   const { Component: GeneratedComponent, error: compileError } = useCodeComponent(debouncedInput);
   const CodeComponent: ToolpadComponent<any> = useLatest(GeneratedComponent) || Noop;
 
-  const { argTypes } = CodeComponent[TOOLPAD_COMPONENT];
+  const { argTypes = {} } = CodeComponent[TOOLPAD_COMPONENT];
 
   const defaultProps = React.useMemo(
     () => mapValues(argTypes, (argType) => argType?.defaultValue),

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
@@ -86,18 +86,19 @@ function ComponentPropsEditor<P>({ componentConfig, node }: ComponentPropsEditor
       <Typography variant="overline" className={classes.sectionHeading}>
         Properties:
       </Typography>
-      {(Object.entries(componentConfig.argTypes) as ExactEntriesOf<ArgTypeDefinitions<P>>).map(
-        ([propName, propTypeDef]) =>
-          propTypeDef && shouldRenderControl(propTypeDef) ? (
-            <div key={propName} className={classes.control}>
-              <NodeAttributeEditor
-                node={node}
-                namespace="props"
-                name={propName}
-                argType={propTypeDef}
-              />
-            </div>
-          ) : null,
+      {(
+        Object.entries(componentConfig.argTypes || {}) as ExactEntriesOf<ArgTypeDefinitions<P>>
+      ).map(([propName, propTypeDef]) =>
+        propTypeDef && shouldRenderControl(propTypeDef) ? (
+          <div key={propName} className={classes.control}>
+            <NodeAttributeEditor
+              node={node}
+              namespace="props"
+              name={propName}
+              argType={propTypeDef}
+            />
+          </div>
+        ) : null,
       )}
     </React.Fragment>
   );

--- a/packages/toolpad-core/src/createComponent.tsx
+++ b/packages/toolpad-core/src/createComponent.tsx
@@ -1,0 +1,11 @@
+import { TOOLPAD_COMPONENT } from './constants';
+import { ComponentConfig, ToolpadComponent } from './types';
+
+export default function createComponent<P>(
+  Component: React.ComponentType<P>,
+  config?: ComponentConfig<P>,
+): ToolpadComponent<P> {
+  return Object.assign(Component, {
+    [TOOLPAD_COMPONENT]: config || { argTypes: {} },
+  });
+}

--- a/packages/toolpad-core/src/index.tsx
+++ b/packages/toolpad-core/src/index.tsx
@@ -1,6 +1,3 @@
-import { TOOLPAD_COMPONENT } from './constants.js';
-import { ComponentConfig, ToolpadComponent } from './types';
-
 export type { PlaceholderProps, SlotsProps, NodeRuntime } from './runtime';
 export { Placeholder, Slots, useNode } from './runtime';
 
@@ -13,13 +10,6 @@ export { default as useUrlQueryState } from './useUrlQueryState.js';
 
 export * from './constants.js';
 
-export function createComponent<P>(
-  Component: React.ComponentType<P>,
-  config?: ComponentConfig<P>,
-): ToolpadComponent<P> {
-  return Object.assign(Component, {
-    [TOOLPAD_COMPONENT]: config || { argTypes: {} },
-  });
-}
+export { default as createComponent } from './createComponent.js';
 
 export * from './types';

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -249,7 +249,7 @@ export interface ComponentConfig<P> {
   /**
    * Describes the individual properties for this component
    */
-  argTypes: ArgTypeDefinitions<P>;
+  argTypes?: ArgTypeDefinitions<P>;
 }
 
 export type ToolpadComponent<P = {}> = React.ComponentType<P> & {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-toolpad/issues/907