### PR TITLE
Fix node not found error

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -1043,7 +1043,7 @@ export default function RenderOverlay({ canvasHostRef }: RenderOverlayProps) {
           }
         }
 
-        const draggedNodeParent = appDom.getParent(dom, draggedNode);
+        const draggedNodeParent = selection ? appDom.getParent(dom, draggedNode) : null;
         if (
           draggedNode.layout?.columnSize &&
           draggedNodeParent &&


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/1221

Explanation: 
When moving or adding a new component in the canvas, there is logic that checks for the parent of the component node. If the component is a new component, there is no parent, therefore this checks throws an error.

This error was not throwing before because `getParent` was using `getMaybeNode`, but it's not anymore after recent changes.

I made it so that `.getParent` only gets called if we're moving a component already in the canvas, instead of adding a new component.
