### PR TITLE
Show self-host bar in demo

### DIFF
--- a/packages/toolpad-app/src/constants.ts
+++ b/packages/toolpad-app/src/constants.ts
@@ -7,6 +7,7 @@ export const RUNTIME_CONFIG_WINDOW_PROPERTY = '__TOOLPAD_RUNTIME_CONFIG__';
 export const TOOLPAD_TARGET_CE = 'CE';
 export const TOOLPAD_TARGET_CLOUD = 'CLOUD';
 export const TOOLPAD_TARGET_PRO = 'PRO';
+export const LANDING_PAGE_URL = 'https://mui.com/toolpad/';
 export const DOCUMENTATION_URL = 'https://mui.com/toolpad/getting-started/overview/';
 export const DOCUMENTATION_INSTALLATION_URL =
   'https://mui.com/toolpad/getting-started/installation/';

--- a/packages/toolpad-app/src/theme.ts
+++ b/packages/toolpad-app/src/theme.ts
@@ -77,7 +77,7 @@ export const blueDark = {
   800: '#001E3C',
   900: '#0A1929',
 };
-const grey = {
+export const grey = {
   50: '#F3F6F9',
   100: '#E7EBF0',
   200: '#E0E3E7',

--- a/packages/toolpad-app/src/toolpad/ToolpadShell/DemoBar.tsx
+++ b/packages/toolpad-app/src/toolpad/ToolpadShell/DemoBar.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Box, Button, Link, styled, Typography } from '@mui/material';
+import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
+import { blueDark, grey } from '../../theme';
+import { DOCUMENTATION_INSTALLATION_URL, LANDING_PAGE_URL } from '../../constants';
+
+const DemoBarContainer = styled(Box)({
+  alignItems: 'center',
+  backgroundColor: blueDark[50],
+  bottom: 0,
+  color: grey[700],
+  display: 'flex',
+  height: 60,
+  justifyContent: 'space-between',
+  left: 0,
+  paddingLeft: 20,
+  paddingRight: 20,
+  position: 'absolute',
+  width: '100vw',
+  zIndex: 1,
+});
+
+export default function ToolpadShell() {
+  return (
+    <DemoBarContainer>
+      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+        Demo version
+      </Typography>
+      <Typography variant="body2">
+        Stay updated with our progress at{' '}
+        <Link
+          href={LANDING_PAGE_URL}
+          target="_blank"
+          underline="always"
+          sx={{
+            color: grey[700],
+            fontWeight: 'normal',
+            textDecorationColor: grey[700],
+            '&:hover': { color: grey[700] },
+          }}
+        >
+          mui.com/toolpad
+        </Link>
+      </Typography>
+      <Link href={DOCUMENTATION_INSTALLATION_URL} target="_blank">
+        <Button size="medium" variant="contained" endIcon={<KeyboardArrowRightRounded />}>
+          Self-host
+        </Button>
+      </Link>
+    </DemoBarContainer>
+  );
+}

--- a/packages/toolpad-app/src/toolpad/ToolpadShell/DemoBar.tsx
+++ b/packages/toolpad-app/src/toolpad/ToolpadShell/DemoBar.tsx
@@ -20,7 +20,7 @@ const DemoBarContainer = styled(Box)({
   zIndex: 1,
 });
 
-export default function ToolpadShell() {
+export default function DemoBar() {
   return (
     <DemoBarContainer>
       <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>

--- a/packages/toolpad-app/src/toolpad/ToolpadShell/Header/index.tsx
+++ b/packages/toolpad-app/src/toolpad/ToolpadShell/Header/index.tsx
@@ -46,7 +46,7 @@ function Header({ actions, status }: HeaderProps) {
               aria-label="Home"
               href="/"
               underline="none"
-              sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 2 }}
+              sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 1 }}
             >
               <Image
                 src={theme.palette.mode === 'dark' ? productIconDark : productIconLight}
@@ -67,9 +67,7 @@ function Header({ actions, status }: HeaderProps) {
               </Box>
             </Link>
           </Tooltip>
-          {config.isDemo ? (
-            <Chip sx={{ ml: 2 }} label="Demo Version" color="primary" size="small" />
-          ) : null}
+          {config.isDemo ? <Chip sx={{ ml: 1 }} label="Alpha" size="small" color="grey" /> : null}
         </Box>
         <Box
           sx={{

--- a/packages/toolpad-app/src/toolpad/ToolpadShell/index.tsx
+++ b/packages/toolpad-app/src/toolpad/ToolpadShell/index.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 import { styled } from '@mui/material';
 import Header from './Header';
 
+import DemoBar from './DemoBar';
+
+import config from '../../config';
+
 export interface ToolpadShellProps {
   actions?: React.ReactNode;
   status?: React.ReactNode;
@@ -27,6 +31,7 @@ export default function ToolpadShell({ children, ...props }: ToolpadShellProps) 
     <ToolpadShellRoot>
       <Header {...props} />
       <ViewPort>{children}</ViewPort>
+      {config.isDemo ? <DemoBar /> : null}
     </ToolpadShellRoot>
   );
 }


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/1254
Show self-host bar at the bottom + "Alpha" chip in header next to logo according to designs

<img width="1792" alt="Screenshot 2022-11-08 at 16 35 02" src="https://user-images.githubusercontent.com/10789765/200623001-b4f2d9c3-a93e-4da2-9eb2-089bb21bd718.png">
<img width="1792" alt="Screenshot 2022-11-08 at 16 35 19" src="https://user-images.githubusercontent.com/10789765/200623018-6238646b-7cb6-4825-b0fa-73b0ac30e5f8.png">
