### PR TITLE
Make sure Monaco theme switches correctly

### DIFF
--- a/packages/toolpad-app/src/components/MonacoEditor.tsx
+++ b/packages/toolpad-app/src/components/MonacoEditor.tsx
@@ -49,14 +49,14 @@ declare global {
   }
 }
 
-monaco.editor.defineTheme('vs-dark-toolpad', {
+monaco.editor.defineTheme('vs-toolpad-dark', {
   base: 'vs-dark',
   inherit: true,
   rules: [],
   colors: {},
 });
 
-monaco.editor.defineTheme('vs-light-toolpad', {
+monaco.editor.defineTheme('vs-toolpad-light', {
   base: 'vs',
   inherit: true,
   rules: [],
@@ -246,7 +246,7 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
   const rootRef = React.useRef<HTMLDivElement>(null);
   const instanceRef = React.useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const theme = useTheme();
-  const monacoTheme = theme.palette.mode === 'dark' ? 'vs-dark-toolpad' : 'vs-light-toolpad';
+  const monacoTheme = theme.palette.mode === 'dark' ? 'vs-toolpad-dark' : 'vs-toolpad-light';
 
   const [isFocused, setIsFocused] = React.useState(false);
 

--- a/packages/toolpad-app/src/components/MonacoEditor.tsx
+++ b/packages/toolpad-app/src/components/MonacoEditor.tsx
@@ -59,7 +59,14 @@ monaco.editor.defineTheme('vs-toolpad-dark', {
   inherit: true,
   rules: [],
   colors: {
-    ...(darkBackground ? { 'editor.background': rgbToHex(lighten(darkBackground, 0.1)) } : {}),
+    ...(darkBackground
+      ? {
+          // See https://code.visualstudio.com/api/references/theme-color
+          'editor.background': rgbToHex(lighten(darkBackground, 0.05)),
+          'menu.background': darkBackground,
+          'editorWidget.background': darkBackground,
+        }
+      : {}),
   },
 });
 

--- a/packages/toolpad-app/src/components/MonacoEditor.tsx
+++ b/packages/toolpad-app/src/components/MonacoEditor.tsx
@@ -17,7 +17,8 @@ import {
   conf as typescriptBasicConf,
   language as typescriptBasicLanguage,
 } from 'monaco-editor/esm/vs/basic-languages/typescript/typescript';
-import { useTheme, Theme } from '@mui/material/styles';
+import { useTheme, Theme, lighten, rgbToHex } from '@mui/material/styles';
+import { getDesignTokens } from '../theme';
 
 export interface ExtraLib {
   content: string;
@@ -49,11 +50,17 @@ declare global {
   }
 }
 
+const designTokensDark = getDesignTokens('dark');
+
+const darkBackground = designTokensDark.palette?.background?.default;
+
 monaco.editor.defineTheme('vs-toolpad-dark', {
   base: 'vs-dark',
   inherit: true,
   rules: [],
-  colors: {},
+  colors: {
+    ...(darkBackground ? { 'editor.background': rgbToHex(lighten(darkBackground, 0.1)) } : {}),
+  },
 });
 
 monaco.editor.defineTheme('vs-toolpad-light', {

--- a/packages/toolpad-app/src/components/MonacoEditor.tsx
+++ b/packages/toolpad-app/src/components/MonacoEditor.tsx
@@ -18,7 +18,6 @@ import {
   language as typescriptBasicLanguage,
 } from 'monaco-editor/esm/vs/basic-languages/typescript/typescript';
 import { useTheme, Theme } from '@mui/material/styles';
-import useMonacoTheme from '../monacoEditorTheme';
 
 export interface ExtraLib {
   content: string;
@@ -49,6 +48,20 @@ declare global {
     MonacoEnvironment?: monaco.Environment | undefined;
   }
 }
+
+monaco.editor.defineTheme('vs-dark-toolpad', {
+  base: 'vs-dark',
+  inherit: true,
+  rules: [],
+  colors: {},
+});
+
+monaco.editor.defineTheme('vs-light-toolpad', {
+  base: 'vs',
+  inherit: true,
+  rules: [],
+  colors: {},
+});
 
 window.MonacoEnvironment = {
   async getWorker(_, label) {
@@ -233,7 +246,7 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
   const rootRef = React.useRef<HTMLDivElement>(null);
   const instanceRef = React.useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const theme = useTheme();
-  const monacoTheme = useMonacoTheme();
+  const monacoTheme = theme.palette.mode === 'dark' ? 'vs-dark-toolpad' : 'vs-light-toolpad';
 
   const [isFocused, setIsFocused] = React.useState(false);
 
@@ -284,6 +297,7 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
 
     const extraOptions: EditorOptions = {
       readOnly: disabled,
+      theme: monacoTheme,
       scrollbar: {
         alwaysConsumeMouseWheel: false,
         ...options?.scrollbar,
@@ -327,7 +341,6 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
         accessibilitySupport: 'off',
         tabSize: 2,
         automaticLayout: true,
-        theme: monacoTheme,
         fixedOverflowWidgets: true,
         // See https://github.com/microsoft/monaco-editor/issues/181
         overflowWidgetsDomNode: getOverflowWidgetsDomNode(theme),

--- a/packages/toolpad-app/src/monacoEditorTheme.ts
+++ b/packages/toolpad-app/src/monacoEditorTheme.ts
@@ -1,8 +1,0 @@
-import { useTheme } from '@mui/material/styles';
-
-const useMonacoTheme = (): string => {
-  const theme = useTheme();
-  return theme.palette.mode === 'dark' ? 'vs-dark' : 'vs';
-};
-
-export default useMonacoTheme;


### PR DESCRIPTION
Currently the Monaco theme doesn't switch when the theme switches without a reload. This PR fixes that. It also prepares two custom themes `'vs-toolpad-dark'`, `'vs-toolpad-light'` that we can define custom colors in.

I did a quick update of the background colors for the dark theme, to bring it all a bit better together, but this needs further tweaking.