### PR TITLE
Enforce the restriction on how icons are imported

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,8 +11,18 @@ module.exports = {
     'import/prefer-default-export': ['off'],
     // TODO move rule into the main repo once it has upgraded
     '@typescript-eslint/return-await': ['off'],
-    // TODO move rule into main repo to allow deep @mui/monorepo imports
-    'no-restricted-imports': ['off'],
+
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: '@mui/icons-material',
+            message: 'Use @mui/icons-material/<Icon> instead.',
+          },
+        ],
+      },
+    ],
     'no-restricted-syntax': [
       'error',
       // From https://github.com/airbnb/javascript/blob/d8cb404da74c302506f91e5928f30cc75109e74d/packages/eslint-config-airbnb-base/rules/style.js#L333
@@ -71,7 +81,6 @@ module.exports = {
       // https://github.com/mui/material-ui/blob/9737bc85bb6960adb742e7709e9c3710c4b6cedd/.eslintrc.js#L359
       files: ['packages/*/src/**/*{.ts,.tsx,.js}'],
       excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx'],
-      rules: { 'no-restricted-imports': 'off' },
     },
   ],
 };

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+// Running into issues compiling @mui/icons-material/Error inside of a "type": "module" package
+// eslint-disable-next-line no-restricted-imports
 import { Error as ErrorIcon } from '@mui/icons-material';
 import { Tooltip } from '@mui/material';
 import { ErrorBoundary } from 'react-error-boundary';


### PR DESCRIPTION
make sure we keep importing icons everywhere the same way

We're making an exception for now for imports inside of `@mui/toolpad-core` adn `@mui/toolpad-components` packages due to some limitations caused by `@mui/` packages not being true ESM. (`@mui/toolpad-core` is and when imported inside of next.js, the compiler expects its transitive dependencies to be ESM as well. Those not fully being esm causes incorrect nested imports)