### PR TITLE
[core] x10 speedup of yarn install in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
                   - v5-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
       - run:
           name: Install js dependencies
-          command: yarn install --frozen-lockfile --verbose
+          command: yarn install
           environment:
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<# parameters.browsers >>0<</ parameters.browsers >><<^ parameters.browsers >>1<</ parameters.browsers >>
 


### PR DESCRIPTION
It's an idea that I wanted to test while I was answering #1089. I assumed that we were trying to get a faster installation time on that PR. Seeing:

<img width="403" alt="Screenshot 2022-10-05 at 21 39 57" src="https://user-images.githubusercontent.com/3165635/194147984-2009fb56-8d4c-4b54-8b1c-7eb8c102b003.png">

put me on that lead. I assumed collecting the logs would put a lot of pressure on the resources. I got lucky. I think that `--verbose` was here to debug the cache behavior. As for `--frozen-lock` file, I think that it prevents the `git diff --exit-code` step to provide details on what's wrong in the yarn.lock so it's better without it.

**Before**
<img width="1120" alt="Screenshot 2022-10-05 at 21 36 49" src="https://user-images.githubusercontent.com/3165635/194147399-9f86e697-37e6-4d86-8ead-51fdcdb49a13.png">
https://app.circleci.com/pipelines/github/mui/mui-toolpad/3639/workflows/0bfb41ca-c613-40ec-8a02-331d4715eeaf/jobs/13780

**After**
<img width="1122" alt="Screenshot 2022-10-05 at 21 36 46" src="https://user-images.githubusercontent.com/3165635/194147397-bb3465e1-816d-479e-a1f4-f8f6cb616564.png">
https://app.circleci.com/pipelines/github/mui/mui-toolpad/3644/workflows/b2d5f809-31e3-4fa6-b2e7-4478aee50327/jobs/13805

🤷‍♂️😁