### PR TITLE
Basic rate limiter implementation

### DIFF
--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -85,6 +85,7 @@ const securityHeaders = [
   },
 ];
 
+/** @type {Partial<import('@sentry/nextjs').SentryWebpackPluginOptions>} */
 const sentryWebpackPluginOptions = {
   // Additional config options for the Sentry Webpack plugin. Keep in mind that
   // the following options are set automatically, and overriding them is not

--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -58,6 +58,7 @@
     "@tanstack/react-query-devtools": "^4.16.0",
     "@types/cors": "^2.8.12",
     "abort-controller": "^3.0.0",
+    "agent-base": "^6.0.2",
     "arg": "^5.0.2",
     "basic-auth": "^2.0.1",
     "clsx": "^1.2.1",

--- a/packages/toolpad-app/src/toolpadDataSources/rest/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/server.ts
@@ -6,6 +6,7 @@ import { FetchPrivateQuery, FetchQuery, RestConnectionParams } from './types';
 import serverEvalExpression from '../../server/evalExpression';
 import { Maybe } from '../../utils/types';
 import { execfetch } from './shared';
+import { withOutboundRateLimiting } from '../../utils/outboundAgent';
 
 async function execBase(
   connection: Maybe<RestConnectionParams>,
@@ -13,7 +14,11 @@ async function execBase(
   params: Record<string, string>,
 ) {
   const har = createHarLog();
-  const instrumentedFetch = withHarInstrumentation(fetch, { har });
+  const instrumentedFetch = withOutboundRateLimiting(
+    // TODO: plumb appId here so we can rate limit specifically to it
+    '<global>',
+    withHarInstrumentation(fetch, { har }),
+  );
 
   const result = await execfetch(fetchQuery, params, {
     connection,

--- a/packages/toolpad-app/src/utils/outboundAgent.ts
+++ b/packages/toolpad-app/src/utils/outboundAgent.ts
@@ -1,0 +1,71 @@
+import agentBase from 'agent-base';
+import http from 'http';
+import https from 'https';
+import dns from 'dns/promises';
+import fetch, { Request } from 'node-fetch';
+
+const SLIDING_WINDOW = 1000;
+const REQS_PER_WINDOW = 5;
+
+const rateLimiterWindows = new Map<string, number[]>();
+
+// Regular garbage collection for the rateLimiterWindows
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, window] of rateLimiterWindows) {
+    if (window.every((timestamp) => timestamp < now - SLIDING_WINDOW)) {
+      rateLimiterWindows.delete(key);
+    }
+  }
+}, 5000).unref();
+
+// Basic sliding window rate limiter
+// We can build this distributed in redis:
+//   https://developer.redis.com/develop/dotnet/aspnetcore/rate-limiting/sliding-window/#sliding-window-rate-limiter-lua-script
+async function rateLimit(address: string): Promise<boolean> {
+  let window = rateLimiterWindows.get(address) ?? [];
+  const now = Date.now();
+  window = window.filter((timestamp) => timestamp > now - SLIDING_WINDOW);
+  let allowed = true;
+  if (window.length >= REQS_PER_WINDOW) {
+    allowed = false;
+  } else {
+    window.push(now);
+  }
+  rateLimiterWindows.set(address, window);
+
+  return allowed;
+}
+
+/**
+ * http(s) agent, to be used for user-originated requests. Rate limits and firewalls outbound requests.
+ */
+function createAgent(key: string) {
+  return agentBase(async (req, opts) => {
+    if (!opts.host) {
+      throw new Error(`Invalid request, missing host`);
+    }
+
+    const { address } = await dns.lookup(opts.host);
+
+    const allowed = await rateLimit(`${key}:${address}`);
+
+    if (!allowed) {
+      throw new Error('Rate limited');
+    }
+
+    return opts.secureEndpoint ? https.globalAgent : http.globalAgent;
+  });
+}
+
+export function withOutboundRateLimiting(key: string, inner: typeof fetch): typeof fetch {
+  const wrapped: typeof fetch = async (...args) => {
+    const req = new Request(...args);
+    req.agent = createAgent(key);
+    return inner(req);
+  };
+
+  wrapped.isRedirect = inner.isRedirect;
+
+  return wrapped;
+}


### PR DESCRIPTION
nginx handles only simple http proxy. but we also need to be able to proxy https traffic. For that we'll need [http tunneling](https://en.wikipedia.org/wiki/HTTP_tunnel). nginx doesn't offer this out of the box. We could opt for an alibaba made module like https://www.alibabacloud.com/blog/how-to-use-nginx-as-an-https-forward-proxy-server_595799. but preferrable not. It seems nginx isn't the exact tool for the job for a forwarding proxy. Further research shows there aren't many options for a rate limiting forward proxy besides writing one.

This leaves us with following options:

- write a forwarding proxy [ourselves](https://javascript.plainenglish.io/build-your-own-forward-and-reverse-proxy-server-using-node-js-from-scratch-eaa0f8d69e1f). Add in-memory rate limiting. On Toolpad side everything remains the same. [Proxy agent](https://www.npmjs.com/package/hpagent) in the fetch and function datasources.
- Write a node.js http(s) agent that rate limits. https://www.npmjs.com/package/agent-base + https://www.npmjs.com/package/limiter. I'm starting with trying this out in this PR.

### further exploration:

- [ ] We need to rate limit per application to prevent one bad actor messing things up for everyone else
- [ ] Add a cooldown period
- [ ] Redis