### PR TITLE
Add guidelines for PR labels

### DIFF
--- a/.github/workflows/check-if-pr-has-label.yml
+++ b/.github/workflows/check-if-pr-has-label.yml
@@ -15,4 +15,5 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: ''
+          # See also https://github.com/mui/mui-toolpad/blob/master/MAINTAINERS.md#pull-request-labels
+          labels: 'core,docs'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,4 +74,4 @@ Please have a look at our general guidelines for sending pull requests [here](ht
 
 ## Release process
 
-See [RELEASE.md](./RELEASE.md)
+See [MAINTAINERS.md](./MAINTANERS.md#release-process)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,7 @@ _We choose these labels according to the way we divide work in the repository, w
 
 - _no label_: Default.
 - `regression`: For bug fixes of regressions, generally, these PRs are accompanied by a test.
+- `dependencies`: Automatically applied by dependabot on dependency updates.
 
 ## Release process
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,29 @@
-# Release process
+# Maintainers guide
+
+This document is intended for _maintainers_. Anyone with commit access to the Toolpad respository.
+
+## Pull request labels
+
+Each pull request must have a label applied. We apply labels in the following dimensions:
+
+### location
+
+- `docs`: For updates to the `./docs` folder.
+- `core`: For updates Toolpad application and its build environment.
+
+_We choose these labels according to the way we divide work in the repository, we will create additional labels as the team grows and the responsibilities are further divided._
+
+### source
+
+- _no label_: For pull rwquests by Toolpad maintainers.
+- `community`: For pull requests opened by members of the community.
+
+### kind
+
+- _no label_: Default.
+- `regression`: For bug fixes of regressions, generally, these PRs are accompanied by a test.
+
+## Release process
 
 1. Generate a new version using:
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,7 +15,7 @@ _We choose these labels according to the way we divide work in the repository, w
 
 ### source
 
-- _no label_: For pull rwquests by Toolpad maintainers.
+- _no label_: For pull requests by Toolpad maintainers.
 - `community`: For pull requests opened by members of the community.
 
 ### kind


### PR DESCRIPTION
Follow up of https://github.com/mui/mui-toolpad/pull/849

* Starting a `MAINTAINERS.md` as a maintainers guide. Move the release process docs in there. Add a section about PR labelling. [Formatted text](https://github.com/mui/mui-toolpad/blob/9b740719745ca27236639995edc123159de63760/MAINTAINERS.md#pull-request-labels)
* Update the PR label checker to mandate at least `core`/`docs` and add a link to the maintenance guide
