### PR TITLE
Deploy latest Docker image in demo

### DIFF
--- a/docker/images/toolpad-demo/Dockerfile
+++ b/docker/images/toolpad-demo/Dockerfile
@@ -1,1 +1,1 @@
-FROM muicom/toolpad:a3a5ddf4243a4b7b8f07755d583bc8986b0cef9e
+FROM muicom/toolpad:latest


### PR DESCRIPTION
Updating demo, using `latest` should be a good option as we have a manual process? (merging to `demo` branch)
Merging now to try something quickly but feel free to leave any comments.
