### PR TITLE
Move component compilation serverside

### DIFF
--- a/packages/toolpad-app/pages/app/[appId]/[version]/[[...path]].tsx
+++ b/packages/toolpad-app/pages/app/[appId]/[version]/[[...path]].tsx
@@ -4,7 +4,7 @@ import { asArray } from '../../../../src/utils/collections';
 import ToolpadApp, { ToolpadAppProps } from '../../../../src/runtime/ToolpadApp';
 
 export const getServerSideProps: GetServerSideProps<ToolpadAppProps> = async (context) => {
-  const { loadRenderTree, parseVersion } = await import('../../../../src/server/data');
+  const { loadRuntimeState, parseVersion } = await import('../../../../src/server/data');
 
   const [appId] = asArray(context.query.appId);
   const version = parseVersion(context.query.version);
@@ -14,7 +14,7 @@ export const getServerSideProps: GetServerSideProps<ToolpadAppProps> = async (co
     };
   }
 
-  const dom = await loadRenderTree(appId, version);
+  const { dom } = await loadRuntimeState(appId, version);
 
   return {
     props: {

--- a/packages/toolpad-app/pages/app/[appId]/[version]/[[...path]].tsx
+++ b/packages/toolpad-app/pages/app/[appId]/[version]/[[...path]].tsx
@@ -14,12 +14,11 @@ export const getServerSideProps: GetServerSideProps<ToolpadAppProps> = async (co
     };
   }
 
-  const { dom } = await loadRuntimeState(appId, version);
+  const state = await loadRuntimeState(appId, version);
 
   return {
     props: {
-      appId,
-      dom,
+      state,
       version,
       basename: `/app/${appId}/${version}`,
     },

--- a/packages/toolpad-app/pages/deploy/[appId]/[[...path]].tsx
+++ b/packages/toolpad-app/pages/deploy/[appId]/[[...path]].tsx
@@ -45,12 +45,11 @@ export const getServerSideProps: GetServerSideProps<ToolpadAppProps> = async (co
 
   const { version } = activeDeployment;
 
-  const { dom } = await loadRuntimeState(appId, version);
+  const state = await loadRuntimeState(appId, version);
 
   return {
     props: {
-      appId,
-      dom,
+      state,
       version,
       basename: `/deploy/${appId}`,
     },

--- a/packages/toolpad-app/pages/deploy/[appId]/[[...path]].tsx
+++ b/packages/toolpad-app/pages/deploy/[appId]/[[...path]].tsx
@@ -5,7 +5,7 @@ import ToolpadApp, { ToolpadAppProps } from '../../../src/runtime/ToolpadApp';
 
 export const getServerSideProps: GetServerSideProps<ToolpadAppProps> = async (context) => {
   const [
-    { loadRenderTree, findActiveDeployment, getApp },
+    { loadRuntimeState, findActiveDeployment, getApp },
     { checkBasicAuth, basicAuthUnauthorized },
   ] = await Promise.all([
     import('../../../src/server/data'),
@@ -45,7 +45,7 @@ export const getServerSideProps: GetServerSideProps<ToolpadAppProps> = async (co
 
   const { version } = activeDeployment;
 
-  const dom = await loadRenderTree(appId, version);
+  const { dom } = await loadRuntimeState(appId, version);
 
   return {
     props: {

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -4,15 +4,12 @@ import invariant from 'invariant';
 import { throttle } from 'lodash-es';
 import { RuntimeEvent } from '@mui/toolpad-core';
 import ToolpadApp from '../runtime';
-import * as appDom from '../appDom';
-import { NodeHashes, PageViewState } from '../types';
+import { NodeHashes, PageViewState, RuntimeData } from '../types';
 import getPageViewState from './getPageViewState';
 import { rectContainsPoint } from '../utils/geometry';
 import { CanvasHooks, CanvasHooksContext } from '../runtime/CanvasHooksContext';
 
-export interface AppCanvasState {
-  appId: string;
-  dom: appDom.RenderTree;
+export interface AppCanvasState extends RuntimeData {
   savedNodes: NodeHashes;
 }
 

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -4,12 +4,12 @@ import invariant from 'invariant';
 import { throttle } from 'lodash-es';
 import { RuntimeEvent } from '@mui/toolpad-core';
 import ToolpadApp from '../runtime';
-import { NodeHashes, PageViewState, RuntimeData } from '../types';
+import { NodeHashes, PageViewState, RuntimeState } from '../types';
 import getPageViewState from './getPageViewState';
 import { rectContainsPoint } from '../utils/geometry';
 import { CanvasHooks, CanvasHooksContext } from '../runtime/CanvasHooksContext';
 
-export interface AppCanvasState extends RuntimeData {
+export interface AppCanvasState extends RuntimeState {
   savedNodes: NodeHashes;
 }
 
@@ -133,10 +133,9 @@ export default function AppCanvas({ basename }: AppCanvasProps) {
       <ToolpadApp
         rootRef={onAppRoot}
         hidePreviewBanner
-        dom={state.dom}
         version="preview"
-        appId={state.appId}
         basename={`${basename}/${state.appId}`}
+        state={state}
       />
     </CanvasHooksContext.Provider>
   ) : (

--- a/packages/toolpad-app/src/createRuntimeData.tsx
+++ b/packages/toolpad-app/src/createRuntimeData.tsx
@@ -1,12 +1,12 @@
 import * as appDom from './appDom';
-import { RuntimeData } from './types';
+import { RuntimeState } from './types';
 
 export interface CreateRuntimeDataParams {
   appId: string;
   dom: appDom.AppDom;
 }
 
-export default function createRuntimeData({ appId, dom }: CreateRuntimeDataParams): RuntimeData {
+export default function createRuntimeData({ appId, dom }: CreateRuntimeDataParams): RuntimeState {
   return {
     appId,
     dom: appDom.createRenderTree(dom),

--- a/packages/toolpad-app/src/createRuntimeData.tsx
+++ b/packages/toolpad-app/src/createRuntimeData.tsx
@@ -49,12 +49,12 @@ function compileModules(dom: appDom.AppDom): Record<string, CompiledModule> {
   return result;
 }
 
-export interface CreateRuntimeDataParams {
+export interface CreateRuntimeStateParams {
   appId: string;
   dom: appDom.AppDom;
 }
 
-export default function createRuntimeData({ appId, dom }: CreateRuntimeDataParams): RuntimeState {
+export default function createRuntimeState({ appId, dom }: CreateRuntimeStateParams): RuntimeState {
   return {
     appId,
     dom: appDom.createRenderTree(dom),

--- a/packages/toolpad-app/src/createRuntimeData.tsx
+++ b/packages/toolpad-app/src/createRuntimeData.tsx
@@ -1,0 +1,14 @@
+import * as appDom from './appDom';
+import { RuntimeData } from './types';
+
+export interface CreateRuntimeDataParams {
+  appId: string;
+  dom: appDom.AppDom;
+}
+
+export default function createRuntimeData({ appId, dom }: CreateRuntimeDataParams): RuntimeData {
+  return {
+    appId,
+    dom: appDom.createRenderTree(dom),
+  };
+}

--- a/packages/toolpad-app/src/createRuntimeData.tsx
+++ b/packages/toolpad-app/src/createRuntimeData.tsx
@@ -1,5 +1,53 @@
+import { codeFrameColumns } from '@babel/code-frame';
+import { transform, TransformResult } from 'sucrase';
 import * as appDom from './appDom';
-import { RuntimeState } from './types';
+import { CompiledModule, RuntimeState } from './types';
+import { errorFrom } from './utils/errors';
+import { findImports, isAbsoluteUrl } from './utils/strings';
+
+export function compileModule(src: string, filename: string): CompiledModule {
+  const urlImports = findImports(src).filter((spec) => isAbsoluteUrl(spec));
+
+  let compiled: TransformResult;
+
+  try {
+    compiled = transform(src, {
+      transforms: ['jsx', 'typescript', 'imports'],
+      filePath: filename,
+      jsxRuntime: 'classic',
+    });
+  } catch (rawError) {
+    const error = errorFrom(rawError);
+    if ((error as any).loc) {
+      error.message = [error.message, codeFrameColumns(src, { start: (error as any).loc })].join(
+        '\n\n',
+      );
+    }
+    return { error };
+  }
+
+  return {
+    ...compiled,
+    urlImports,
+  };
+}
+
+function compileModules(dom: appDom.AppDom): Record<string, CompiledModule> {
+  const result: Record<string, CompiledModule> = {};
+  const root = appDom.getApp(dom);
+  const { codeComponents = [], pages = [] } = appDom.getChildNodes(dom, root);
+  for (const node of codeComponents) {
+    const src = node.attributes.code.value;
+    const name = `codeComponents/${node.id}`;
+    result[name] = compileModule(src, name);
+  }
+  for (const node of pages) {
+    const src = node.attributes.module?.value ?? `export {};`;
+    const name = `pages/${node.id}`;
+    result[name] = compileModule(src, name);
+  }
+  return result;
+}
 
 export interface CreateRuntimeDataParams {
   appId: string;
@@ -10,5 +58,6 @@ export default function createRuntimeData({ appId, dom }: CreateRuntimeDataParam
   return {
     appId,
     dom: appDom.createRenderTree(dom),
+    modules: compileModules(dom),
   };
 }

--- a/packages/toolpad-app/src/createRuntimeState.tsx
+++ b/packages/toolpad-app/src/createRuntimeState.tsx
@@ -42,9 +42,11 @@ function compileModules(dom: appDom.AppDom): Record<string, CompiledModule> {
     result[name] = compileModule(src, name);
   }
   for (const node of pages) {
-    const src = node.attributes.module?.value ?? `export {};`;
-    const name = `pages/${node.id}`;
-    result[name] = compileModule(src, name);
+    const src = node.attributes.module?.value;
+    if (src) {
+      const name = `pages/${node.id}`;
+      result[name] = compileModule(src, name);
+    }
   }
   return result;
 }

--- a/packages/toolpad-app/src/runtime/AppModulesProvider.tsx
+++ b/packages/toolpad-app/src/runtime/AppModulesProvider.tsx
@@ -29,10 +29,10 @@ export function AppModulesProvider({
   const pending: Promise<void>[] = [];
 
   for (const [id, mod] of Object.entries(compiledModules)) {
-    const cacheId = `// ${id}\n${mod.code}`;
-    const fromCache = cache.get(cacheId);
+    if (!mod.error) {
+      const cacheId = `// ${id}\n${mod.code}`;
+      const fromCache = cache.get(cacheId);
 
-    if (mod) {
       if (!fromCache) {
         const createPromise = loadModule(mod).then(
           (module: unknown) => {

--- a/packages/toolpad-app/src/runtime/ToolpadApp.spec.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.spec.tsx
@@ -5,6 +5,7 @@ import { LiveBindings } from '@mui/toolpad-core';
 import { setEventHandler } from '@mui/toolpad-core/runtime';
 import ToolpadApp from './ToolpadApp';
 import * as appDom from '../appDom';
+import createRuntimeState from '../createRuntimeData';
 
 // More sensible default for these tests
 const waitFor: typeof waitForOrig = (waiter, options) =>
@@ -28,7 +29,9 @@ function renderPage(initPage: (dom: appDom.AppDom, page: appDom.PageNode) => app
 
   window.history.replaceState({}, 'Test page', `/toolpad/pages/${page.id}`);
 
-  return render(<ToolpadApp appId={appId} version={version} basename="toolpad" dom={dom} />);
+  const state = createRuntimeState({ appId, dom });
+
+  return render(<ToolpadApp state={state} version={version} basename="toolpad" />);
 }
 
 afterEach(() => {

--- a/packages/toolpad-app/src/runtime/ToolpadApp.spec.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.spec.tsx
@@ -9,7 +9,7 @@ import createRuntimeState from '../createRuntimeData';
 
 // More sensible default for these tests
 const waitFor: typeof waitForOrig = (waiter, options) =>
-  waitForOrig(waiter, { timeout: 4000, ...options });
+  waitForOrig(waiter, { timeout: 10000, ...options });
 
 function renderPage(initPage: (dom: appDom.AppDom, page: appDom.PageNode) => appDom.AppDom) {
   const appId = '12345';

--- a/packages/toolpad-app/src/runtime/ToolpadApp.spec.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.spec.tsx
@@ -5,7 +5,7 @@ import { LiveBindings } from '@mui/toolpad-core';
 import { setEventHandler } from '@mui/toolpad-core/runtime';
 import ToolpadApp from './ToolpadApp';
 import * as appDom from '../appDom';
-import createRuntimeState from '../createRuntimeData';
+import createRuntimeState from '../createRuntimeState';
 
 // More sensible default for these tests
 const waitFor: typeof waitForOrig = (waiter, options) =>

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -952,7 +952,7 @@ export default function ToolpadApp({
             <ErrorBoundary FallbackComponent={AppError}>
               <ResetNodeErrorsKeyProvider value={resetNodeErrorsKey}>
                 <React.Suspense fallback={<AppLoading />}>
-                  <AppModulesProvider dom={dom}>
+                  <AppModulesProvider modules={state.modules}>
                     <ComponentsContext dom={dom}>
                       <AppContextProvider value={appContext}>
                         <QueryClientProvider client={queryClient}>

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -40,7 +40,7 @@ import {
 import * as _ from 'lodash-es';
 import ErrorIcon from '@mui/icons-material/Error';
 import * as appDom from '../appDom';
-import { VersionOrPreview } from '../types';
+import { RuntimeState, VersionOrPreview } from '../types';
 import { createProvidedContext } from '../utils/react';
 import {
   getElementNodeComponentId,
@@ -916,19 +916,18 @@ export interface ToolpadAppProps {
   rootRef?: React.Ref<HTMLDivElement>;
   hidePreviewBanner?: boolean;
   basename: string;
-  appId: string;
   version: VersionOrPreview;
-  dom: appDom.AppDom;
+  state: RuntimeState;
 }
 
 export default function ToolpadApp({
   rootRef,
   basename,
-  appId,
   version,
-  dom,
   hidePreviewBanner,
+  state,
 }: ToolpadAppProps) {
+  const { appId, dom } = state;
   const appContext = React.useMemo(() => ({ appId, version }), [appId, version]);
 
   const [resetNodeErrorsKey, setResetNodeErrorsKey] = React.useState(0);

--- a/packages/toolpad-app/src/runtime/loadCodeComponent.tsx
+++ b/packages/toolpad-app/src/runtime/loadCodeComponent.tsx
@@ -1,6 +1,6 @@
 import { createComponent, ToolpadComponent, TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import * as ReactIs from 'react-is';
-import { compileModule } from '../createRuntimeData';
+import { compileModule } from '../createRuntimeState';
 import loadModule from './loadModule';
 
 export function ensureToolpadComponent<P>(Component: unknown): ToolpadComponent<P> {

--- a/packages/toolpad-app/src/runtime/loadCodeComponent.tsx
+++ b/packages/toolpad-app/src/runtime/loadCodeComponent.tsx
@@ -1,5 +1,6 @@
 import { createComponent, ToolpadComponent, TOOLPAD_COMPONENT } from '@mui/toolpad-core';
 import * as ReactIs from 'react-is';
+import { compileModule } from '../createRuntimeData';
 import loadModule from './loadModule';
 
 export function ensureToolpadComponent<P>(Component: unknown): ToolpadComponent<P> {
@@ -20,7 +21,8 @@ export default async function loadCodeComponent(
   src: string,
   filename: string,
 ): Promise<ToolpadComponent> {
-  const { default: Component } = await loadModule(src, filename);
+  const compiledModule = compileModule(src, filename);
+  const { default: Component } = await loadModule(compiledModule);
 
   if (!ReactIs.isValidElementType(Component) || typeof Component === 'string') {
     throw new Error(`No React Component exported.`);

--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -13,7 +13,7 @@ import { getAppTemplateDom } from './appTemplateDoms/doms';
 import { validateRecaptchaToken } from './validateRecaptchaToken';
 import config from './config';
 import { migrateUp } from '../appDom/migrations';
-import createRuntimeState from '../createRuntimeData';
+import createRuntimeState from '../createRuntimeState';
 
 const SELECT_RELEASE_META = excludeFields(prisma.Prisma.ReleaseScalarFieldEnum, ['snapshot']);
 const SELECT_APP_META = excludeFields(prisma.Prisma.AppScalarFieldEnum, ['dom']);

--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -1,7 +1,12 @@
 import { NodeId, BindableAttrValue, ExecFetchResult } from '@mui/toolpad-core';
 import * as _ from 'lodash-es';
 import * as prisma from '../../prisma/generated/client';
-import { ServerDataSource, VersionOrPreview, AppTemplateId } from '../types';
+import {
+  ServerDataSource,
+  VersionOrPreview,
+  AppTemplateId,
+  RuntimeData as RuntimeState,
+} from '../types';
 import serverDataSources from '../toolpadDataSources/server';
 import * as appDom from '../appDom';
 import { omit } from '../utils/immutability';
@@ -13,6 +18,7 @@ import { getAppTemplateDom } from './appTemplateDoms/doms';
 import { validateRecaptchaToken } from './validateRecaptchaToken';
 import config from './config';
 import { migrateUp } from '../appDom/migrations';
+import createRuntimeState from '../createRuntimeData';
 
 const SELECT_RELEASE_META = excludeFields(prisma.Prisma.ReleaseScalarFieldEnum, ['snapshot']);
 const SELECT_APP_META = excludeFields(prisma.Prisma.AppScalarFieldEnum, ['dom']);
@@ -525,8 +531,11 @@ export async function loadDom(appId: string, version: VersionOrPreview = 'previe
 /**
  * Version of loadDom that returns a subset of the dom that doesn't contain sensitive information
  */
-export async function loadRenderTree(appId: string, version: VersionOrPreview = 'preview') {
-  return appDom.createRenderTree(await loadDom(appId, version));
+export async function loadRuntimeState(
+  appId: string,
+  version: VersionOrPreview = 'preview',
+): Promise<RuntimeState> {
+  return createRuntimeState({ appId, dom: await loadDom(appId, version) });
 }
 
 export async function duplicateApp(id: string, name: string): Promise<AppMeta> {

--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -1,12 +1,7 @@
 import { NodeId, BindableAttrValue, ExecFetchResult } from '@mui/toolpad-core';
 import * as _ from 'lodash-es';
 import * as prisma from '../../prisma/generated/client';
-import {
-  ServerDataSource,
-  VersionOrPreview,
-  AppTemplateId,
-  RuntimeData as RuntimeState,
-} from '../types';
+import { ServerDataSource, VersionOrPreview, AppTemplateId, RuntimeState } from '../types';
 import serverDataSources from '../toolpadDataSources/server';
 import * as appDom from '../appDom';
 import { omit } from '../utils/immutability';

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -14,7 +14,7 @@ import { LogEntry } from '../../../components/Console';
 import { Maybe } from '../../../utils/types';
 import { useDomApi } from '../../DomLoader';
 import { hasFieldFocus } from '../../../utils/fields';
-import createRuntimeState from '../../../createRuntimeData';
+import createRuntimeState from '../../../createRuntimeState';
 
 type IframeContentWindow = Window & typeof globalThis;
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -14,6 +14,7 @@ import { LogEntry } from '../../../components/Console';
 import { Maybe } from '../../../utils/types';
 import { useDomApi } from '../../DomLoader';
 import { hasFieldFocus } from '../../../utils/fields';
+import createRuntimeData from '../../../createRuntimeData';
 
 type IframeContentWindow = Window & typeof globalThis;
 
@@ -86,9 +87,9 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
     const [bridge, setBridge] = React.useState<ToolpadBridge | null>(null);
 
     const updateOnBridge = React.useCallback(
-      (bridgeInstance: ToolpadBridge) => {
-        const renderDom = appDom.createRenderTree(dom);
-        bridgeInstance.update({ appId, dom: renderDom, savedNodes });
+      async (bridgeInstance: ToolpadBridge) => {
+        const data = createRuntimeData({ appId, dom });
+        bridgeInstance.update({ ...data, savedNodes });
       },
       [appId, dom, savedNodes],
     );

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -14,7 +14,7 @@ import { LogEntry } from '../../../components/Console';
 import { Maybe } from '../../../utils/types';
 import { useDomApi } from '../../DomLoader';
 import { hasFieldFocus } from '../../../utils/fields';
-import createRuntimeData from '../../../createRuntimeData';
+import createRuntimeState from '../../../createRuntimeData';
 
 type IframeContentWindow = Window & typeof globalThis;
 
@@ -88,7 +88,7 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
 
     const updateOnBridge = React.useCallback(
       async (bridgeInstance: ToolpadBridge) => {
-        const data = createRuntimeData({ appId, dom });
+        const data = createRuntimeState({ appId, dom });
         bridgeInstance.update({ ...data, savedNodes });
       },
       [appId, dom, savedNodes],

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -162,6 +162,18 @@ export type AppTemplateId = 'blank' | 'stats' | 'images';
 
 export type NodeHashes = Record<NodeId, number | undefined>;
 
+export type CompiledModule =
+  | {
+      code: string;
+      urlImports: string[];
+      error?: undefined;
+    }
+  | {
+      code?: undefined;
+      urlImports?: undefined;
+      error: Error;
+    };
+
 /**
  * Defines all the data needed to render the runtime.
  * While the dom is optimized for storage and editing. It isn't the ideal format used to render the application
@@ -175,4 +187,5 @@ export interface RuntimeState {
   // We start out with just the rendertree. The ultimate goal will be to move things out of this tree
   dom: appDom.RenderTree;
   appId: string;
+  modules: Record<string, CompiledModule>;
 }

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -169,8 +169,6 @@ export type CompiledModule =
       error?: undefined;
     }
   | {
-      code?: undefined;
-      urlImports?: undefined;
       error: Error;
     };
 

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -171,7 +171,7 @@ export type NodeHashes = Record<NodeId, number | undefined>;
  * - datastructures optimized for rendering with less processing required
  * - ...
  */
-export interface RuntimeData {
+export interface RuntimeState {
   // We start out with just the rendertree. The ultimate goal will be to move things out of this tree
   dom: appDom.RenderTree;
   appId: string;

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -10,7 +10,6 @@ import {
 } from '@mui/toolpad-core';
 import { PaletteMode } from '@mui/material';
 import type * as appDom from './appDom';
-
 import type { Maybe, WithControlledProp } from './utils/types';
 import type { Rectangle } from './utils/geometry';
 
@@ -162,3 +161,18 @@ export type VersionOrPreview = 'preview' | number;
 export type AppTemplateId = 'blank' | 'stats' | 'images';
 
 export type NodeHashes = Record<NodeId, number | undefined>;
+
+/**
+ * Defines all the data needed to render the runtime.
+ * While the dom is optimized for storage and editing. It isn't the ideal format used to render the application
+ * `RuntimeData` will hold all data to render a toolpad app and will contain things like:
+ * - precompile assets, like code component modules
+ * - precompiled expressions
+ * - datastructures optimized for rendering with less processing required
+ * - ...
+ */
+export interface RuntimeData {
+  // We start out with just the rendertree. The ultimate goal will be to move things out of this tree
+  dom: appDom.RenderTree;
+  appId: string;
+}


### PR DESCRIPTION
Avoid compiling code components and page module client side.
* This avoids pulling in `sucrase` and running code transformations in production
* Prepares for removing code transformation client side in https://github.com/mui/mui-toolpad/pull/1325