### PR TITLE
[core] Relax the restrictions on node naming

### DIFF
--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -933,29 +933,26 @@ export function duplicateNode(
   dom: AppDom,
   node: AppDomNode,
   parent: AppDomNode | null = getParent(dom, node),
-) {
-  if (!parent || !node.parentId || !node.parentProp || !node.parentIndex) {
+  parentprop: string | null = node.parentProp,
+): AppDom {
+  if (!parent || !parentprop) {
     throw new Error(`Node: "${node.id}" can't be duplicated`);
   }
 
-  const childNodes = getChildNodes(dom, node);
-  const existingNames = getExistingNamesForChildren(dom, parent);
-
   const newNode = createNode(dom, node.type, node);
+  const childNodes = getChildNodes(dom, node);
 
-  let updatedDom = dom;
+  dom = addNode<any, any>(dom, newNode, parent, parentprop);
 
-  children?.forEach((childNode) => {
-    updatedDom = duplicateNode(updatedDom, childNode, newNode);
-  });
-
-  if (parent) {
-    return setNodeParent(updatedDom, newNode, parent.id, node.parentProp, node.parentIndex);
+  for (const [childParentProp, children] of Object.entries(childNodes)) {
+    if (children) {
+      for (const child of children as AppDomNode[]) {
+        dom = duplicateNode(dom, child, newNode, childParentProp);
+      }
+    }
   }
 
-  const newParentIndex = getNewParentIndexAfterNode(updatedDom, node, node.parentProp);
-
-  return setNodeParent(updatedDom, newNode, node.parentId, node.parentProp, newParentIndex);
+  return dom;
 }
 
 const RENDERTREE_NODES = [

--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -595,7 +595,7 @@ export function getExistingNamesForChildren<Parent extends AppDomNode>(
     return new Set(pageDescendants.map((scopeNode) => scopeNode.name));
   }
 
-  const { [parentProp]: children } = getChildNodes(dom, parent);
+  const { [parentProp]: children = [] } = getChildNodes(dom, parent);
   return new Set(children.map((scopeNode) => scopeNode.name));
 }
 
@@ -753,6 +753,15 @@ export function addNode<Parent extends AppDomNode, Child extends AppDomNode>(
 ): AppDom {
   if (newNode.parentId) {
     throw new Error(`Node "${newNode.id}" is already attached to a parent`);
+  }
+
+  const existingNames = getExistingNamesForChildren(dom, parent, parentProp);
+
+  if (existingNames.has(newNode.name)) {
+    newNode = {
+      ...newNode,
+      name: proposeName(newNode.name, existingNames),
+    };
   }
 
   return setNodeParent(dom, newNode, parent.id, parentProp, parentIndex);

--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -949,16 +949,16 @@ export function duplicateNode(
   dom: AppDom,
   node: AppDomNode,
   parent: AppDomNode | null = getParent(dom, node),
-  parentprop: string | null = node.parentProp,
+  parentProp: string | null = node.parentProp,
 ): AppDom {
-  if (!parent || !parentprop) {
+  if (!parent || !parentProp) {
     throw new Error(`Node: "${node.id}" can't be duplicated`);
   }
 
   const newNode = createNode(dom, node.type, node);
   const childNodes = getChildNodes(dom, node);
 
-  dom = addNode<any, any>(dom, newNode, parent, parentprop);
+  dom = addNode<any, any>(dom, newNode, parent, parentProp);
 
   for (const [childParentProp, children] of Object.entries(childNodes)) {
     if (children) {

--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -800,7 +800,15 @@ export function moveNode<Parent extends AppDomNode, Child extends AppDomNode>(
   return setNodeParent(dom, node, parent.id, parentProp, parentIndex);
 }
 
+export function nodeExists(dom: AppDom, nodeId: NodeId): boolean {
+  return !!getMaybeNode(dom, nodeId);
+}
+
 export function saveNode(dom: AppDom, node: AppDomNode) {
+  if (!nodeExists(dom, node.id)) {
+    throw new Error(`Attempt to update node "${node.id}", but it doesn't exist in the dom`);
+  }
+
   return update(dom, {
     nodes: update(dom.nodes, {
       [node.id]: update(dom.nodes[node.id], omit(node, ...RESERVED_NODE_PROPERTIES)),

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -15,6 +15,8 @@ import DialogForm from '../../../components/DialogForm';
 import useEvent from '../../../utils/useEvent';
 import { useNameInputError } from './validation';
 
+const DEFAULT_NAME = 'MyComponent';
+
 function createDefaultCodeComponent(name: string): string {
   const componentId = name.replace(/\s/g, '');
   const propTypeId = `${componentId}Props`;
@@ -64,12 +66,12 @@ export default function CreateCodeComponentDialog({
     [dom],
   );
 
-  const [name, setName] = React.useState(appDom.proposeName('MyComponent', existingNames));
+  const [name, setName] = React.useState(appDom.proposeName(DEFAULT_NAME, existingNames));
 
   const navigate = useNavigate();
 
   // Reset form
-  const handleReset = useEvent(() => setName(appDom.proposeName('page', existingNames)));
+  const handleReset = useEvent(() => setName(appDom.proposeName(DEFAULT_NAME, existingNames)));
 
   React.useEffect(() => {
     if (open) {
@@ -120,7 +122,7 @@ export default function CreateCodeComponentDialog({
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!name || isNameInvalid}>
+          <Button type="submit" disabled={isNameInvalid}>
             Create
           </Button>
         </DialogActions>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -13,7 +13,7 @@ import { useDom, useDomApi } from '../../DomLoader';
 import { format } from '../../../utils/prettier';
 import DialogForm from '../../../components/DialogForm';
 import useEvent from '../../../utils/useEvent';
-import { useNameInputError } from './validation';
+import { useNodeNameValidation } from './validation';
 
 const DEFAULT_NAME = 'MyComponent';
 
@@ -83,8 +83,8 @@ export default function CreateCodeComponentDialog({
     event.target.select();
   }, []);
 
-  const inputErrorMsg = useNameInputError(name, existingNames, 'component');
-  const isNameInvalid = !!inputErrorMsg;
+  const inputErrorMsg = useNodeNameValidation(name, existingNames, 'component');
+  const isNameValid = !inputErrorMsg;
 
   return (
     <Dialog open={open} onClose={onClose} {...props}>
@@ -114,7 +114,7 @@ export default function CreateCodeComponentDialog({
             label="name"
             value={name}
             onChange={(event) => setName(event.target.value)}
-            error={isNameInvalid}
+            error={!isNameValid}
             helperText={inputErrorMsg}
           />
         </DialogContent>
@@ -122,7 +122,7 @@ export default function CreateCodeComponentDialog({
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isNameInvalid}>
+          <Button type="submit" disabled={!isNameValid}>
             Create
           </Button>
         </DialogActions>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -108,6 +108,7 @@ export default function CreateCodeComponentDialog({
         <DialogContent>
           <TextField
             sx={{ my: 1 }}
+            required
             onFocus={handleInputFocus}
             autoFocus
             fullWidth

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
@@ -84,6 +84,7 @@ export default function CreateConnectionDialog({
         <DialogContent>
           <TextField
             sx={{ my: 1 }}
+            required
             autoFocus
             fullWidth
             label="name"

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
@@ -14,7 +14,7 @@ import { useDom, useDomApi } from '../../DomLoader';
 import dataSources from '../../../toolpadDataSources/client';
 import { ExactEntriesOf } from '../../../utils/types';
 import DialogForm from '../../../components/DialogForm';
-import { useNameInputError } from './validation';
+import { useNodeNameValidation } from './validation';
 import useEvent from '../../../utils/useEvent';
 
 const DEFAULT_NAME = 'connection';
@@ -53,8 +53,8 @@ export default function CreateConnectionDialog({
     }
   }, [open, handleReset]);
 
-  const inputErrorMsg = useNameInputError(name, existingNames, 'connection');
-  const isNameInvalid = !!inputErrorMsg;
+  const inputErrorMsg = useNodeNameValidation(name, existingNames, 'connection');
+  const isNameValid = !inputErrorMsg;
 
   return (
     <Dialog open={open} onClose={onClose} {...props}>
@@ -89,7 +89,7 @@ export default function CreateConnectionDialog({
             label="name"
             value={name}
             onChange={(event) => setName(event.target.value)}
-            error={isNameInvalid}
+            error={!isNameValid}
             helperText={inputErrorMsg}
           />
           <TextField
@@ -114,7 +114,7 @@ export default function CreateConnectionDialog({
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!dataSourceType || isNameInvalid}>
+          <Button type="submit" disabled={!dataSourceType || !isNameValid}>
             Create
           </Button>
         </DialogActions>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
@@ -17,6 +17,8 @@ import DialogForm from '../../../components/DialogForm';
 import { useNameInputError } from './validation';
 import useEvent from '../../../utils/useEvent';
 
+const DEFAULT_NAME = 'connection';
+
 export interface CreateConnectionDialogProps {
   appId: string;
   open: boolean;
@@ -37,13 +39,13 @@ export default function CreateConnectionDialog({
     [dom],
   );
 
-  const [name, setName] = React.useState(appDom.proposeName('connection', existingNames));
+  const [name, setName] = React.useState(appDom.proposeName(DEFAULT_NAME, existingNames));
 
   const [dataSourceType, setDataSourceType] = React.useState('');
   const navigate = useNavigate();
 
   // Reset form
-  const handleReset = useEvent(() => setName(appDom.proposeName('connection', existingNames)));
+  const handleReset = useEvent(() => setName(appDom.proposeName(DEFAULT_NAME, existingNames)));
 
   React.useEffect(() => {
     if (open) {
@@ -112,7 +114,7 @@ export default function CreateConnectionDialog({
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!dataSourceType || !name || isNameInvalid}>
+          <Button type="submit" disabled={!dataSourceType || isNameInvalid}>
             Create
           </Button>
         </DialogActions>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
@@ -14,6 +14,8 @@ import { useDom, useDomApi } from '../../DomLoader';
 import dataSources from '../../../toolpadDataSources/client';
 import { ExactEntriesOf } from '../../../utils/types';
 import DialogForm from '../../../components/DialogForm';
+import { useNameInputError } from './validation';
+import useEvent from '../../../utils/useEvent';
 
 export interface CreateConnectionDialogProps {
   appId: string;
@@ -23,16 +25,37 @@ export interface CreateConnectionDialogProps {
 
 export default function CreateConnectionDialog({
   appId,
+  open,
   onClose,
   ...props
 }: CreateConnectionDialogProps) {
   const dom = useDom();
   const domApi = useDomApi();
+
+  const existingNames = React.useMemo(
+    () => appDom.getExistingNamesForChildren(dom, appDom.getApp(dom), 'connections'),
+    [dom],
+  );
+
+  const [name, setName] = React.useState(appDom.proposeName('connection', existingNames));
+
   const [dataSourceType, setDataSourceType] = React.useState('');
   const navigate = useNavigate();
 
+  // Reset form
+  const handleReset = useEvent(() => setName(appDom.proposeName('connection', existingNames)));
+
+  React.useEffect(() => {
+    if (open) {
+      handleReset();
+    }
+  }, [open, handleReset]);
+
+  const inputErrorMsg = useNameInputError(name, existingNames, 'connection');
+  const isNameInvalid = !!inputErrorMsg;
+
   return (
-    <Dialog {...props} onClose={onClose}>
+    <Dialog open={open} onClose={onClose} {...props}>
       <DialogForm
         autoComplete="off"
         onSubmit={(e) => {
@@ -42,6 +65,7 @@ export default function CreateConnectionDialog({
             throw new Error(`Can't find a datasource for "${dataSourceType}"`);
           }
           const newNode = appDom.createNode(dom, 'connection', {
+            name,
             attributes: {
               dataSource: appDom.createConst(dataSourceType),
               params: appDom.createSecret(null),
@@ -56,6 +80,16 @@ export default function CreateConnectionDialog({
       >
         <DialogTitle>Create a new MUI Toolpad Connection</DialogTitle>
         <DialogContent>
+          <TextField
+            sx={{ my: 1 }}
+            autoFocus
+            fullWidth
+            label="name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            error={isNameInvalid}
+            helperText={inputErrorMsg}
+          />
           <TextField
             select
             sx={{ my: 1 }}
@@ -78,7 +112,7 @@ export default function CreateConnectionDialog({
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!dataSourceType}>
+          <Button type="submit" disabled={!dataSourceType || !name || isNameInvalid}>
             Create
           </Button>
         </DialogActions>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
@@ -75,6 +75,7 @@ export default function CreatePageDialog({
         <DialogContent>
           <TextField
             sx={{ my: 1 }}
+            required
             autoFocus
             fullWidth
             label="name"

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
@@ -86,7 +86,7 @@ export default function CreatePageDialog({
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!name || !isNameInvalid}>
+          <Button type="submit" disabled={!name || isNameInvalid}>
             Create
           </Button>
         </DialogActions>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
@@ -14,6 +14,8 @@ import useEvent from '../../../utils/useEvent';
 import { useDom, useDomApi } from '../../DomLoader';
 import { useNameInputError } from './validation';
 
+const DEFAULT_NAME = 'page';
+
 export interface CreatePageDialogProps {
   appId: string;
   open: boolean;
@@ -34,12 +36,12 @@ export default function CreatePageDialog({
     [dom],
   );
 
-  const [name, setName] = React.useState(appDom.proposeName('page', existingNames));
+  const [name, setName] = React.useState(appDom.proposeName(DEFAULT_NAME, existingNames));
 
   const navigate = useNavigate();
 
   // Reset form
-  const handleReset = useEvent(() => setName(appDom.proposeName('page', existingNames)));
+  const handleReset = useEvent(() => setName(appDom.proposeName(DEFAULT_NAME, existingNames)));
 
   React.useEffect(() => {
     if (open) {
@@ -86,7 +88,7 @@ export default function CreatePageDialog({
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!name || isNameInvalid}>
+          <Button type="submit" disabled={isNameInvalid}>
             Create
           </Button>
         </DialogActions>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
@@ -12,7 +12,7 @@ import * as appDom from '../../../appDom';
 import DialogForm from '../../../components/DialogForm';
 import useEvent from '../../../utils/useEvent';
 import { useDom, useDomApi } from '../../DomLoader';
-import { useNameInputError } from './validation';
+import { useNodeNameValidation } from './validation';
 
 const DEFAULT_NAME = 'page';
 
@@ -49,8 +49,8 @@ export default function CreatePageDialog({
     }
   }, [open, handleReset]);
 
-  const inputErrorMsg = useNameInputError(name, existingNames, 'page');
-  const isNameInvalid = !!inputErrorMsg;
+  const inputErrorMsg = useNodeNameValidation(name, existingNames, 'page');
+  const isNameValid = !inputErrorMsg;
 
   return (
     <Dialog open={open} onClose={onClose} {...props}>
@@ -80,7 +80,7 @@ export default function CreatePageDialog({
             label="name"
             value={name}
             onChange={(event) => setName(event.target.value)}
-            error={isNameInvalid}
+            error={!isNameValid}
             helperText={inputErrorMsg}
           />
         </DialogContent>
@@ -88,7 +88,7 @@ export default function CreatePageDialog({
           <Button color="inherit" variant="text" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" disabled={isNameInvalid}>
+          <Button type="submit" disabled={!isNameValid}>
             Create
           </Button>
         </DialogActions>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/validation.ts
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/validation.ts
@@ -1,17 +1,9 @@
 import * as React from 'react';
 import * as appDom from '../../../appDom';
 
-function validateNodeName(name: string, disallowedNames: Set<string>, kind: string) {
-  const isUnique = !disallowedNames.has(name);
-  return name
-    ? appDom.validateNodeName(name, `a ${kind} name`) ||
-        (isUnique ? null : `There already is a ${kind} with this name`)
-    : 'a name is required';
-}
-
 export function useNodeNameValidation(name: string, disallowedNames: Set<string>, kind: string) {
   return React.useMemo(
-    () => validateNodeName(name, disallowedNames, kind),
+    () => appDom.validateNodeName(name, disallowedNames, kind),
     [name, disallowedNames, kind],
   );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/validation.ts
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/validation.ts
@@ -7,7 +7,7 @@ export function useNameInputError(name: string, disallowedNames: Set<string>, ki
     return name
       ? appDom.validateNodeName(name, `a ${kind} name`) ||
           (isUnique ? null : `There already is a ${kind} with this name`)
-      : null;
+      : 'a name is required';
   }, [name, kind, isUnique]);
   return inputErrorMsg;
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/validation.ts
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/validation.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import * as appDom from '../../../appDom';
+
+export function useNameInputError(name: string, disallowedNames: Set<string>, kind: string) {
+  const isUnique = React.useMemo(() => !disallowedNames.has(name), [disallowedNames, name]);
+  const inputErrorMsg = React.useMemo(() => {
+    return name
+      ? appDom.validateNodeName(name, `a ${kind} name`) ||
+          (isUnique ? null : `There already is a ${kind} with this name`)
+      : null;
+  }, [name, kind, isUnique]);
+  return inputErrorMsg;
+}

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/validation.ts
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/validation.ts
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import * as appDom from '../../../appDom';
 
-export function useNameInputError(name: string, disallowedNames: Set<string>, kind: string) {
-  const isUnique = React.useMemo(() => !disallowedNames.has(name), [disallowedNames, name]);
-  const inputErrorMsg = React.useMemo(() => {
-    return name
-      ? appDom.validateNodeName(name, `a ${kind} name`) ||
-          (isUnique ? null : `There already is a ${kind} with this name`)
-      : 'a name is required';
-  }, [name, kind, isUnique]);
-  return inputErrorMsg;
+function validateNodeName(name: string, disallowedNames: Set<string>, kind: string) {
+  const isUnique = !disallowedNames.has(name);
+  return name
+    ? appDom.validateNodeName(name, `a ${kind} name`) ||
+        (isUnique ? null : `There already is a ${kind} with this name`)
+    : 'a name is required';
+}
+
+export function useNodeNameValidation(name: string, disallowedNames: Set<string>, kind: string) {
+  return React.useMemo(
+    () => validateNodeName(name, disallowedNames, kind),
+    [name, disallowedNames, kind],
+  );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/material';
 import * as React from 'react';
 import AddIcon from '@mui/icons-material/Add';
-import { BindableAttrEntries, BindableAttrValue, NodeId } from '@mui/toolpad-core';
+import { BindableAttrEntries, BindableAttrValue } from '@mui/toolpad-core';
 import invariant from 'invariant';
 import useLatest from '../../../utils/useLatest';
 import { usePageEditorState } from './PageEditorProvider';
@@ -32,6 +32,7 @@ import BindableEditor from './BindableEditor';
 import { ConfirmDialog } from '../../../components/SystemDialogs';
 import useBoolean from '../../../utils/useBoolean';
 import { useNodeNameValidation } from '../HierarchyExplorer/validation';
+import useEvent from '../../../utils/useEvent';
 
 const EMPTY_OBJECT = {};
 
@@ -161,24 +162,32 @@ interface QueryNodeEditorProps<Q> {
   onSave: (newNode: appDom.QueryNode) => void;
   onRemove: (newNode: appDom.QueryNode) => void;
   node: appDom.QueryNode<Q>;
+  isDraft: boolean;
 }
 
 function QueryNodeEditorDialog<Q>({
   open,
-  node,
+  node: nodeProp,
   onClose,
   onRemove,
   onSave,
+  isDraft,
 }: QueryNodeEditorProps<Q>) {
   const { appId } = usePageEditorState();
   const dom = useDom();
 
+  // To keep it around during closing animation
+  const node = useLatest(nodeProp);
+
   const [input, setInput] = React.useState<appDom.QueryNode<Q>>(node);
+
+  const reset = useEvent(() => setInput(node));
+
   React.useEffect(() => {
     if (open) {
-      setInput(node);
+      reset();
     }
-  }, [open, node]);
+  }, [open, reset]);
 
   const connectionId = input.attributes.connectionId.value
     ? appDom.deref(input.attributes.connectionId.value)
@@ -292,7 +301,7 @@ function QueryNodeEditorDialog<Q>({
     onClose();
   }, [onRemove, node, onClose]);
 
-  const isInputSaved = node === input;
+  const isInputSaved = !isDraft && node === input;
 
   const handleClose = React.useCallback(() => {
     const ok = isInputSaved
@@ -438,9 +447,15 @@ function QueryNodeEditorDialog<Q>({
   );
 }
 
-type DialogState = {
-  nodeId?: NodeId;
-};
+type DialogState =
+  | {
+      node?: undefined;
+      isDraft?: undefined;
+    }
+  | {
+      node: appDom.QueryNode;
+      isDraft: boolean;
+    };
 
 export default function QueryEditor() {
   const dom = useDom();
@@ -459,18 +474,20 @@ export default function QueryEditor() {
   }, []);
 
   const handleCreated = React.useCallback(
-    (node: appDom.QueryNode) => {
-      domApi.addNode(node, page, 'queries');
-      setDialogState({ nodeId: node.id });
-    },
-    [domApi, page],
+    (node: appDom.QueryNode) => setDialogState({ node, isDraft: true }),
+    [],
   );
 
   const handleSave = React.useCallback(
     (node: appDom.QueryNode) => {
-      domApi.saveNode(node);
+      if (appDom.nodeExists(dom, node.id)) {
+        domApi.saveNode(node);
+      } else {
+        domApi.addNode(node, page, 'queries');
+      }
+      setDialogState({ node, isDraft: false });
     },
-    [domApi],
+    [dom, domApi, page],
   );
 
   const handleRemove = React.useCallback(
@@ -480,13 +497,6 @@ export default function QueryEditor() {
     },
     [domApi, handleEditStateDialogClose],
   );
-
-  const editedNode = dialogState?.nodeId
-    ? appDom.getMaybeNode(dom, dialogState.nodeId, 'query')
-    : null;
-
-  // To keep it around during closing animation
-  const lastEditednode = useLatest(editedNode);
 
   return (
     <Stack spacing={1} alignItems="start">
@@ -499,17 +509,18 @@ export default function QueryEditor() {
             <ListItem
               key={queryNode.id}
               button
-              onClick={() => setDialogState({ nodeId: queryNode.id })}
+              onClick={() => setDialogState({ node: queryNode, isDraft: false })}
             >
               {queryNode.name}
             </ListItem>
           );
         })}
       </List>
-      {dialogState?.nodeId && lastEditednode ? (
+      {dialogState?.node ? (
         <QueryNodeEditorDialog
           open={!!dialogState}
-          node={lastEditednode}
+          node={dialogState.node}
+          isDraft={dialogState.isDraft}
           onSave={handleSave}
           onRemove={handleRemove}
           onClose={handleEditStateDialogClose}

--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -106,7 +106,7 @@ export function domReducer(dom: appDom.AppDom, action: DomAction): appDom.AppDom
       );
     }
     case 'DOM_DUPLICATE_NODE': {
-      return appDom.duplicateNode<any, any>(dom, action.node);
+      return appDom.duplicateNode(dom, action.node);
     }
     case 'DOM_SAVE_NODE': {
       return appDom.saveNode(dom, action.node);

--- a/packages/toolpad-app/src/utils/useEvent.ts
+++ b/packages/toolpad-app/src/utils/useEvent.ts
@@ -21,7 +21,7 @@ function isInRender() {
 /**
  * See https://github.com/reactjs/rfcs/pull/220
  */
-export default function useEvent<F extends Function>(handler: F): F {
+export default function useEvent<F extends (...args: any[]) => void>(handler: F): F {
   useRenderTracker();
   const ref = React.useRef(handler);
   React.useInsertionEffect(() => {
@@ -33,6 +33,6 @@ export default function useEvent<F extends Function>(handler: F): F {
       throw new Error('Cannot call event in Render!');
     }
     const fn = ref.current;
-    return fn(...args);
+    fn(...args);
   }, []);
 }


### PR DESCRIPTION
Working up towards https://github.com/mui/mui-toolpad/issues/1126 this PR changes when unique names are enforced and relaxes the strictness on duplicate names. e.g. after this PR page 1 can have a query name "x" and page 2 as well.

* Nodes must be unique within their siblings, and in the case of pages within the descendants on the page
* Improved the validation of the creation dialogs and add default names for nodes
* Had to rewrite the duplication method so that it uses `addNode` which now is in charge of renaming if there's a duplicate name (the new version should also duplicate all children, not just `children` parent prop)
* Also closes https://github.com/mui/mui-toolpad/issues/1126