### PR TITLE
Codify the icons exception in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,5 +87,24 @@ module.exports = {
       files: ['packages/*/src/**/*{.ts,.tsx,.js}'],
       excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx'],
     },
+    {
+      files: ['packages/toolpad-core/**/*', 'packages/toolpad-components/**/*'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                // Running into issues with @mui/icons-material not being an ESM pakage, while the
+                // toolpad-core package is. This makes Next.js try to load @mui/icons-material/* as ESM
+                // Loading from the index export works as a workaround for now
+                group: ['@mui/icons-material/*'],
+                message: "Use `import { Icon } from '@mui/icons-material'` instead.",
+              },
+            ],
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 // Running into issues compiling @mui/icons-material/Error inside of a "type": "module" package
-// eslint-disable-next-line no-restricted-imports
 import { Error as ErrorIcon } from '@mui/icons-material';
 import { Tooltip } from '@mui/material';
 import { ErrorBoundary } from 'react-error-boundary';


### PR DESCRIPTION
To avoid maintainers from wasting too much time on discovering the workaround.