### PR TITLE
[core] Rename query and params to parameters in fetch and function editors

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -235,16 +235,19 @@ function QueryNodeEditorDialog<Q>({
 
   const connectionParams = connection?.attributes.params.value;
 
-  const queryModel = React.useMemo<QueryEditorModel<any>>(
-    () => ({
+  const queryModel = React.useMemo<QueryEditorModel<any>>(() => {
+    const params =
+      (Object.entries(inputParams).filter(([, value]) => Boolean(value)) as BindableAttrEntries) ||
+      [];
+
+    return {
       query: input.attributes.query.value,
-      params:
-        (Object.entries(inputParams).filter(([, value]) =>
-          Boolean(value),
-        ) as BindableAttrEntries) || [],
-    }),
-    [input.attributes.query.value, inputParams],
-  );
+
+      // TODO mark params as @deprecated
+      params,
+      parameters: params,
+    };
+  }, [input.attributes.query.value, inputParams]);
 
   const handleQueryModelChange = React.useCallback(
     (model: QueryEditorModel<Q>) => {

--- a/packages/toolpad-app/src/toolpadDataSources/function/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/function/client.tsx
@@ -81,8 +81,8 @@ function ConnectionParamsInput({
   );
 }
 
-const DEFAULT_MODULE = `export default async function ({ params }: ${EVENT_INTERFACE_IDENTIFIER}) {
-  console.info('Executing function with params:', params);
+const DEFAULT_MODULE = `export default async function ({ parameters }: ${EVENT_INTERFACE_IDENTIFIER}) {
+  console.info('Executing function with parameters:', parameters);
   const url = new URL('https://gist.githubusercontent.com/saniyusuf/406b843afdfb9c6a86e25753fe2761f4/raw/523c324c7fcc36efab8224f9ebb7556c09b69a14/Film.JSON');
   url.searchParams.set('timestamp', String(Date.now()));
   const response = await fetch(String(url));
@@ -141,7 +141,7 @@ function QueryEditor({
 
     const content = `
       interface ${EVENT_INTERFACE_IDENTIFIER} {       
-        params: {
+        parameters: {
           ${paramsMembers}
         }
         secrets: {

--- a/packages/toolpad-app/src/toolpadDataSources/function/execFunction.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/function/execFunction.ts
@@ -134,7 +134,7 @@ export default async function execFunction(
     userModule.evaluateSync({ timeout: 30000 });
 
     const defaultExport = await userModule.namespace.get('default', { reference: true });
-    data = await defaultExport.apply(null, [{ params, secrets }], {
+    data = await defaultExport.apply(null, [{ params, parameters: params, secrets }], {
       arguments: { copy: true },
       result: { copy: true, promise: true },
       timeout: 30000,

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -279,7 +279,9 @@ function QueryEditor({
   );
 
   const queryScope = {
+    // TODO mark query as @deprecated
     query: previewParams,
+    parameters: previewParams,
   };
 
   const liveUrl: LiveBinding = useEvaluateLiveBinding({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Closes https://github.com/mui/mui-toolpad/issues/882

<img width="928" alt="image" src="https://user-images.githubusercontent.com/437214/194066942-d4480adc-0eb7-4058-94f5-9a8eb35f7425.png">

<img width="927" alt="image" src="https://user-images.githubusercontent.com/437214/194067059-820b29cb-9b3d-417f-997f-0ab1ad8cc731.png">

1. As per issue's description I've renamed `params` and `query` to `parameters`
2. I've done it only to the parts that are relevant to end-user, kept every other variable named same way as the changes to all `params` variable names seems to bring a lot of unnecessary/noisy changes. Lemme know if we should also change related variables
3. I'll leave comments in PR for the `@deprecated` part - I need some guidance to understand what would be the best way to mark them deprecated (cc @Janpot )
4. I've got `function` argument type updated and it shows dev hints in the editor correctly, however, I couldn't figure out how should I change type for `fetch` so it doesn't come up as `Query` type:
<img width="239" alt="image" src="https://user-images.githubusercontent.com/437214/194068372-ddb07f66-70f1-4d96-9ed6-51a2d3e8145d.png">
