### PR TITLE
Fix Elastic Search configuration

### DIFF
--- a/packages/toolpad-app/src/server/config.ts
+++ b/packages/toolpad-app/src/server/config.ts
@@ -19,7 +19,7 @@ export type ServerConfig = {
   basicAuthPassword?: string;
   serverLogsEnabled: boolean;
   recaptchaSecretKey?: string;
-  ecsHostUrl?: string;
+  ecsNodeUrl?: string;
   ecsApiKey?: string;
 } & BasicAuthConfig;
 
@@ -56,7 +56,7 @@ function readConfig(): ServerConfig & typeof sharedConfig {
     googleSheetsClientSecret: process.env.TOOLPAD_DATASOURCE_GOOGLESHEETS_CLIENT_SECRET,
     serverLogsEnabled: !!process.env.TOOLPAD_SERVER_LOGS_ENABLED,
     recaptchaSecretKey: process.env.TOOLPAD_RECAPTCHA_SECRET_KEY,
-    ecsHostUrl: process.env.TOOLPAD_ECS_HOST_URL,
+    ecsNodeUrl: process.env.TOOLPAD_ECS_NODE_URL,
     ecsApiKey: process.env.TOOLPAD_ECS_API_KEY,
     encryptionKeys,
   };

--- a/packages/toolpad-app/src/server/logs/logger.ts
+++ b/packages/toolpad-app/src/server/logs/logger.ts
@@ -10,12 +10,12 @@ import {
 } from './logSerializers';
 
 let transport;
-if (config.ecsHostUrl) {
+if (config.ecsNodeUrl) {
   transport = pino.transport({
     target: 'pino-elasticsearch',
     options: {
       index: 'toolpad-pino',
-      host: config.ecsHostUrl,
+      node: config.ecsNodeUrl,
       auth: {
         apiKey: config.ecsApiKey,
       },
@@ -35,7 +35,7 @@ const logger = pino(
       res: resSerializer,
       recaptchaRes: recaptchaResSerializer,
     },
-    ...(config.ecsHostUrl ? ecsFormat() : {}),
+    ...(config.ecsNodeUrl ? ecsFormat() : {}),
   },
   transport,
 );


### PR DESCRIPTION
`host` param was called `node` instead... 
There seem to be no type definitions in npm for `pino-elasticsearch`, unfortunately...
