### PR TITLE
[docs] Link changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,9 @@ Although we love giving you the opportunity to put your stamp on MUI, we also ar
 
 ## Changelog
 
-<!-- TODO -->
+The [changelog](https://github.com/mui/mui-toolpad/releases) is regularly updated to reflect what's changed in each new release.
 
 ## Roadmap
-
-<!-- TODO -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The [changelog](https://github.com/mui/mui-toolpad/releases) is regularly update
 
 ## Roadmap
 
+<!-- TODO -->
+
 ## License
 
 This project is licensed under the terms of the [MIT license](/LICENSE).


### PR DESCRIPTION
I have copied https://github.com/mui/mui-x/#changelog.

Eventually, we could use something else for the changelog, like a blog category.