### PR TITLE
[core] Group renovate GitHub Action dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,10 @@
     {
       "matchDepTypes": ["action"],
       "pinDigests": true
+    },
+    {
+      "groupName": ["github-actions"],
+      "matchManagers": ["github-actions"]
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],

--- a/renovate.json
+++ b/renovate.json
@@ -79,7 +79,7 @@
       "pinDigests": true
     },
     {
-      "groupName": "GitHub Action",
+      "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -79,7 +79,7 @@
       "pinDigests": true
     },
     {
-      "groupName": ["github-actions"],
+      "groupName": "GitHub Action",
       "matchManagers": ["github-actions"]
     }
   ],


### PR DESCRIPTION
Having to merge #1339, #1335, #1336 as different PRs feels overkill.

The solution is based on https://github.com/renovatebot/renovate/discussions/14578.