### PR TITLE
Add "alpha" label to app and landing page hero

### DIFF
--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import IconImage from 'docs/src/components/icon/IconImage';
 import GradientText from 'docs/src/components/typography/GradientText';
@@ -27,9 +28,10 @@ export default function Hero() {
           }}
         >
           <IconImage name="product-toolpad" width="28" height="28" sx={{ mr: 1 }} />
-          <Box component="span" sx={{ mr: 2 }}>
+          <Box component="span" sx={{ mr: 1 }}>
             MUI Toolpad
           </Box>
+          <Chip label="Alpha" color="grey" size="small" />
         </Typography>
         <Typography variant="h1" sx={{ my: 2 }}>
           Low-code

--- a/packages/toolpad-app/src/toolpad/ToolpadShell/Header/index.tsx
+++ b/packages/toolpad-app/src/toolpad/ToolpadShell/Header/index.tsx
@@ -6,7 +6,6 @@ import ThemeModeMenu from './ThemeModeMenu';
 import { useThemeMode, ThemeMode } from '../../../ThemeContext';
 import productIconDark from '../../../../public/product-icon-dark.svg';
 import productIconLight from '../../../../public/product-icon-light.svg';
-import config from '../../../config';
 
 export interface HeaderProps {
   actions?: React.ReactNode;
@@ -67,7 +66,7 @@ function Header({ actions, status }: HeaderProps) {
               </Box>
             </Link>
           </Tooltip>
-          {config.isDemo ? <Chip sx={{ ml: 1 }} label="Alpha" size="small" color="grey" /> : null}
+          <Chip sx={{ ml: 1 }} label="Alpha" size="small" color="grey" />
         </Box>
         <Box
           sx={{


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Closes #1251 
- Visual demonstration <!-- Screenshot/Video link -->
<img width="1319" alt="Alpha2" src="https://user-images.githubusercontent.com/19550456/202423329-d06306f0-14e0-4d03-9bea-815d54b51eff.png">
<img width="1328" alt="Alpha" src="https://user-images.githubusercontent.com/19550456/202423349-2865260a-a27d-49a9-8de8-c3bd38b8db2c.png">
<img width="1473" alt="Screenshot 2022-11-17 at 4 06 00 PM" src="https://user-images.githubusercontent.com/19550456/202424161-ed28617a-1f0d-460b-b431-e601ed7f1615.png">


