### PR TITLE
Simplify menu actions

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -108,7 +108,7 @@ export default function CreateCodeComponentDialog({
           navigate(`/app/${appId}/codeComponents/${newNode.id}`);
         }}
       >
-        <DialogTitle>Create a new MUI Toolpad Code Component</DialogTitle>
+        <DialogTitle>Create a new Code Component</DialogTitle>
         <DialogContent>
           <TextField
             sx={{ my: 1 }}

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateConnectionNodeDialog.tsx
@@ -84,7 +84,7 @@ export default function CreateConnectionDialog({
           navigate(`/app/${appId}/connections/${newNode.id}`);
         }}
       >
-        <DialogTitle>Create a new MUI Toolpad Connection</DialogTitle>
+        <DialogTitle>Create a new Connection</DialogTitle>
         <DialogContent>
           <TextField
             sx={{ my: 1 }}

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreatePageNodeDialog.tsx
@@ -75,7 +75,7 @@ export default function CreatePageDialog({
           navigate(`/app/${appId}/pages/${newNode.id}`);
         }}
       >
-        <DialogTitle>Create a new MUI Toolpad Page</DialogTitle>
+        <DialogTitle>Create a new Page</DialogTitle>
         <DialogContent>
           <TextField
             sx={{ my: 1 }}

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -33,7 +33,7 @@ const StyledTreeItem = styled(TreeItem)({
     visibility: 'hidden',
   },
   [`
-    & .${treeItemClasses.content}:hover .${classes.treeItemMenuButton}, 
+    & .${treeItemClasses.content}:hover .${classes.treeItemMenuButton},
     & .${classes.treeItemMenuOpen}
   `]: {
     visibility: 'visible',
@@ -75,9 +75,9 @@ function HierarchyTreeItem(props: StyledTreeItemProps) {
     onCreate,
     onDeleteNode,
     onDuplicateNode,
-    createLabelText = `Create ${labelText}`,
-    deleteLabelText = `Delete ${labelText}`,
-    duplicateLabelText = `Duplicate ${labelText}`,
+    createLabelText,
+    deleteLabelText = 'Delete',
+    duplicateLabelText = 'Duplicate',
     toolpadNodeId,
     ...other
   } = props;
@@ -282,7 +282,6 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
           aria-level={1}
           labelText="Connections"
           createLabelText="Create connection"
-          deleteLabelText="Delete connection"
           onCreate={handleCreateConnectionDialogOpen}
         >
           {connections.map((connectionNode) => (
@@ -302,7 +301,6 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
           aria-level={1}
           labelText="Components"
           createLabelText="Create component"
-          deleteLabelText="Delete component"
           onCreate={handleCreateCodeComponentDialogOpen}
         >
           {codeComponents.map((codeComponent) => (
@@ -322,7 +320,6 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
           aria-level={1}
           labelText="Pages"
           createLabelText="Create page"
-          deleteLabelText="Delete page"
           onCreate={handleCreatePageDialogOpen}
         >
           {pages.map((page) => (

--- a/packages/toolpad-app/src/toolpad/AppEditor/NodeMenu.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/NodeMenu.tsx
@@ -68,7 +68,6 @@ export default function NodeMenu({
         buttonProps,
         menuProps,
       })}
-
       <Menu
         {...menuProps}
         onClick={(event) => {
@@ -80,17 +79,15 @@ export default function NodeMenu({
           <ListItemIcon>
             <ContentCopyIcon />
           </ListItemIcon>
-          <ListItemText> {duplicateLabelText}</ListItemText>
+          <ListItemText>{duplicateLabelText}</ListItemText>
         </MenuItem>
-
         <MenuItem onClick={handleDeleteNodeDialogOpen}>
           <ListItemIcon>
             <DeleteIcon />
           </ListItemIcon>
-          <ListItemText> {deleteLabelText}</ListItemText>
+          <ListItemText>{deleteLabelText}</ListItemText>
         </MenuItem>
       </Menu>
-
       <ConfirmDialog
         open={!!deletedNode}
         severity="error"

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor/QueryEditorDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor/QueryEditorDialog.tsx
@@ -282,9 +282,7 @@ export default function QueryNodeEditorDialog<Q>({
               />
             </Stack>
           </DialogTitle>
-
           <Divider />
-
           <DialogContent
             sx={{
               // height will be clipped by max-height
@@ -310,7 +308,6 @@ export default function QueryNodeEditorDialog<Q>({
                 globalScope={pageState}
               />
             </Box>
-
             <Stack direction="row" alignItems="center" sx={{ pt: 2, px: 3, gap: 2 }}>
               <TextField select label="mode" value={mode} onChange={handleModeChange}>
                 <MenuItem value="query">
@@ -341,7 +338,6 @@ export default function QueryNodeEditorDialog<Q>({
               />
             </Stack>
           </DialogContent>
-
           <QueryeditorDialogActions
             onSave={handleSave}
             onClose={handleClose}

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor/index.tsx
@@ -194,8 +194,8 @@ export default function QueryEditor() {
                     </IconButton>
                   )}
                   nodeId={queryNode.id}
-                  deleteLabelText={`Delete ${queryNode.name}`}
-                  duplicateLabelText={`Duplicate ${queryNode.name}`}
+                  deleteLabelText="Delete"
+                  duplicateLabelText="Duplicate"
                   onDeleteNode={handleDeleteNode}
                   onDuplicateNode={handleDuplicateNode}
                 />

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeHud.tsx
@@ -183,13 +183,13 @@ export default function NodeHud({
           >
             {component?.displayName || '<unknown>'}
             <DragIndicatorIcon color="inherit" />
-            <IconButton aria-label="Duplicate element" color="inherit" onMouseUp={onDuplicate}>
-              <Tooltip title="Duplicate element" enterDelay={400}>
+            <IconButton aria-label="Duplicate" color="inherit" onMouseUp={onDuplicate}>
+              <Tooltip title="Duplicate" enterDelay={400}>
                 <ContentCopy color="inherit" />
               </Tooltip>
             </IconButton>
-            <IconButton aria-label="Remove element" color="inherit" onMouseUp={onDelete}>
-              <Tooltip title="Remove element" enterDelay={400}>
+            <IconButton aria-label="Remove" color="inherit" onMouseUp={onDelete}>
+              <Tooltip title="Remove" enterDelay={400}>
                 <DeleteIcon color="inherit" />
               </Tooltip>
             </IconButton>

--- a/packages/toolpad-app/src/toolpad/Home/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Home/index.tsx
@@ -161,7 +161,7 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
           sendAppCreatedEvent(name, appTemplateId);
         }}
       >
-        <DialogTitle>Create a new MUI Toolpad App</DialogTitle>
+        <DialogTitle>Create a new App</DialogTitle>
         <DialogContent>
           {config.isDemo ? (
             <Alert severity="warning" sx={{ mb: 2 }}>

--- a/test/integration/duplication/index.spec.ts
+++ b/test/integration/duplication/index.spec.ts
@@ -16,14 +16,14 @@ test('duplication', async ({ page, browserName }) => {
 
   {
     await editorModel.openHierarchyMenu('connections', 'connection');
-    const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate connection' });
+    const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate' });
     await Promise.all([duplicateMenuItem.click(), page.waitForNavigation()]);
 
     const input = page.getByLabel('base url');
     await expect(input).toHaveValue('https://example.com/');
 
     await editorModel.openHierarchyMenu('connections', 'connection1');
-    const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete connection1' });
+    const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete' });
     await deleteMenuItem.click();
     const deleteButton = editorModel.confirmationDialog.getByRole('button', { name: 'Delete' });
     await Promise.all([deleteButton.click(), page.waitForNavigation()]);
@@ -33,11 +33,11 @@ test('duplication', async ({ page, browserName }) => {
 
   {
     await editorModel.openHierarchyMenu('components', 'myComponent');
-    const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate myComponent' });
+    const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate' });
     await Promise.all([duplicateMenuItem.click(), page.waitForNavigation()]);
 
     await editorModel.openHierarchyMenu('components', 'myComponent1');
-    const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete myComponent1' });
+    const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete' });
     await deleteMenuItem.click();
     const deleteButton = editorModel.confirmationDialog.getByRole('button', { name: 'Delete' });
     await Promise.all([deleteButton.click(), page.waitForNavigation()]);
@@ -47,14 +47,14 @@ test('duplication', async ({ page, browserName }) => {
 
   {
     await editorModel.openHierarchyMenu('pages', 'page1');
-    const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate page1' });
+    const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate' });
     await Promise.all([duplicateMenuItem.click(), page.waitForNavigation()]);
 
     const button = editorModel.appCanvas.getByRole('button', { name: 'hello world' });
     await expect(button).toBeVisible();
 
     await editorModel.openHierarchyMenu('pages', 'page2');
-    const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete page2' });
+    const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete' });
     await deleteMenuItem.click();
     const deleteButton = editorModel.confirmationDialog.getByRole('button', { name: 'Delete' });
     await Promise.all([deleteButton.click(), page.waitForNavigation()]);

--- a/test/integration/editor/index.spec.ts
+++ b/test/integration/editor/index.spec.ts
@@ -99,7 +99,7 @@ test('can delete elements from page', async ({ page, browserName }) => {
 
   const canvasInputLocator = editorModel.appCanvas.locator('input');
   const canvasRemoveElementButtonLocator = editorModel.appCanvas.locator(
-    'button[aria-label="Remove element"]',
+    'button[aria-label="Remove"]',
   );
 
   await expect(canvasInputLocator).toHaveCount(2);

--- a/test/models/ToolpadEditor.ts
+++ b/test/models/ToolpadEditor.ts
@@ -13,7 +13,7 @@ class CreatePageDialog {
   constructor(page: Page) {
     this.page = page;
     this.dialog = page.locator('[role="dialog"]', {
-      hasText: 'Create a new MUI Toolpad Page',
+      hasText: 'Create a new Page',
     });
     this.nameInput = this.dialog.locator('label:has-text("name")');
     this.createButton = this.dialog.locator('button:has-text("Create")');
@@ -33,7 +33,7 @@ class CreateComponentDialog {
     this.page = page;
 
     this.dialog = page.locator('[role="dialog"]', {
-      hasText: 'Create a new MUI Toolpad Code Component',
+      hasText: 'Create a new Code Component',
     });
     this.nameInput = this.dialog.locator('label:has-text("name")');
     this.createButton = this.dialog.locator('button:has-text("Create")');

--- a/test/models/ToolpadHome.ts
+++ b/test/models/ToolpadHome.ts
@@ -36,7 +36,7 @@ export class ToolpadHome {
     this.createNewbtn = page.locator('button:has-text("create new")');
 
     this.newAppDialog = page.locator('[role="dialog"]', {
-      hasText: 'Create a App',
+      hasText: 'Create a new App',
     });
     this.newAppNameInput = this.newAppDialog.locator('label:has-text("name")');
     this.newAppTemplateSelect = this.newAppDialog.locator(

--- a/test/models/ToolpadHome.ts
+++ b/test/models/ToolpadHome.ts
@@ -36,7 +36,7 @@ export class ToolpadHome {
     this.createNewbtn = page.locator('button:has-text("create new")');
 
     this.newAppDialog = page.locator('[role="dialog"]', {
-      hasText: 'Create a new MUI Toolpad App',
+      hasText: 'Create a App',
     });
     this.newAppNameInput = this.newAppDialog.locator('label:has-text("name")');
     this.newAppTemplateSelect = this.newAppDialog.locator(


### PR DESCRIPTION
I have found the existing labels confusing:

1. The name of the page/connection/etc. feels confusing. It adds more text to read which make it harder for me to understand what the action is doing:

<img width="550" alt="Screenshot 2022-11-04 at 15 51 36" src="https://user-images.githubusercontent.com/3165635/200005100-4c15f1f1-9d2d-41e5-8412-7871c22aa1fe.png">

What felt better as a user:

<img width="567" alt="Screenshot 2022-11-04 at 15 54 31" src="https://user-images.githubusercontent.com/3165635/200005798-0e3e4792-492e-4c85-94f0-0d70ec7e5b1e.png">

So I have removed these names.

2. We already know that I'm on Toolpad, I think that we can remove "MUI Toolpad"

<img width="484" alt="Screenshot 2022-11-04 at 15 54 54" src="https://user-images.githubusercontent.com/3165635/200005878-b59b25fc-a779-4be0-972f-e2aee219b4f6.png">
