### PR TITLE
Provide accessible locators

### DIFF
--- a/test/integration/appTemplates.spec.ts
+++ b/test/integration/appTemplates.spec.ts
@@ -30,13 +30,13 @@ test('can use images app template', async ({ page }) => {
 
   await page.locator('h3:has-text("Dog Images")').waitFor({ state: 'visible' });
 
-  const breedInputLocator = page.locator('[aria-haspopup="listbox"]').first();
+  const breedInputLocator = page.getByRole('button', { name: /Pick a dog breed/ });
   await breedInputLocator.click();
-  await page.locator('li:has-text("australian")').click();
+  await page.getByRole('option', { name: 'australian' }).click();
 
-  const subBreedInputLocator = page.locator('[aria-haspopup="listbox"]').nth(1);
+  const subBreedInputLocator = page.getByRole('button', { name: /Pick a sub-breed/ });
   await subBreedInputLocator.click();
-  await page.locator('li:has-text("shepherd")').click();
+  await page.getByRole('option', { name: 'shepherd' }).click();
 
   const imageLocator = page.locator('img');
   await expect(imageLocator).toHaveAttribute(


### PR DESCRIPTION
PR got merged before I had the chance to answer https://github.com/mui/mui-toolpad/pull/1257#discussion_r1011769767

Here's my proposal after playing with it a bit locally. This makes the locators less implementation dependant. And base them purely on accessible properties
