### PR TITLE
Undo redo fix proposal

### DIFF
--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -292,9 +292,8 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
 
   const layoutElementProps = React.useMemo(() => {
     if (appDom.isElement(node) && isPageRow(node)) {
-      const children = childNodeGroups.children || [];
       return {
-        layoutColumnSizes: children.map((child) => child.layout?.columnSize?.value),
+        layoutColumnSizes: childNodeGroups.children.map((child) => child.layout?.columnSize?.value),
       };
     }
     return {};

--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { NodeId, BindableAttrValue, BindableAttrValues } from '@mui/toolpad-core';
 import invariant from 'invariant';
+import { debounce } from 'lodash-es';
 import * as appDom from '../appDom';
 import { update } from '../utils/immutability';
 import client from '../api';
@@ -9,7 +10,6 @@ import useDebouncedHandler from '../utils/useDebouncedHandler';
 import { createProvidedContext } from '../utils/react';
 import { mapValues } from '../utils/collections';
 import insecureHash from '../utils/insecureHash';
-import useThrottled from '../utils/useThottled';
 import { NodeHashes } from '../types';
 
 export type DomAction =
@@ -414,11 +414,15 @@ export default function DomProvider({ appId, children }: DomContextProps) {
     redo: [],
   });
 
-  const scheduleHistoryUpdate = useThrottled((action: DomAction) => {
-    if (action) {
-      dispatch({ type: 'DOM_UPDATE_HISTORY' });
-    }
-  }, 500);
+  const scheduleHistoryUpdate = React.useMemo(
+    () =>
+      debounce((action: DomAction) => {
+        if (action) {
+          dispatch({ type: 'DOM_UPDATE_HISTORY' });
+        }
+      }, 500),
+    [],
+  );
 
   const dispatchWithHistory = (action: DomAction) => {
     dispatch(action);


### PR DESCRIPTION
@bytasv proposed fix for undo/redo in-between states / crashing issues in https://github.com/mui/mui-toolpad/pull/1225.
Looks like `useThrottled` does not work as intended in that PR (it's not throttling changes) which is why some in-between updates are being saved and causing crashes, and I found the hook implementation a bit confusing as it's connected to component rendering and such?

Why not do something like this instead?