### PR TITLE
Automatic app names in demo

### DIFF
--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -218,26 +218,15 @@ export async function createApp(name: string, opts: CreateAppOptions = {}): Prom
     }
   }
 
-  let appName = name.trim();
+  const cleanAppName = name.trim();
 
-  if (config.isDemo) {
-    appName = appName.replace(/\(#[0-9]+\)/g, '').trim();
-
-    const sameNameAppCount = await prismaClient.app.count({
-      where: { OR: [{ name: appName }, { name: { startsWith: `${appName} (#`, endsWith: ')' } }] },
-    });
-    if (sameNameAppCount > 0) {
-      appName = `${appName} (#${sameNameAppCount + 1})`;
-    }
-  }
-
-  if (await prismaClient.app.findUnique({ where: { name: appName } })) {
+  if (await prismaClient.app.findUnique({ where: { name: cleanAppName } })) {
     throw new Error(`An app named "${name}" already exists.`);
   }
 
   return prismaClient.$transaction(async () => {
     const app = await prismaClient.app.create({
-      data: { name: appName },
+      data: { name: cleanAppName },
     });
 
     let dom: appDom.AppDom | null = null;

--- a/packages/toolpad-app/src/toolpad/Home/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Home/index.tsx
@@ -160,9 +160,11 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
             });
           }
 
+          const appName = config.isDemo ? `demo_app_${Date.now()}` : name;
           const appDom = dom.trim() ? JSON.parse(dom) : null;
+
           const app = await createAppMutation.mutateAsync([
-            config.isDemo ? `demo_app_${Date.now()}` : name,
+            appName,
             {
               from: {
                 ...(appDom

--- a/packages/toolpad-app/src/toolpad/Home/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Home/index.tsx
@@ -64,6 +64,7 @@ import { AppTemplateId } from '../../types';
 import { errorFrom } from '../../utils/errors';
 import { sendAppCreatedEvent } from '../../utils/ga';
 import { LatestStoredAppValue, TOOLPAD_LATEST_APP_KEY } from '../../storageKeys';
+import { uuidv4 } from '../../utils/uuid';
 
 export const APP_TEMPLATE_OPTIONS: Map<
   AppTemplateId,
@@ -138,7 +139,7 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
     null,
   );
 
-  const isFormValid = Boolean(name);
+  const isFormValid = config.isDemo || Boolean(name);
 
   const isSubmitting =
     createAppMutation.isLoading || isNavigatingToNewApp || isNavigatingToExistingApp;
@@ -162,7 +163,7 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
 
           const appDom = dom.trim() ? JSON.parse(dom) : null;
           const app = await createAppMutation.mutateAsync([
-            name,
+            config.isDemo ? `demo_app_${Date.now()}` : name,
             {
               from: {
                 ...(appDom
@@ -189,21 +190,23 @@ function CreateAppDialog({ onClose, ...props }: CreateAppDialogProps) {
               Your application will be ephemeral and may be deleted at any time.
             </Alert>
           ) : null}
-          <TextField
-            sx={{ my: 1 }}
-            required
-            autoFocus
-            fullWidth
-            label="Name"
-            value={name}
-            error={createAppMutation.isError}
-            helperText={(createAppMutation.error as Error)?.message || ''}
-            onChange={(event) => {
-              createAppMutation.reset();
-              setName(event.target.value);
-            }}
-            disabled={isSubmitting}
-          />
+          {!config.isDemo ? (
+            <TextField
+              sx={{ my: 1 }}
+              required
+              autoFocus
+              fullWidth
+              label="Name"
+              value={name}
+              error={createAppMutation.isError}
+              helperText={(createAppMutation.error as Error)?.message || ''}
+              onChange={(event) => {
+                createAppMutation.reset();
+                setName(event.target.value);
+              }}
+              disabled={isSubmitting}
+            />
+          ) : null}
 
           <TextField
             sx={{ my: 1 }}

--- a/packages/toolpad-app/src/toolpad/Home/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Home/index.tsx
@@ -64,7 +64,6 @@ import { AppTemplateId } from '../../types';
 import { errorFrom } from '../../utils/errors';
 import { sendAppCreatedEvent } from '../../utils/ga';
 import { LatestStoredAppValue, TOOLPAD_LATEST_APP_KEY } from '../../storageKeys';
-import { uuidv4 } from '../../utils/uuid';
 
 export const APP_TEMPLATE_OPTIONS: Map<
   AppTemplateId,

--- a/packages/toolpad-app/src/utils/crypto.ts
+++ b/packages/toolpad-app/src/utils/crypto.ts
@@ -3,7 +3,7 @@ import invariant from 'invariant';
 const crypto =
   typeof window === 'undefined'
     ? // eslint-disable-next-line global-require
-      (invariant(!global.crypto, 'Remove the crypto polyfill'), require('crypto'))
+      (invariant(!!global.crypto, 'Remove the crypto polyfill'), require('crypto'))
     : global.crypto;
 
 export default crypto;

--- a/packages/toolpad-app/src/utils/crypto.ts
+++ b/packages/toolpad-app/src/utils/crypto.ts
@@ -3,7 +3,7 @@ import invariant from 'invariant';
 const crypto =
   typeof window === 'undefined'
     ? // eslint-disable-next-line global-require
-      (invariant(!!global.crypto, 'Remove the crypto polyfill'), require('crypto'))
+      (invariant(!global.crypto, 'Remove the crypto polyfill'), require('crypto'))
     : global.crypto;
 
 export default crypto;


### PR DESCRIPTION
From https://github.com/mui/mui-toolpad/issues/592

Set automatic app names in demo mode and remove logic for non-duplicated app names.
Here I'm setting the app name client-side with a format like `demo_app_1668543595554`.

<img width="473" alt="Screenshot 2022-11-15 at 20 19 49" src="https://user-images.githubusercontent.com/10789765/202017500-5363e6b4-2781-4f94-bd01-f1b8122a7a80.png">
