### PR TITLE
Remove false sourceMapReference in next config

### DIFF
--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -93,7 +93,6 @@ const sentryWebpackPluginOptions = {
   silent: true, // Suppresses all logs
 
   dryRun: true,
-  sourceMapReference: false,
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.
 };


### PR DESCRIPTION
This option is stopping many source maps from being generated - should not have added it.
