### PR TITLE
Remove pullRequestPreviewsEnabled from render.yml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,6 @@ services:
     startCommand: yarn start
     healthCheckPath: /health-check
     plan: starter plus
-    pullRequestPreviewsEnabled: true
     envVars:
       - key: NODE_VERSION
         value: '18.10.0'
@@ -36,7 +35,6 @@ services:
     dockerContext: ./docker/images/toolpad-demo/
     healthCheckPath: /health-check
     plan: starter plus
-    pullRequestPreviewsEnabled: false
     envVars:
       - key: NODE_VERSION
         value: '18.10.0'


### PR DESCRIPTION
I believe it could be the reason we see a sporadic mixup with the production database showing up in a preview environment sometimes. We're already using preview environments in this render.yml.

Looks like we used `pullRequestPreviewsEnabled` when still on a free plan, and moved to `previewsEnabled` when we started paying, but forgot to remove the `pullRequestPreviewsEnabled`.