### PR TITLE
Revert "[core] Add default data to DataGrid, Image, Select components"

### DIFF
--- a/packages/toolpad-components/src/Image.tsx
+++ b/packages/toolpad-components/src/Image.tsx
@@ -12,9 +12,6 @@ export interface ImageProps {
   fit: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
 }
 
-const DEFAULT_IMG_SRC =
-  'https://images.unsplash.com/photo-1663436031310-f40198ba736e?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80';
-
 function Image({ sx: sxProp, src, width, height, alt, loading: loadingProp, fit }: ImageProps) {
   const sx: SxProps = React.useMemo(
     () => ({
@@ -61,7 +58,6 @@ export default createComponent(Image, {
   argTypes: {
     src: {
       typeDef: { type: 'string' },
-      defaultValue: DEFAULT_IMG_SRC,
     },
     alt: {
       typeDef: { type: 'string' },

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -11,24 +11,6 @@ export type SelectProps = TextFieldProps & {
   options: (string | SelectOption)[];
 };
 
-const DEFAULT_OPTIONS = {
-  options: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ],
-  label: 'Month',
-};
-
 function Select({ options, value, defaultValue, fullWidth, sx, ...rest }: SelectProps) {
   return (
     <TextField
@@ -58,7 +40,7 @@ export default createComponent(Select, {
     options: {
       typeDef: { type: 'array', schema: '/schemas/SelectOptions.json' },
       control: { type: 'SelectOptions' },
-      defaultValue: DEFAULT_OPTIONS.options,
+      defaultValue: [],
     },
     value: {
       typeDef: { type: 'string' },
@@ -69,11 +51,11 @@ export default createComponent(Select, {
     },
     defaultValue: {
       typeDef: { type: 'string' },
-      defaultValue: DEFAULT_OPTIONS.options[0],
+      defaultValue: '',
     },
     label: {
       typeDef: { type: 'string' },
-      defaultValue: DEFAULT_OPTIONS.label,
+      defaultValue: '',
     },
     variant: {
       typeDef: { type: 'string', enum: ['outlined', 'filled', 'standard'] },


### PR DESCRIPTION
Looks like the implementation of https://github.com/mui/mui-toolpad/pull/1048 still has a few problems:

- https://github.com/mui/mui-toolpad/issues/1086
- I'm noticing issues in the components integration test. Since this PR, when I open [that app](https://github.com/mui/mui-toolpad/blob/master/test/integration/components/componentsDom.json) in the editor, I immediately see "1 changes saved." in the console. I think it's also what's making the integration test flaky in https://github.com/mui/mui-toolpad/pull/1097 as it triggers a dialog when trying to navigate away from a page with unsaved changes

cc @bharatkashyap 