### PR TITLE
Make queries capable of mutations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ const baseline = require('@mui/monorepo/.eslintrc');
 
 module.exports = {
   ...baseline,
-  plugins: [...baseline.plugins, 'jsdoc'],
+  plugins: baseline.plugins,
   /**
    * Sorted alphanumerically within each group. built-in and each plugin form
    * their own groups.
@@ -14,13 +14,6 @@ module.exports = {
     '@typescript-eslint/return-await': ['off'],
     // TODO move rule into main repo to allow deep @mui/monorepo imports
     'no-restricted-imports': ['off'],
-    'jsdoc/require-param': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-param-type': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-param-name': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-param-description': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-returns': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-returns-type': ['error', { contexts: ['TSFunctionType'] }],
-    'jsdoc/require-returns-description': ['error', { contexts: ['TSFunctionType'] }],
     'no-restricted-syntax': [
       'error',
       // From https://github.com/airbnb/javascript/blob/d8cb404da74c302506f91e5928f30cc75109e74d/packages/eslint-config-airbnb-base/rules/style.js#L333

--- a/packages/toolpad-app/src/appDom.ts
+++ b/packages/toolpad-app/src/appDom.ts
@@ -106,6 +106,8 @@ export interface CodeComponentNode extends AppDomNodeBase {
   };
 }
 
+export type FetchMode = 'query' | 'mutation';
+
 /**
  * A DOM query is defined primarily by a server defined part "attributes.query"
  * and a clientside defined part "params". "params" are constructed in the runtime
@@ -116,6 +118,7 @@ export interface QueryNode<Q = any> extends AppDomNodeBase {
   readonly type: 'query';
   readonly params?: BindableAttrValues;
   readonly attributes: {
+    readonly mode?: ConstantAttrValue<FetchMode>;
     readonly dataSource?: ConstantAttrValue<string>;
     readonly connectionId: ConstantAttrValue<NodeReference | null>;
     readonly query: ConstantAttrValue<Q>;
@@ -124,6 +127,7 @@ export interface QueryNode<Q = any> extends AppDomNodeBase {
     readonly refetchOnWindowFocus?: ConstantAttrValue<boolean>;
     readonly refetchOnReconnect?: ConstantAttrValue<boolean>;
     readonly refetchInterval?: ConstantAttrValue<number>;
+    readonly cacheTime?: ConstantAttrValue<number>;
     readonly enabled?: BindableAttrValue<boolean>;
   };
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -14,6 +14,7 @@ import {
   Divider,
   Alert,
   Box,
+  MenuItem,
 } from '@mui/material';
 import * as React from 'react';
 import AddIcon from '@mui/icons-material/Add';
@@ -289,6 +290,16 @@ function QueryNodeEditorDialog<Q>({
     [],
   );
 
+  const handleModeChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setInput((existing) =>
+      update(existing, {
+        attributes: update(existing.attributes, {
+          mode: appDom.createConst(event.target.value as appDom.FetchMode),
+        }),
+      }),
+    );
+  }, []);
+
   const handleRefetchOnWindowFocusChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setInput((existing) =>
@@ -414,6 +425,15 @@ function QueryNodeEditorDialog<Q>({
           value={input.attributes.enabled ?? appDom.createConst(true)}
           onChange={handleEnabledChange}
         />
+        <TextField
+          select
+          label="mode"
+          value={input.attributes.mode?.value || 'query'}
+          onChange={handleModeChange}
+        >
+          <MenuItem value="query">Fetch automatically on page load</MenuItem>
+          <MenuItem value="mutation">Only fetch on manual action</MenuItem>
+        </TextField>
         <FormControlLabel
           control={
             <Checkbox
@@ -446,6 +466,7 @@ function QueryNodeEditorDialog<Q>({
     ),
     [
       input,
+      handleModeChange,
       handleEnabledChange,
       handleRefetchIntervalChange,
       handleRefetchOnReconnectChange,

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -413,9 +413,14 @@ function QueryNodeEditorDialog<Q>({
     ],
   );
 
-  const renderQueryOptions = React.useCallback(
-    () => (
+  const renderQueryOptions = React.useCallback(() => {
+    const mode = input.attributes.mode?.value || 'query';
+    return (
       <Stack direction="row" alignItems="center" sx={{ pt: 2, px: 3, gap: 2 }}>
+        <TextField select label="mode" value={mode} onChange={handleModeChange}>
+          <MenuItem value="query">Fetch at any time to always be available on the page</MenuItem>
+          <MenuItem value="mutation">Only fetch on manual action</MenuItem>
+        </TextField>
         <BindableEditor
           liveBinding={liveEnabled}
           globalScope={pageState}
@@ -424,21 +429,14 @@ function QueryNodeEditorDialog<Q>({
           propType={{ type: 'boolean' }}
           value={input.attributes.enabled ?? appDom.createConst(true)}
           onChange={handleEnabledChange}
+          disabled={mode !== 'query'}
         />
-        <TextField
-          select
-          label="mode"
-          value={input.attributes.mode?.value || 'query'}
-          onChange={handleModeChange}
-        >
-          <MenuItem value="query">Fetch automatically on page load</MenuItem>
-          <MenuItem value="mutation">Only fetch on manual action</MenuItem>
-        </TextField>
         <FormControlLabel
           control={
             <Checkbox
               checked={input.attributes.refetchOnWindowFocus?.value ?? true}
               onChange={handleRefetchOnWindowFocusChange}
+              disabled={mode !== 'query'}
             />
           }
           label="Refetch on window focus"
@@ -448,6 +446,7 @@ function QueryNodeEditorDialog<Q>({
             <Checkbox
               checked={input.attributes.refetchOnReconnect?.value ?? true}
               onChange={handleRefetchOnReconnectChange}
+              disabled={mode !== 'query'}
             />
           }
           label="Refetch on network reconnect"
@@ -461,20 +460,20 @@ function QueryNodeEditorDialog<Q>({
           label="Refetch interval"
           value={refetchIntervalInSeconds(input.attributes.refetchInterval?.value) ?? ''}
           onChange={handleRefetchIntervalChange}
+          disabled={mode !== 'query'}
         />
       </Stack>
-    ),
-    [
-      input,
-      handleModeChange,
-      handleEnabledChange,
-      handleRefetchIntervalChange,
-      handleRefetchOnReconnectChange,
-      handleRefetchOnWindowFocusChange,
-      liveEnabled,
-      pageState,
-    ],
-  );
+    );
+  }, [
+    input,
+    handleModeChange,
+    handleEnabledChange,
+    handleRefetchIntervalChange,
+    handleRefetchOnReconnectChange,
+    handleRefetchOnWindowFocusChange,
+    liveEnabled,
+    pageState,
+  ]);
 
   const renderDialogActions: RenderDialogActions = React.useCallback(
     ({ isDirty, onCommit }) => {

--- a/packages/toolpad-components/src/Typography.tsx
+++ b/packages/toolpad-components/src/Typography.tsx
@@ -23,7 +23,7 @@ function Typography({ value, loading, sx, ...rest }: TypographyProps) {
       }}
       {...rest}
     >
-      {loading ? <Skeleton /> : value}
+      {loading ? <Skeleton /> : String(value)}
     </MuiTypography>
   );
 }

--- a/packages/toolpad-core/src/index.tsx
+++ b/packages/toolpad-core/src/index.tsx
@@ -3,7 +3,7 @@ export { Placeholder, Slots, useNode } from './runtime';
 
 export type FlowDirection = 'row' | 'column' | 'row-reverse' | 'column-reverse';
 
-export type { UseDataQuery } from './useDataQuery.js';
+export type { UseFetch } from './useDataQuery.js';
 export * from './useDataQuery.js';
 
 export { default as useUrlQueryState } from './useUrlQueryState.js';

--- a/packages/toolpad-core/src/useDataQuery.ts
+++ b/packages/toolpad-core/src/useDataQuery.ts
@@ -20,23 +20,17 @@ export type UseDataQueryConfig = Pick<
   'enabled' | 'refetchOnWindowFocus' | 'refetchOnReconnect' | 'refetchInterval'
 >;
 
-export interface UseDataQuery {
+export interface UseFetch {
   isLoading: boolean;
   isFetching: boolean;
   error: any;
   data: any;
   rows: GridRowsProp;
+  fetch: (overrides?: any) => void;
   refetch: () => void;
+  /** @deprecated Use fetch */
+  call: (overrides?: any) => Promise<void>;
 }
