### PR TITLE
Remove branch option from database in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -59,7 +59,6 @@ databases:
   - name: toolpad-demo-db
     ipAllowList: []
     plan: starter
-    branch: demo
 
 envVarGroups:
   - name: toolpad-settings


### PR DESCRIPTION
Databases don't take a `branch` option in `render.yaml`, hopefully this is the only fix needed for the automatic deploy to work.