### PR TITLE
Allow working on latest used app from demo home page

### DIFF
--- a/packages/toolpad-app/src/storageKeys.ts
+++ b/packages/toolpad-app/src/storageKeys.ts
@@ -1,0 +1,2 @@
+export const TOOLPAD_LATEST_APP_KEY = 'toolpad-latest-app';
+export type LatestStoredAppValue = { appId: string; appName: string } | null;

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -22,6 +22,8 @@ import client from '../../api';
 import { useDom } from '../DomLoader';
 import JsonView from '../../components/JsonView';
 import useMenu from '../../utils/useMenu';
+import useLocalStorageState from '../../utils/useLocalStorageState';
+import { LatestStoredAppValue, TOOLPAD_LATEST_APP_KEY } from '../../storageKeys';
 
 const PagePanelRoot = styled('div')({
   display: 'flex',
@@ -81,6 +83,20 @@ export interface ComponentPanelProps {
 
 export default function PagePanel({ appId, className, sx }: ComponentPanelProps) {
   const { data: app, isLoading } = client.useQuery('getApp', [appId]);
+
+  const [, setLatestStoredApp] = useLocalStorageState<LatestStoredAppValue>(
+    TOOLPAD_LATEST_APP_KEY,
+    null,
+  );
+
+  React.useEffect(() => {
+    if (app) {
+      setLatestStoredApp({
+        appId,
+        appName: app.name,
+      });
+    }
+  }, [app, appId, setLatestStoredApp]);
 
   return (
     <PagePanelRoot className={className} sx={sx}>

--- a/packages/toolpad-app/src/toolpad/Home/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Home/index.tsx
@@ -63,6 +63,7 @@ import config from '../../config';
 import { AppTemplateId } from '../../types';
 import { errorFrom } from '../../utils/errors';
 import { sendAppCreatedEvent } from '../../utils/ga';
+import { LatestStoredAppValue, TOOLPAD_LATEST_APP_KEY } from '../../storageKeys';
 
 export const APP_TEMPLATE_OPTIONS: Map<
   AppTemplateId,
@@ -124,6 +125,11 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
     },
   });
 
+  const [latestStoredApp] = useLocalStorageState<LatestStoredAppValue>(
+    TOOLPAD_LATEST_APP_KEY,
+    null,
+  );
+
   const isFormValid = Boolean(name);
 
   return (
@@ -162,7 +168,7 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
         <DialogTitle>Create a new MUI Toolpad App</DialogTitle>
         <DialogContent>
           {config.isDemo ? (
-            <Alert severity="warning" sx={{ mb: 2 }}>
+            <Alert severity="warning" sx={{ mb: 1 }}>
               <AlertTitle>For demo purposes only!</AlertTitle>
               Your application will be ephemeral and may be deleted at any time.
             </Alert>
@@ -194,7 +200,9 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
               <MenuItem key={value} value={value}>
                 <span>
                   <Typography>{label}</Typography>
-                  <Typography variant="caption">{description || ''}</Typography>
+                  <Typography variant="caption" sx={{ fontWeight: 'normal' }}>
+                    {description || ''}
+                  </Typography>
                 </span>
               </MenuItem>
             ))}
@@ -211,28 +219,47 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
               onChange={handleDomChange}
             />
           ) : null}
+          {config.isDemo && latestStoredApp ? (
+            <Box mt={1} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <Typography variant="subtitle2" textAlign="center" sx={{ mb: -0.5 }}>
+                OR
+              </Typography>
+              <Button
+                variant="text"
+                size="medium"
+                component="a"
+                href={`/_toolpad/app/${latestStoredApp.appId}`}
+                sx={{ mt: 1 }}
+              >
+                Continue working on &ldquo;{latestStoredApp.appName}&rdquo;
+              </Button>
+            </Box>
+          ) : null}
           {config.recaptchaSiteKey ? (
-            <Typography variant="caption" color="text.secondary">
-              This site is protected by reCAPTCHA and the Google{' '}
-              <Link
-                href="https://policies.google.com/privacy"
-                underline="none"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Privacy Policy
-              </Link>{' '}
-              and{' '}
-              <Link
-                href="https://policies.google.com/terms"
-                underline="none"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Terms of Service
-              </Link>{' '}
-              apply.
-            </Typography>
+            <Box mt={2}>
+              <Divider sx={{ mb: 1 }} />
+              <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 'normal' }}>
+                This site is protected by reCAPTCHA and the Google{' '}
+                <Link
+                  href="https://policies.google.com/privacy"
+                  underline="none"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Privacy Policy
+                </Link>{' '}
+                and{' '}
+                <Link
+                  href="https://policies.google.com/terms"
+                  underline="none"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Terms of Service
+                </Link>{' '}
+                apply.
+              </Typography>
+            </Box>
           ) : null}
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
From https://github.com/mui/mui-toolpad/issues/1213
Allow demo users to go back to the latest app they were working on from the home page.
Used `localStorage` to save the user's latest app id and name.

https://user-images.githubusercontent.com/10789765/200396072-87874881-2a76-4a2b-bb5d-4e2816b0854d.mov