-
-export const INITIAL_DATA_QUERY: UseDataQuery = {
-  isLoading: false,
-  isFetching: false,
-  error: null,
-  data: null,
-  rows: [],
-  refetch: () => {},
-};
 
 const EMPTY_ARRAY: any[] = [];
 const EMPTY_OBJECT: any = {};
@@ -52,7 +46,7 @@ export function useDataQuery(
     UseQueryOptions<any, unknown, unknown, any[]>,
     'enabled' | 'refetchOnWindowFocus' | 'refetchOnReconnect' | 'refetchInterval'
   >,
-): UseDataQuery {
+): UseFetch {
   const {
     isLoading,
     isFetching,
@@ -74,7 +68,7 @@ export function useDataQuery(
 
   const rows = Array.isArray(data) ? data : EMPTY_ARRAY;
 
-  const result: UseDataQuery = React.useMemo(
+  const result: UseFetch = React.useMemo(
     () => ({
       isLoading: isLoading && enabled,
       isFetching,
@@ -82,6 +76,12 @@ export function useDataQuery(
       data,
       rows,
       refetch,
+      fetch: async () => {
+        throw new Error(`"fetch" is unsupported for automatic queries`);
+      },
+      call: async () => {
+        throw new Error(`"call" is unsupported for automatic queries`);
+      },
     }),
     [isLoading, enabled, isFetching, error, data, rows, refetch],
   );


### PR DESCRIPTION
Step 1 of https://github.com/mui/mui-toolpad/issues/990

https://user-images.githubusercontent.com/2109932/194826423-aa7c8a62-731d-4fbe-a813-f85e88d9b28b.mov


To Do list:
- [ ] Migrate existing mutations to queries (blocked on https://github.com/mui/mui-toolpad/pull/776)
- [ ] Remove current "migrations" feature in favor of queries
- [ ] https://github.com/mui/mui-toolpad/issues/1121
- [ ] Automatically switch to mutation mode when user selects non-idempotent HTTP method in the fetch datasource