### PR TITLE
[app] Fix manifest 401 loading

### DIFF
--- a/packages/toolpad-app/pages/_document.tsx
+++ b/packages/toolpad-app/pages/_document.tsx
@@ -69,13 +69,13 @@ export default class MyDocument extends Document<ToolpadDocumentProps> {
             rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
           />
-          <link rel="manifest" href="/site.webmanifest" />
+          <link rel="manifest" href="/manifest.json" />
           <script
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: `
                 // Add the data-toolpad-canvas attribute to the canvas iframe element
-                if (window.frameElement?.dataset.toolpadCanvas){ 
+                if (window.frameElement?.dataset.toolpadCanvas){
                   var script = document.createElement('script');
                   script.type = 'module';
                   script.src = '/reactDevtools/bootstrap.js';
@@ -84,7 +84,6 @@ export default class MyDocument extends Document<ToolpadDocumentProps> {
               `,
             }}
           />
-
           <script
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
@@ -93,7 +92,6 @@ export default class MyDocument extends Document<ToolpadDocumentProps> {
               )}] = ${serializeJavascript(this.props.config, { ignoreFunction: true })}`,
             }}
           />
-
           {/* Global site tag (gtag.js) - Google Analytics */}
           <Script
             async

--- a/packages/toolpad-app/public/manifest.json
+++ b/packages/toolpad-app/public/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/packages/toolpad-app/public/site.webmanifest
+++ b/packages/toolpad-app/public/site.webmanifest
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
You can take the preview of https://github.com/mui/mui-toolpad/pull/1141#issuecomment-1276151048 and you will get this in the console:

<img width="570" alt="Screenshot 2022-10-13 at 01 01 15" src="https://user-images.githubusercontent.com/3165635/195463682-9835e84b-a5a8-4765-b7b0-7fd584867d75.png">

I was testing writing a new component with console.log, it harms my DX 😁