### PR TITLE
Replace chevron icons with arrow icons

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -2,8 +2,8 @@ import { TreeView } from '@mui/lab';
 import { Typography, styled, Box, IconButton } from '@mui/material';
 import * as React from 'react';
 import TreeItem, { TreeItemProps } from '@mui/lab/TreeItem';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import { useNavigate, useLocation, matchRoutes, Location } from 'react-router-dom';
@@ -231,8 +231,8 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
         expanded={expanded}
         onNodeToggle={handleToggle}
         multiSelect
-        defaultCollapseIcon={<ExpandMoreIcon />}
-        defaultExpandIcon={<ChevronRightIcon />}
+        defaultCollapseIcon={<ArrowDropDownIcon />}
+        defaultExpandIcon={<ArrowRightIcon />}
       >
         <HierarchyTreeItem
           nodeId=":connections"

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Box, Collapse, darken, IconButton, Link, styled, Typography } from '@mui/material';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ArrowLeftIcon from '@mui/icons-material/ArrowLeft';
+import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import ArrowDropDownSharpIcon from '@mui/icons-material/ArrowDropDownSharp';
 import invariant from 'invariant';
 import ComponentCatalogItem from './ComponentCatalogItem';
@@ -252,7 +252,7 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
             width: WIDTH_COLLAPSED,
           }}
         >
-          <Box sx={{ mt: 2 }}>{openStart ? <ChevronLeftIcon /> : <ChevronRightIcon />}</Box>
+          <Box sx={{ mt: 2 }}>{openStart ? <ArrowLeftIcon /> : <ArrowRightIcon />}</Box>
           <Box position="relative">
             <Typography
               sx={{


### PR DESCRIPTION
in the explorer and component drawer:

![Screenshot 2022-10-18 at 17 27 59](https://user-images.githubusercontent.com/2109932/196474943-ebfa771c-b4b9-4801-a95b-0e4fac191c01.png)
