### PR TITLE
Fix visible horizontal scroll

### DIFF
--- a/packages/toolpad-app/src/toolpad/ToolpadShell/index.tsx
+++ b/packages/toolpad-app/src/toolpad/ToolpadShell/index.tsx
@@ -10,6 +10,7 @@ export interface ToolpadShellProps {
 
 const ToolpadShellRoot = styled('div')({
   width: '100vw',
+  maxWidth: '100%',
   minHeight: '100vh',
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Closes https://github.com/mui/mui-toolpad/issues/1058

Found this suggestions: https://stackoverflow.com/questions/23367345/100vw-causing-horizontal-overflow-but-only-if-more-than-one - if someone knows a better way or if this should be done differently please lemme know.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/437214/195630344-d2e3013a-39c0-4050-92a0-1f6f90c1fd42.png">
