### PR TITLE
Allow iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "release:changelog": "dotenv -- node ./scripts/releaseChangelog.js --repo mui-toolpad",
     "test:build": "lerna run build --scope @mui/toolpad-core --scope @mui/toolpad-components --stream",
     "test:integration": "playwright test --config ./test/integration/playwright.config.ts",
-    "e2e:smoke": "playwright test --config ./test/e2e-smoke/playwright.config.ts",
     "test": "yarn test:build && jest"
   },
   "devDependencies": {

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -64,6 +64,10 @@ const regexEqual = (x, y) => {
 // See https://nextjs.org/docs/advanced-features/security-headers
 const securityHeaders = [
   {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
     // Force the browser to trust the Content-Type header
     // https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff
     key: 'X-Content-Type-Options',
@@ -189,6 +193,24 @@ export default /** @type {import('next').NextConfig} */ withSentryConfig(
         {
           source: '/:path*',
           headers: securityHeaders,
+        },
+        {
+          source: '/reactDevtools/:path*',
+          headers: [
+            {
+              key: 'X-Frame-Options',
+              value: 'SAMEORIGIN',
+            },
+          ],
+        },
+        {
+          source: '/app-canvas/:path*',
+          headers: [
+            {
+              key: 'X-Frame-Options',
+              value: 'SAMEORIGIN',
+            },
+          ],
         },
       ];
     },

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -64,10 +64,6 @@ const regexEqual = (x, y) => {
 // See https://nextjs.org/docs/advanced-features/security-headers
 const securityHeaders = [
   {
-    key: 'X-Frame-Options',
-    value: 'SAMEORIGIN',
-  },
-  {
     // Force the browser to trust the Content-Type header
     // https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff
     key: 'X-Content-Type-Options',

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -191,7 +191,7 @@ export default /** @type {import('next').NextConfig} */ withSentryConfig(
     headers: async () => {
       return [
         {
-          source: '/:path*',
+          source: '/((?!deploy/).*)',
           headers: securityHeaders,
         },
         {

--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -195,15 +195,6 @@ export default /** @type {import('next').NextConfig} */ withSentryConfig(
           headers: securityHeaders,
         },
         {
-          source: '/reactDevtools/:path*',
-          headers: [
-            {
-              key: 'X-Frame-Options',
-              value: 'SAMEORIGIN',
-            },
-          ],
-        },
-        {
           source: '/app-canvas/:path*',
           headers: [
             {

--- a/packages/toolpad-app/pages/deploy/[appId]/[[...path]].tsx
+++ b/packages/toolpad-app/pages/deploy/[appId]/[[...path]].tsx
@@ -12,22 +12,19 @@ export const getServerSideProps: GetServerSideProps<ToolpadAppProps> = async (co
     import('../../../src/server/basicAuth'),
   ]);
 
-  context.res.removeHeader('X-Frame-Options');
-
   const [appId] = asArray(context.query.appId);
+  const app = appId ? await getApp(appId) : null;
 
-  if (!appId) {
+  if (!app || !appId) {
     return {
       notFound: true,
     };
   }
 
-  const app = await getApp(appId);
-  if (!app) {
-    return {
-      notFound: true,
-    };
-  }
+  // TODO: iframes should be disallowed by default.
+  // if (!app.allowIframes) {
+  //   context.res.setHeader('X-Frame-Options', 'DENY');
+  // }
 
   if (!app.public) {
     if (!checkBasicAuth(context.req)) {

--- a/packages/toolpad-app/pages/deploy/[appId]/[[...path]].tsx
+++ b/packages/toolpad-app/pages/deploy/[appId]/[[...path]].tsx
@@ -12,6 +12,8 @@ export const getServerSideProps: GetServerSideProps<ToolpadAppProps> = async (co
     import('../../../src/server/basicAuth'),
   ]);
 
+  context.res.removeHeader('X-Frame-Options');
+
   const [appId] = asArray(context.query.appId);
 
   if (!appId) {

--- a/test/integration/deploy.spec.ts
+++ b/test/integration/deploy.spec.ts
@@ -1,0 +1,18 @@
+import fetch from 'node-fetch';
+import { test, expect } from '../playwright/test';
+
+const userAgent = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
+test('can render in an iframe', async ({ baseURL, browserName }) => {
+  if (browserName !== 'chromium') {
+    test.skip(true, 'No use, test HTTP statuses');
+  }
+
+  const response = await fetch(`${baseURL}deploy/cl9bp4czk00019kt2grzr5m3u/pages/l11ao9l`, {
+    headers: { 'User-Agent': userAgent },
+    method: 'HEAD',
+    redirect: 'manual',
+  });
+  expect(response.status).toBe(404);
+  expect(response.headers.get('X-Frame-Options')).toBe(null);
+});


### PR DESCRIPTION
I'm doing a quick POC https://github.com/mui/mui-store/pull/224 to use Toolpad to render a custom extension for showing WooCommerce information on Zendesk. It would looks something like this: https://www.zendesk.com/marketplace/apps/support/273938/woocommerce-by-zenplates/. 

<img width="1118" alt="Screenshot 2022-10-15 at 21 10 34" src="https://user-images.githubusercontent.com/3165635/196003980-24598d47-f9f0-41a8-9b57-330e04dd283c.png">

https://mui.zendesk.com/agent/tickets/4354

However, I can't load the Toolpad app with an iframe. The alternative would be to render the app with React but I'm not aware that it's still something that we can do with Toolpad, so hence my PR.