### PR TITLE
Alternative fix for 1050

### DIFF
--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -23,7 +23,6 @@ import {
   BindableAttrValue,
   UseDataQueryConfig,
   NestedBindableAttrs,
-  BindableAttrValues,
 } from '@mui/toolpad-core';
 import { QueryClient, QueryClientProvider, useMutation } from '@tanstack/react-query';
 import {
@@ -180,22 +179,11 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
 
   const nodeId = node.id;
 
-  const isPageNode = appDom.isPage(node);
-  const isElementNode = appDom.isElement(node);
-
-  const nodeProps: BindableAttrValues<Record<string, any>> = React.useMemo(
-    () => (isElementNode ? node.props || {} : {}),
-    [isElementNode, node],
-  );
-  const nodeLayoutProps = React.useMemo(
-    () => (isElementNode ? node.layout || {} : {}),
-    [isElementNode, node],
-  );
-
   const componentConfig = Component[TOOLPAD_COMPONENT];
   const { argTypes, errorProp, loadingProp, loadingPropSource } = componentConfig;
 
-  const isLayoutNode = isPageNode || (isElementNode && isPageLayoutComponent(node));
+  const isLayoutNode =
+    appDom.isPage(node) || (appDom.isElement(node) && isPageLayoutComponent(node));
 
   const liveBindings = useBindingsContext();
   const boundProps: Record<string, any> = React.useMemo(() => {
@@ -219,12 +207,8 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
         }
       }
 
-      if (typeof hookResult[propName] === 'undefined') {
-        if (nodeProps && nodeProps[propName]?.type === 'const') {
-          hookResult[propName] = nodeProps[propName]?.value;
-        } else if (argType) {
-          hookResult[propName] = argType.defaultValue;
-        }
+      if (typeof hookResult[propName] === 'undefined' && argType) {
+        hookResult[propName] = argType.defaultValue;
       }
     }
 
@@ -241,32 +225,25 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
     }
 
     return hookResult;
-  }, [argTypes, errorProp, liveBindings, loadingProp, loadingPropSource, nodeId, nodeProps]);
+  }, [argTypes, errorProp, liveBindings, loadingProp, loadingPropSource, nodeId]);
 
   const boundLayoutProps: Record<string, any> = React.useMemo(() => {
     const hookResult: Record<string, any> = {};
 
-    for (const layoutBoxArgTypesEntry of isLayoutNode ? [] : Object.entries(layoutBoxArgTypes)) {
-      const propName = layoutBoxArgTypesEntry[0] as keyof typeof layoutBoxArgTypes;
-      const argType = layoutBoxArgTypesEntry[1];
-
+    for (const [propName, argType] of isLayoutNode ? [] : Object.entries(layoutBoxArgTypes)) {
       const bindingId = `${nodeId}.layout.${propName}`;
       const binding = liveBindings[bindingId];
       if (binding) {
         hookResult[propName] = binding.value;
       }
 
-      if (typeof hookResult[propName] === 'undefined') {
-        if (nodeLayoutProps && nodeLayoutProps[propName]?.type === 'const') {
-          hookResult[propName] = nodeLayoutProps[propName]?.value;
-        } else if (argType) {
-          hookResult[propName] = argType.defaultValue;
-        }
+      if (typeof hookResult[propName] === 'undefined' && argType) {
+        hookResult[propName] = argType.defaultValue;
       }
     }
 
     return hookResult;
-  }, [isLayoutNode, liveBindings, nodeId, nodeLayoutProps]);
+  }, [isLayoutNode, liveBindings, nodeId]);
 
   const onChangeHandlers: Record<string, (param: any) => void> = React.useMemo(
     () =>


### PR DESCRIPTION
This is proposed as an alternative to https://github.com/mui/mui-toolpad/pull/1061
The advantage is that besides const bindings, this PR should also work for javascript bindings.

The issue is caused by [this effect](https://github.com/mui/mui-toolpad/blob/712642e7a23e0c9db6f0885854810bbf89e81cbe/packages/toolpad-app/src/runtime/ToolpadApp.tsx#L730) that updates the bindings only on the second render when the page changes. By forcing a remount the state gets reset when the page loads.

To reviewers: for extra clarity I recommend reviewing the second commit on its own https://github.com/mui/mui-toolpad/pull/1091/commits/7e40adb038b21659189e664fec431182dcd07876. The first commit just reverts the previous fix