### PR TITLE
Lazy load icons in runtime

### DIFF
--- a/packages/toolpad-app/src/runtime/iconsMaterialStub.tsx
+++ b/packages/toolpad-app/src/runtime/iconsMaterialStub.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+const cache = new Map();
+
+export default new Proxy(
+  {
+    __esModule: true,
+  },
+  {
+    get(target, prop: string) {
+      let LazyIcon = cache.get(prop);
+
+      if (!LazyIcon) {
+        LazyIcon = React.lazy(async () => {
+          const icons = await import('@mui/icons-material');
+          const MuiIcon = (icons as any)[prop];
+          if (!MuiIcon) {
+            throw new Error(`Can't resolve "@mui/icons-material/${prop}"`);
+          }
+          return { default: MuiIcon };
+        });
+        cache.set(prop, LazyIcon);
+      }
+
+      return LazyIcon;
+    },
+  },
+);

--- a/packages/toolpad-app/src/runtime/loadModule.tsx
+++ b/packages/toolpad-app/src/runtime/loadModule.tsx
@@ -3,6 +3,7 @@ import { codeFrameColumns } from '@babel/code-frame';
 import { findImports, isAbsoluteUrl } from '../utils/strings';
 import { errorFrom } from '../utils/errors';
 import muiMaterialExports from './muiExports';
+import muiIcons from './iconsMaterialStub';
 
 async function resolveValues(input: Map<string, Promise<unknown>>): Promise<Map<string, unknown>> {
   const resolved = await Promise.all(input.values());
@@ -19,8 +20,6 @@ async function createRequire(urlImports: string[]) {
       ['react-dom', import('react-dom')],
       ['@mui/toolpad-core', import(`@mui/toolpad-core`)],
 
-      ['@mui/icons-material', import('@mui/icons-material')],
-
       ...muiMaterialExports,
 
       ...urlImports.map((url) => [url, import(/* webpackIgnore: true */ url)] as const),
@@ -31,12 +30,15 @@ async function createRequire(urlImports: string[]) {
     let esModule = modules.get(moduleId);
 
     if (!esModule) {
+      if (moduleId === '@mui/icons-material') {
+        return muiIcons;
+      }
+
       // Custom solution for icons
       const iconMatch = /^@mui\/icons-material\/(.*)$/.exec(moduleId);
       if (iconMatch) {
         const iconName = iconMatch[1];
-        const iconsModule = modules.get('@mui/icons-material');
-        esModule = { default: (iconsModule as any)[iconName] };
+        esModule = { default: (muiIcons as any)[iconName] };
       }
     }
 


### PR DESCRIPTION
A custom solution to avoid loading the full icon package during runtime start.

This replaces the module with a proxy that generates lazy react components that load the full package asynchronously. The items still take long to load, but at least they don't block rendering the page.
