### PR TITLE
Remove sentry debug option

### DIFF
--- a/packages/toolpad-app/sentry.client.config.js
+++ b/packages/toolpad-app/sentry.client.config.js
@@ -11,7 +11,6 @@ Sentry.init({
   enabled: !!SENTRY_DSN,
   dsn: SENTRY_DSN,
   tracesSampleRate: 0.1,
-  debug: process.env.NODE_ENV === 'development',
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/packages/toolpad-app/sentry.server.config.js
+++ b/packages/toolpad-app/sentry.server.config.js
@@ -10,7 +10,6 @@ Sentry.init({
   enabled: !!SENTRY_DSN,
   dsn: SENTRY_DSN,
   tracesSampleRate: 0.1,
-  debug: process.env.NODE_ENV === 'development',
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
Was this enabled by accident? I feel like it's a bit chatty to be enabled by default in development