### PR TITLE
Fix a few issues with app DOM migrations

### DIFF
--- a/packages/toolpad-app/src/appDomMigrations/index.ts
+++ b/packages/toolpad-app/src/appDomMigrations/index.ts
@@ -16,7 +16,8 @@ export function migrateUp(
     throw new Error(`Can't migrate dom from version "${fromVersion}" to "${toVersion}"`);
   }
 
-  const migrationsToApply = Array.from(versions).slice(fromVersion, toVersion);
+  const migrationsToApply = versions.slice(fromVersion, toVersion);
+
   let toDom = fromDom;
   for (const migration of migrationsToApply) {
     toDom = migration.up(toDom);

--- a/packages/toolpad-app/src/appDomMigrations/index.ts
+++ b/packages/toolpad-app/src/appDomMigrations/index.ts
@@ -1,11 +1,26 @@
 import invariant from 'invariant';
 import v1 from './v1';
-import { CURRENT_APPDOM_VERSION } from '../appDom';
+import * as appDom from '../appDom';
 
-const versions = new Map([[1, v1]]);
+const versions = [v1];
 
-export const latestVersion = Array.from(versions.keys()).pop() as number;
+invariant(versions.length === appDom.CURRENT_APPDOM_VERSION, 'Unable to find the latest version');
 
-invariant(versions.size === CURRENT_APPDOM_VERSION, 'Unable to find the latest version');
+export function migrateUp(
+  fromDom: appDom.AppDom,
+  toVersion = appDom.CURRENT_APPDOM_VERSION,
+): appDom.AppDom {
+  const fromVersion = fromDom.version || 0;
 
-export const latestMigration = versions.get(latestVersion);
+  if (toVersion < fromVersion) {
+    throw new Error(`Can't migrate dom from version "${fromVersion}" to "${toVersion}"`);
+  }
+
+  const migrationsToApply = Array.from(versions).slice(fromVersion, toVersion);
+  let toDom = fromDom;
+  for (const migration of migrationsToApply) {
+    toDom = migration.up(toDom);
+  }
+
+  return toDom;
+}

--- a/packages/toolpad-app/src/server/appTemplateDoms/doms.ts
+++ b/packages/toolpad-app/src/server/appTemplateDoms/doms.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as appDom from '../../appDom';
-
+import { migrateUp } from '../../appDomMigrations';
 import { AppTemplateId } from '../../types';
 import { readJsonFile } from '../../utils/fs';
 import projectRoot from '../projectRoot';
@@ -13,7 +13,10 @@ const APP_TEMPLATE_DOM_PATHS: Record<AppTemplateId, string | null> = {
   images: path.resolve(projectRoot, DOMS_DIR_PATH, './images.json'),
 };
 
-export function getAppTemplateDom(appTemplateId: AppTemplateId): Promise<appDom.AppDom> | null {
+export async function getAppTemplateDom(
+  appTemplateId: AppTemplateId,
+): Promise<appDom.AppDom | null> {
   const domPath = APP_TEMPLATE_DOM_PATHS[appTemplateId];
-  return domPath ? readJsonFile(domPath) : null;
+  const dom = domPath ? await readJsonFile(domPath) : null;
+  return dom ? migrateUp(dom) : null;
 }


### PR DESCRIPTION
Trying to add a second migration in https://github.com/mui/mui-toolpad/pull/1130, can't merge because it doesn't know how to migrate from version 0 to version 2. Did an overall review to fix a few other things:

- Only the last migration was applied, instead the current version of  a dom needs to be detected and all migrations up until the last one needs to be applied in order. Adding a function for that
- A few missing points where dom has to be migrated:
  - when reading from a template (we should probably make sure the template dom is always at the latest version, maybe a script and an `invariant` that prompts to run the script?)
  - when reading from the user when supplied as a seed dom
  - when reading a production snapshot
- `getAppTemplateDom` was returning a `Promise<AppDom> | null` instead of a `Promise<AppDom | null>`. Would recommend to always use an `async` function if it returns a promise, unless you specifically want to do something with a synchronous promise