### PR TITLE
Option to send logs to Elastic Cloud Search

### DIFF
--- a/packages/toolpad-app/log.txt
+++ b/packages/toolpad-app/log.txt
@@ -1,0 +1,2 @@
+[32mready[39m - started server on 0.0.0.0:3000, url: http://localhost:3000
+[35mevent[39m - compiled client and server successfully in 8.6s (1745 modules)

--- a/packages/toolpad-app/log.txt
+++ b/packages/toolpad-app/log.txt
@@ -1,2 +1,0 @@
-[32mready[39m - started server on 0.0.0.0:3000, url: http://localhost:3000
-[35mevent[39m - compiled client and server successfully in 8.6s (1745 modules)

--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -13,7 +13,7 @@
     "build:react-devtools": "rimraf ./public/reactDevtools && esbuild ./reactDevtools/bootstrap.ts --target=es6 --bundle --outdir=./public/reactDevtools",
     "build:typings": "ts-node ./scripts/typings.ts",
     "build:function-runtime": "rimraf ./src/toolpadDataSources/function/dist && esbuild ./src/toolpadDataSources/function/runtime/index.ts --target=es2020 --bundle --outdir=./src/toolpadDataSources/function/dist",
-    "dev:next": "next dev | pino-pretty",
+    "dev:next": "next dev",
     "dev:react-devtools": "yarn build:react-devtools --watch",
     "dev:typings": "yarn build:typings",
     "dev:prisma": "prisma generate --watch",
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "@babel/code-frame": "^7.18.6",
+    "@elastic/ecs-pino-format": "^1.3.0",
     "@emotion/cache": "^11.10.3",
     "@emotion/react": "^11.10.4",
     "@emotion/server": "^11.10.0",

--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -13,7 +13,7 @@
     "build:react-devtools": "rimraf ./public/reactDevtools && esbuild ./reactDevtools/bootstrap.ts --target=es6 --bundle --outdir=./public/reactDevtools",
     "build:typings": "ts-node ./scripts/typings.ts",
     "build:function-runtime": "rimraf ./src/toolpadDataSources/function/dist && esbuild ./src/toolpadDataSources/function/runtime/index.ts --target=es2020 --bundle --outdir=./src/toolpadDataSources/function/dist",
-    "dev:next": "next dev",
+    "dev:next": "next dev | pino-pretty",
     "dev:react-devtools": "yarn build:react-devtools --watch",
     "dev:typings": "yarn build:typings",
     "dev:prisma": "prisma generate --watch",

--- a/packages/toolpad-app/pages/api/data/[appId]/[version]/[queryId].ts
+++ b/packages/toolpad-app/pages/api/data/[appId]/[version]/[queryId].ts
@@ -3,7 +3,7 @@ import { NextApiHandler } from 'next';
 import { withSentry } from '@sentry/nextjs';
 import { parseVersion } from '../../../../../src/server/data';
 import handleDataRequest from '../../../../../src/server/handleDataRequest';
-import withReqResLogs from '../../../../../src/server/withReqResLogs';
+import { withReqResLogs } from '../../../../../src/server/withLogs';
 import { asArray } from '../../../../../src/utils/collections';
 
 export const config = {

--- a/packages/toolpad-app/pages/api/dataSources/[dataSource]/[...path].ts
+++ b/packages/toolpad-app/pages/api/dataSources/[dataSource]/[...path].ts
@@ -3,7 +3,7 @@ import { withSentry } from '@sentry/nextjs';
 import { asArray } from '../../../../src/utils/collections';
 import serverDataSources from '../../../../src/toolpadDataSources/server';
 import { getConnectionParams, setConnectionParams } from '../../../../src/server/data';
-import withReqResLogs from '../../../../src/server/withReqResLogs';
+import { withReqResLogs } from '../../../../src/server/withLogs';
 
 export const config = {
   api: {

--- a/packages/toolpad-app/pages/api/rpc.ts
+++ b/packages/toolpad-app/pages/api/rpc.ts
@@ -25,7 +25,7 @@ import {
 } from '../../src/server/data';
 import { getLatestToolpadRelease } from '../../src/server/getLatestRelease';
 import { hasOwnProperty } from '../../src/utils/collections';
-import withReqResLogs from '../../src/server/withReqResLogs';
+import { withRpcReqResLogs } from '../../src/server/withLogs';
 
 export const config = {
   api: {
@@ -191,4 +191,4 @@ const rpcServer = {
 
 export type ServerDefinition = MethodsOf<typeof rpcServer>;
 
-export default withSentry(withReqResLogs(createRpcHandler(rpcServer)));
+export default withSentry(withRpcReqResLogs(createRpcHandler(rpcServer)));

--- a/packages/toolpad-app/src/server/config.ts
+++ b/packages/toolpad-app/src/server/config.ts
@@ -20,7 +20,7 @@ export type ServerConfig = {
   basicAuthPassword?: string;
   apiLogsEnabled: boolean;
   recaptchaSecretKey?: string;
-  ecsCloudId?: string;
+  ecsHostUrl?: string;
   ecsApiKey?: string;
 } & BasicAuthConfig;
 
@@ -58,7 +58,7 @@ function readConfig(): ServerConfig & typeof sharedConfig {
     externalUrl: process.env.TOOLPAD_EXTERNAL_URL || `http://localhost:${process.env.PORT || 3000}`,
     apiLogsEnabled: !!process.env.TOOLPAD_API_LOGS_ENABLED,
     recaptchaSecretKey: process.env.TOOLPAD_RECAPTCHA_SECRET_KEY,
-    ecsCloudId: process.env.TOOLPAD_ECS_CLOUD_ID,
+    ecsHostUrl: process.env.TOOLPAD_ECS_HOST_URL,
     ecsApiKey: process.env.TOOLPAD_ECS_API_KEY,
     encryptionKeys,
   };

--- a/packages/toolpad-app/src/server/config.ts
+++ b/packages/toolpad-app/src/server/config.ts
@@ -20,6 +20,8 @@ export type ServerConfig = {
   basicAuthPassword?: string;
   apiLogsEnabled: boolean;
   recaptchaSecretKey?: string;
+  ecsCloudId?: string;
+  ecsApiKey?: string;
 } & BasicAuthConfig;
 
 function readConfig(): ServerConfig & typeof sharedConfig {
@@ -56,6 +58,8 @@ function readConfig(): ServerConfig & typeof sharedConfig {
     externalUrl: process.env.TOOLPAD_EXTERNAL_URL || `http://localhost:${process.env.PORT || 3000}`,
     apiLogsEnabled: !!process.env.TOOLPAD_API_LOGS_ENABLED,
     recaptchaSecretKey: process.env.TOOLPAD_RECAPTCHA_SECRET_KEY,
+    ecsCloudId: process.env.TOOLPAD_ECS_CLOUD_ID,
+    ecsApiKey: process.env.TOOLPAD_ECS_API_KEY,
     encryptionKeys,
   };
 }

--- a/packages/toolpad-app/src/server/logSerializers.ts
+++ b/packages/toolpad-app/src/server/logSerializers.ts
@@ -1,0 +1,19 @@
+import * as _ from 'lodash-es';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export const reqSerializer = (req: NextApiRequest) => ({
+  ..._.pick(req, ['url', 'method']),
+  ...(!_.isEmpty(req.query) ? { query: req.query } : {}),
+  body: _.pick(req.body, [
+    'type',
+    'name',
+    // Omitting request params, but we could enable them if it would be useful
+    // 'params'
+  ]),
+  headers: _.pick(req.headers, ['x-forwarded-for', 'host', 'user-agent']),
+  socket: _.pick(req.socket, ['remoteAddress']),
+});
+
+export const resSerializer = (res: NextApiResponse) => ({
+  statusCode: res.statusCode,
+});

--- a/packages/toolpad-app/src/server/logSerializers.ts
+++ b/packages/toolpad-app/src/server/logSerializers.ts
@@ -2,8 +2,7 @@ import * as _ from 'lodash-es';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export const reqSerializer = (req: NextApiRequest) => ({
-  ..._.pick(req, ['url', 'method']),
-  ...(!_.isEmpty(req.query) ? { query: req.query } : {}),
+  ..._.pick(req, ['url', 'method', 'query']),
   body: _.pick(req.body, [
     'type',
     'name',

--- a/packages/toolpad-app/src/server/logSerializers.ts
+++ b/packages/toolpad-app/src/server/logSerializers.ts
@@ -1,18 +1,22 @@
-import * as _ from 'lodash-es';
 import { NextApiRequest, NextApiResponse } from 'next';
 
-export const reqSerializer = (req: NextApiRequest) => ({
-  ..._.pick(req, ['url', 'method', 'query']),
-  body: _.pick(req.body, [
-    'type',
-    'name',
+export function reqSerializer(req: NextApiRequest) {
+  return {
+    url: req.url,
+    method: req.method,
+    query: req.query,
+    type: req.body.type,
+    name: req.body.name,
     // Omitting request params, but we could enable them if it would be useful
-    // 'params'
-  ]),
-  headers: _.pick(req.headers, ['x-forwarded-for', 'host', 'user-agent']),
-  socket: _.pick(req.socket, ['remoteAddress']),
-});
+    // params: req.body.params,
+    ipAddress: req.headers['x-forwarded-for'] || req.socket?.remoteAddress,
+    host: req.headers.host,
+    userAgent: req.headers['user-agent'],
+  };
+}
 
-export const resSerializer = (res: NextApiResponse) => ({
-  statusCode: res.statusCode,
-});
+export function resSerializer(res: NextApiResponse) {
+  return {
+    statusCode: res.statusCode,
+  };
+}

--- a/packages/toolpad-app/src/server/logSerializers.ts
+++ b/packages/toolpad-app/src/server/logSerializers.ts
@@ -6,8 +6,6 @@ export function reqSerializer(req: NextApiRequest) {
     method: req.method,
     query: req.query,
     body: {
-      type: req.body.type,
-      name: req.body.name,
       // Omitting request params, but we could enable them if it would be useful
       // params: req.body.params,
     },
@@ -25,5 +23,15 @@ export function reqSerializer(req: NextApiRequest) {
 export function resSerializer(res: NextApiResponse) {
   return {
     statusCode: res.statusCode,
+  };
+}
+
+export function rpcReqSerializer(req: NextApiRequest) {
+  return {
+    ...reqSerializer(req),
+    body: {
+      type: req.body.type,
+      name: req.body.name,
+    },
   };
 }

--- a/packages/toolpad-app/src/server/logSerializers.ts
+++ b/packages/toolpad-app/src/server/logSerializers.ts
@@ -5,13 +5,20 @@ export function reqSerializer(req: NextApiRequest) {
     url: req.url,
     method: req.method,
     query: req.query,
-    type: req.body.type,
-    name: req.body.name,
-    // Omitting request params, but we could enable them if it would be useful
-    // params: req.body.params,
-    ipAddress: req.headers['x-forwarded-for'] || req.socket?.remoteAddress,
-    host: req.headers.host,
-    userAgent: req.headers['user-agent'],
+    body: {
+      type: req.body.type,
+      name: req.body.name,
+      // Omitting request params, but we could enable them if it would be useful
+      // params: req.body.params,
+    },
+    headers: {
+      'x-forwarded-for': req.headers['x-forwarded-for'],
+      host: req.headers.host,
+      userAgent: req.headers['user-agent'],
+    },
+    socket: {
+      remoteAddress: req.socket?.remoteAddress,
+    },
   };
 }
 

--- a/packages/toolpad-app/src/server/logger.ts
+++ b/packages/toolpad-app/src/server/logger.ts
@@ -1,10 +1,28 @@
 import pino from 'pino';
+import ecsFormat from '@elastic/ecs-pino-format';
 import config from './config';
 
-const logger = pino({
-  enabled: config.apiLogsEnabled,
-  level: process.env.LOG_LEVEL || 'info',
-  redact: { paths: [] },
+const transport = pino.transport({
+  target: 'pino-elasticsearch',
+  options: {
+    index: 'toolpad-pino',
+    cloud: {
+      id: config.ecsCloudId,
+    },
+    auth: {
+      apiKey: config.ecsApiKey,
+    },
+  },
 });
+
+const logger = pino(
+  {
+    enabled: config.apiLogsEnabled,
+    level: process.env.LOG_LEVEL || 'info',
+    redact: { paths: [] },
+    ...ecsFormat(),
+  },
+  transport,
+);
 
 export default logger;

--- a/packages/toolpad-app/src/server/logger.ts
+++ b/packages/toolpad-app/src/server/logger.ts
@@ -4,23 +4,20 @@ import ecsFormat from '@elastic/ecs-pino-format';
 import config from './config';
 import { reqSerializer, resSerializer } from './logSerializers';
 
-function getTransport() {
-  let transport;
-  if (config.ecsCloudId) {
-    transport = pino.transport({
-      target: 'pino-elasticsearch',
-      options: {
-        index: 'toolpad-pino',
-        cloud: {
-          id: config.ecsCloudId,
-        },
-        auth: {
-          apiKey: config.ecsApiKey,
-        },
+let transport;
+if (config.ecsCloudId) {
+  transport = pino.transport({
+    target: 'pino-elasticsearch',
+    options: {
+      index: 'toolpad-pino',
+      cloud: {
+        id: config.ecsCloudId,
       },
-    });
-  }
-  return transport;
+      auth: {
+        apiKey: config.ecsApiKey,
+      },
+    },
+  });
 }
 
 const logger = pino(
@@ -35,7 +32,7 @@ const logger = pino(
     },
     ...(config.ecsCloudId ? ecsFormat() : {}),
   },
-  getTransport(),
+  transport,
 );
 
 export default logger;

--- a/packages/toolpad-app/src/server/logger.ts
+++ b/packages/toolpad-app/src/server/logger.ts
@@ -49,6 +49,6 @@ const logger = pino(
   transport,
 );
 
-export function log(payload: LogPayload, message?: string): void {
+export function logInfo(payload: LogPayload, message?: string): void {
   logger.info(payload, message);
 }

--- a/packages/toolpad-app/src/server/withLogs.ts
+++ b/packages/toolpad-app/src/server/withLogs.ts
@@ -1,23 +1,16 @@
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { logInfo } from './logger';
 
-function getLogMessageInfo(req: NextApiRequest) {
-  const { type, name } = req.body;
-  return type && name ? `${type}:${name}` : '';
-}
-
 export const withReqResLogs =
   (apiHandler: NextApiHandler) =>
   (req: NextApiRequest, res: NextApiResponse): unknown | Promise<unknown> => {
-    const logMessageInfo = getLogMessageInfo(req);
-
     logInfo(
       {
         key: 'apiReqRes',
         req,
         res,
       },
-      `Handled request ${logMessageInfo ? `(${logMessageInfo})` : ''}`,
+      'Handled request',
     );
 
     return apiHandler(req, res);
@@ -26,15 +19,13 @@ export const withReqResLogs =
 export const withRpcReqResLogs =
   (apiHandler: NextApiHandler) =>
   (req: NextApiRequest, res: NextApiResponse): unknown | Promise<unknown> => {
-    const logMessageInfo = getLogMessageInfo(req);
-
     logInfo(
       {
         key: 'rpcReqRes',
         rpcReq: req,
         res,
       },
-      `Handled request ${logMessageInfo ? `(${logMessageInfo})` : ''}`,
+      `Handled request (${req.body.type}:${req.body.name})`,
     );
 
     return apiHandler(req, res);

--- a/packages/toolpad-app/src/server/withLogs.ts
+++ b/packages/toolpad-app/src/server/withLogs.ts
@@ -1,18 +1,19 @@
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
-import logger from './logger';
+import { log } from './logger';
 
 function getLogMessageInfo(req: NextApiRequest) {
   const { type, name } = req.body;
   return type && name ? `${type}:${name}` : '';
 }
 
-const withReqResLogs =
+export const withReqResLogs =
   (apiHandler: NextApiHandler) =>
   (req: NextApiRequest, res: NextApiResponse): unknown | Promise<unknown> => {
     const logMessageInfo = getLogMessageInfo(req);
 
-    logger.info(
+    log(
       {
+        key: 'apiReqRes',
         req,
         res,
       },
@@ -22,4 +23,19 @@ const withReqResLogs =
     return apiHandler(req, res);
   };
 
-export default withReqResLogs;
+export const withRpcReqResLogs =
+  (apiHandler: NextApiHandler) =>
+  (req: NextApiRequest, res: NextApiResponse): unknown | Promise<unknown> => {
+    const logMessageInfo = getLogMessageInfo(req);
+
+    log(
+      {
+        key: 'rpcReqRes',
+        rpcReq: req,
+        res,
+      },
+      `Handled request ${logMessageInfo ? `(${logMessageInfo})` : ''}`,
+    );
+
+    return apiHandler(req, res);
+  };

--- a/packages/toolpad-app/src/server/withLogs.ts
+++ b/packages/toolpad-app/src/server/withLogs.ts
@@ -1,5 +1,5 @@
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
-import { log } from './logger';
+import { logInfo } from './logger';
 
 function getLogMessageInfo(req: NextApiRequest) {
   const { type, name } = req.body;
@@ -11,7 +11,7 @@ export const withReqResLogs =
   (req: NextApiRequest, res: NextApiResponse): unknown | Promise<unknown> => {
     const logMessageInfo = getLogMessageInfo(req);
 
-    log(
+    logInfo(
       {
         key: 'apiReqRes',
         req,
@@ -28,7 +28,7 @@ export const withRpcReqResLogs =
   (req: NextApiRequest, res: NextApiResponse): unknown | Promise<unknown> => {
     const logMessageInfo = getLogMessageInfo(req);
 
-    log(
+    logInfo(
       {
         key: 'rpcReqRes',
         rpcReq: req,

--- a/packages/toolpad-app/src/server/withReqResLogs.ts
+++ b/packages/toolpad-app/src/server/withReqResLogs.ts
@@ -1,29 +1,22 @@
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
-import * as _ from 'lodash-es';
 import logger from './logger';
+
+function getLogMessageInfo(req: NextApiRequest) {
+  const { type, name } = req.body;
+  return type && name ? `${type}:${name}` : '';
+}
 
 const withReqResLogs =
   (apiHandler: NextApiHandler) =>
   (req: NextApiRequest, res: NextApiResponse): unknown | Promise<unknown> => {
+    const logMessageInfo = getLogMessageInfo(req);
+
     logger.info(
       {
-        req: {
-          ..._.pick(req, ['url', 'method']),
-          ...(!_.isEmpty(req.query) ? { query: req.query } : {}),
-          body: _.pick(req.body, [
-            'type',
-            'name',
-            // Omitting request params, but we could enable them if it would be useful
-            // 'params'
-          ]),
-          headers: _.pick(req.headers, ['x-forwarded-for', 'host', 'user-agent']),
-          socket: _.pick(req.socket, ['remoteAddress']),
-        },
-        res: {
-          statusCode: res.statusCode,
-        },
+        req,
+        res,
       },
-      'handled request',
+      `Handled request ${logMessageInfo ? `(${logMessageInfo})` : ''}`,
     );
 
     return apiHandler(req, res);

--- a/packages/toolpad-app/src/utils/crypto.ts
+++ b/packages/toolpad-app/src/utils/crypto.ts
@@ -1,0 +1,9 @@
+import invariant from 'invariant';
+
+const crypto =
+  typeof window === 'undefined'
+    ? // eslint-disable-next-line global-require
+      (invariant(!!global.crypto, 'Remove the crypto polyfill'), require('crypto'))
+    : global.crypto;
+
+export default crypto;

--- a/packages/toolpad-app/src/utils/uuid.ts
+++ b/packages/toolpad-app/src/utils/uuid.ts
@@ -1,10 +1,10 @@
-import { webcrypto } from 'crypto';
+import crypto from './crypto';
 
 // credit: https://stackoverflow.com/a/2117523
 export function uuidv4() {
   // @ts-ignore
   return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
     // eslint-disable-next-line no-bitwise
-    (c ^ (webcrypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16),
+    (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16),
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -587,6 +587,20 @@
     "@docsearch/css" "3.2.1"
     algoliasearch "^4.0.0"
 
+"@elastic/ecs-helpers@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/ecs-helpers/-/ecs-helpers-1.1.0.tgz#ee7e6f870f75a2222c5d7179b36a628f1db4779e"
+  integrity sha512-MDLb2aFeGjg46O5mLpdCzT5yOUDnXToJSrco2ShqGIXxNJaM8uJjX+4nd+hRYV4Vex8YJyDtOFEVBldQct6ndg==
+  dependencies:
+    fast-json-stringify "^2.4.1"
+
+"@elastic/ecs-pino-format@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@elastic/ecs-pino-format/-/ecs-pino-format-1.3.0.tgz#6e349a7da342b3c370d15361ba7f850bc2f783bc"
+  integrity sha512-U8D57gPECYoRCcwREsrXKBtqeyFFF/KAwHi4rG1u/oQhAg91Kzw8ZtUQJXD/DMDieLOqtbItFr2FRBWI3t3wog==
+  dependencies:
+    "@elastic/ecs-helpers" "^1.1.0"
+
 "@elastic/elasticsearch@^7.7.1":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.17.0.tgz#589fb219234cf1b0da23744e82b1d25e2fe9a797"
@@ -3461,7 +3475,7 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.10.0, ajv@^6.11.0, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -6106,6 +6120,16 @@ fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-json-stringify@^2.4.1:
+  version "2.7.13"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz#277aa86c2acba4d9851bd6108ed657aa327ed8c0"
+  integrity sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==
+  dependencies:
+    ajv "^6.11.0"
+    deepmerge "^4.2.2"
+    rfdc "^1.2.0"
+    string-similarity "^4.0.1"
 
 fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
@@ -10705,6 +10729,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rfdc@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
 rifm@^0.12.1:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.12.1.tgz#8fa77f45b7f1cda2a0068787ac821f0593967ac4"
@@ -11152,6 +11181,11 @@ string-length@^4.0.1:
   dependencies:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
+
+string-similarity@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/1068

Continuation of https://github.com/mui/mui-toolpad/pull/1066
Also applied some suggested improvements from the review for the request/response logs.

Kibana UI screenshot:
<img width="1792" alt="Screen Shot 2022-10-13 at 19 34 06" src="https://user-images.githubusercontent.com/10789765/195678860-8cbed6c3-00e5-4803-949f-32b6a5f4bb93.png">

Unfortunately I was not able to implement this in the Next.js middleware - it doesn't seem like `pino` works in the middleware runtime (at least some of its dependencies don't seem to).

If you want to test it I can give you the credentials to my trial project, or you can create one yourself at elastic.co.