### PR TITLE
Use latest version of Toolpad in demo

### DIFF
--- a/docker/images/toolpad-demo/Dockerfile
+++ b/docker/images/toolpad-demo/Dockerfile
@@ -1,1 +1,1 @@
-FROM muicom/toolpad:v0.0.23
+FROM muicom/toolpad:latest

--- a/docker/images/toolpad-demo/Dockerfile
+++ b/docker/images/toolpad-demo/Dockerfile
@@ -1,1 +1,1 @@
-FROM muicom/toolpad:latest
+FROM muicom/toolpad:a3a5ddf4243a4b7b8f07755d583bc8986b0cef9e


### PR DESCRIPTION
Need to use a more recent version in the demo Dockerfile than the latest release, at least for now, so that we have `TOOLPAD_DEMO` in the runtime.