### PR TITLE
disable react-router-dom update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,28 +27,12 @@
     },
     {
       "groupName": "MUI Core",
-      "matchPackageNames": [
-        "@mui/material",
-        "@mui/joy",
-        "@mui/icons-material",
-        "@mui/base",
-        "@mui/system",
-        "@mui/styles",
-        "@mui/utils"
-      ],
+      "matchPackagePatterns": ["^@mui/"],
       "prCreation": "immediate"
     },
     {
       "groupName": "MUI X",
-      "matchPackageNames": [
-        "@mui/x-data-grid",
-        "@mui/x-data-grid",
-        "@mui/x-data-grid-pro",
-        "@mui/x-data-grid-premium",
-        "@mui/x-data-grid-generator",
-        "@mui/x-date-pickers",
-        "@mui/x-date-pickers-pro"
-      ],
+      "matchPackagePatterns": ["^@mui/x-"],
       "prCreation": "immediate"
     },
     {
@@ -58,7 +42,8 @@
         "node-fetch",
         "eslint-config-airbnb-typescript",
         "chalk",
-        "react-router"
+        "react-router",
+        "react-router-dom"
       ],
       "enabled": false
     }


### PR DESCRIPTION
* disable `react-router-dom` updates: `react-router` folks came back on their promise of moving `usePrompt` features from v5 to v6 (https://github.com/remix-run/react-router/issues/8139), yet we depend on it to prevent navigating away when there's unsaved changes. I'm not 100% convinced their proposed solution is the most sensible for us. Short term we're disabling updates to this dependencies. Long term we have the following choices:
    * Do nothing, wait for them to change their mind and support the future in `react-router` > 6. Basically stay stuck on an outdated version of the latest major, potentially forever.
    * Migrate back to v5 which supports the functionality. Basically staying forever on the last version of an outdated major.
    * Migrate towards a library that cares more about the migration path for their users. e.g. [`@tanstack/react-location`](https://www.npmjs.com/package/@tanstack/react-location)
    * Refactor our UX to not rely on dialogs that asks users to confirm they want to navigate away with unsaved changes.
    
    IMO only the last two of those are desirable long-term

 * replace the package matcher for MUI(X) packages with regex