### PR TITLE
Don't immediately open duplicated apps

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -49,16 +49,7 @@ export default function PagePanel({ appId, className, sx }: ComponentPanelProps)
             loading={Boolean(!app)}
           />
         )}
-        {app ? (
-          <AppOptions
-            app={app}
-            dom={dom}
-            allowDelete
-            redirectOnDelete
-            allowDuplicate
-            onRename={handleRename}
-          />
-        ) : null}
+        {app ? <AppOptions app={app} dom={dom} redirectOnDelete onRename={handleRename} /> : null}
       </Box>
       <Divider />
       <HierarchyExplorer appId={appId} />

--- a/packages/toolpad-app/src/toolpad/AppOptions/AppDuplicateDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppOptions/AppDuplicateDialog.tsx
@@ -6,13 +6,18 @@ import {
   DialogTitle,
   DialogActions,
   TextField,
+  IconButton,
+  Snackbar,
 } from '@mui/material';
 import LoadingButton from '@mui/lab/LoadingButton';
 import invariant from 'invariant';
+import { Link } from 'react-router-dom';
+import CloseIcon from '@mui/icons-material/Close';
 import client from '../../api';
 import DialogForm from '../../components/DialogForm';
 import type { AppMeta } from '../../server/data';
 import { errorFrom } from '../../utils/errors';
+import useLatest from '../../utils/useLatest';
 
 interface AppDuplicateDialogProps {
   open: boolean;
@@ -22,6 +27,13 @@ interface AppDuplicateDialogProps {
 
 function AppDuplicateDialog({ app, onClose, ...props }: AppDuplicateDialogProps) {
   const [nameInput, setNameInput] = React.useState(app?.name ?? '');
+  const [duplicatedApp, setDuplicatedApp] = React.useState<{
+    name: string;
+    url: string;
+  } | null>(null);
+
+  // To keep content around during closing animation
+  const lastDuplicatedApp = useLatest(duplicatedApp);
 
   const handleNameInputChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => setNameInput(event.target.value),
@@ -33,8 +45,7 @@ function AppDuplicateDialog({ app, onClose, ...props }: AppDuplicateDialogProps)
   const duplicateApp = React.useCallback(async () => {
     if (app) {
       const duplicated = await duplicateAppMutation.mutateAsync([app.id, nameInput]);
-      const url = new URL(`/_toolpad/app/${duplicated.id}`, window.location.href);
-      window.open(url, '_blank');
+      setDuplicatedApp({ name: duplicated.name, url: `/app/${duplicated.id}` });
     }
     await client.invalidateQueries('getApps');
   }, [app, nameInput, duplicateAppMutation]);
@@ -48,51 +59,80 @@ function AppDuplicateDialog({ app, onClose, ...props }: AppDuplicateDialogProps)
     return '';
   }, [isFormValid, duplicateAppMutation.error]);
 
+  const handleSnackbarClose = React.useCallback(() => {
+    setDuplicatedApp(null);
+  }, []);
+
   return (
-    <Dialog {...props} onClose={onClose} maxWidth="xs">
-      <DialogForm
-        onSubmit={(event) => {
-          invariant(isFormValid, 'Form should not be submitted when invalid');
-          event.preventDefault();
-          duplicateApp();
-          onClose();
-        }}
-      >
-        <DialogTitle>Duplicate app</DialogTitle>
-        <DialogContent>
-          <TextField
-            sx={{ my: 1 }}
-            autoFocus
-            required
-            fullWidth
-            label="Name"
-            value={nameInput}
-            error={!isFormValid}
-            helperText={formError}
-            onChange={handleNameInputChange}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button
-            color="inherit"
-            variant="text"
-            onClick={() => {
-              onClose();
-            }}
-          >
-            Cancel
-          </Button>
-          <LoadingButton
-            type="submit"
-            aria-label="Duplicate app submit button"
-            loading={duplicateAppMutation.isLoading}
-            disabled={!isFormValid}
-          >
-            Create
-          </LoadingButton>
-        </DialogActions>
-      </DialogForm>
-    </Dialog>
+    <React.Fragment>
+      <Dialog {...props} onClose={onClose} maxWidth="xs">
+        <DialogForm
+          onSubmit={(event) => {
+            invariant(isFormValid, 'Form should not be submitted when invalid');
+            event.preventDefault();
+            duplicateApp();
+            onClose();
+          }}
+        >
+          <DialogTitle>Duplicate app</DialogTitle>
+          <DialogContent>
+            <TextField
+              sx={{ my: 1 }}
+              autoFocus
+              required
+              fullWidth
+              label="Name"
+              value={nameInput}
+              error={!isFormValid}
+              helperText={formError}
+              onChange={handleNameInputChange}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button
+              color="inherit"
+              variant="text"
+              onClick={() => {
+                onClose();
+              }}
+            >
+              Cancel
+            </Button>
+            <LoadingButton
+              type="submit"
+              aria-label="Duplicate app submit button"
+              loading={duplicateAppMutation.isLoading}
+              disabled={!isFormValid}
+            >
+              Create
+            </LoadingButton>
+          </DialogActions>
+        </DialogForm>
+      </Dialog>
+      {lastDuplicatedApp ? (
+        <Snackbar
+          open={!!duplicatedApp}
+          onClose={handleSnackbarClose}
+          message={`App ${lastDuplicatedApp.name} created`}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          action={
+            <React.Fragment>
+              <Button size="small" component={Link} to={lastDuplicatedApp.url ?? '#'}>
+                Open
+              </Button>
+              <IconButton
+                size="small"
+                aria-label="close"
+                color="inherit"
+                onClick={handleSnackbarClose}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </React.Fragment>
+          }
+        />
+      ) : null}
+    </React.Fragment>
   );
 }
 

--- a/packages/toolpad-app/src/toolpad/AppOptions/AppDuplicateDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppOptions/AppDuplicateDialog.tsx
@@ -82,6 +82,7 @@ function AppDuplicateDialog({ app, onClose, open, ...props }: AppDuplicateDialog
             <TextField
               sx={{ my: 1 }}
               autoFocus
+              onFocus={(event) => event.target.select()}
               required
               fullWidth
               label="Name"

--- a/packages/toolpad-app/src/toolpad/AppOptions/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppOptions/index.tsx
@@ -16,7 +16,7 @@ import AppDeleteDialog from './AppDeleteDialog';
 import AppDuplicateDialog from './AppDuplicateDialog';
 
 interface AppOptionsProps {
-  app?: AppMeta;
+  app: AppMeta;
   onRename: () => void;
   dom?: any;
   redirectOnDelete?: boolean;
@@ -29,15 +29,11 @@ function AppOptions({ app, onRename, dom, redirectOnDelete }: AppOptionsProps) {
   const [duplicateApp, setDuplicateApp] = React.useState<AppMeta | null>(null);
 
   const onDuplicate = React.useCallback(() => {
-    if (app) {
-      setDuplicateApp(app);
-    }
+    setDuplicateApp(app);
   }, [app]);
 
   const onDelete = React.useCallback(() => {
-    if (app) {
-      setDeletedApp(app);
-    }
+    setDeletedApp(app);
   }, [app]);
 
   const handleRenameClick = React.useCallback(() => {
@@ -130,7 +126,7 @@ function AppOptions({ app, onRename, dom, redirectOnDelete }: AppOptionsProps) {
       />
       <AppDuplicateDialog
         open={Boolean(duplicateApp)}
-        app={duplicateApp}
+        app={app}
         onClose={() => setDuplicateApp(null)}
       />
     </React.Fragment>

--- a/packages/toolpad-app/src/toolpad/AppOptions/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppOptions/index.tsx
@@ -18,20 +18,11 @@ import AppDuplicateDialog from './AppDuplicateDialog';
 interface AppOptionsProps {
   app?: AppMeta;
   onRename: () => void;
-  allowDuplicate?: boolean;
-  allowDelete?: boolean;
   dom?: any;
   redirectOnDelete?: boolean;
 }
 
-function AppOptions({
-  app,
-  onRename,
-  allowDelete,
-  allowDuplicate,
-  dom,
-  redirectOnDelete,
-}: AppOptionsProps) {
+function AppOptions({ app, onRename, dom, redirectOnDelete }: AppOptionsProps) {
   const { buttonProps, menuProps, onMenuClose } = useMenu();
 
   const [deletedApp, setDeletedApp] = React.useState<AppMeta | null>(null);
@@ -98,22 +89,18 @@ function AppOptions({
           </ListItemIcon>
           <ListItemText>Rename</ListItemText>
         </MenuItem>
-        {allowDuplicate ? (
-          <MenuItem onClick={handleDuplicateClick}>
-            <ListItemIcon>
-              <ContentCopyOutlinedIcon />
-            </ListItemIcon>
-            <ListItemText>Duplicate</ListItemText>
-          </MenuItem>
-        ) : null}
-        {allowDelete ? (
-          <MenuItem onClick={handleDeleteClick}>
-            <ListItemIcon>
-              <DeleteIcon />
-            </ListItemIcon>
-            <ListItemText>Delete</ListItemText>
-          </MenuItem>
-        ) : null}
+        <MenuItem onClick={handleDuplicateClick}>
+          <ListItemIcon>
+            <ContentCopyOutlinedIcon />
+          </ListItemIcon>
+          <ListItemText>Duplicate</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={handleDeleteClick}>
+          <ListItemIcon>
+            <DeleteIcon />
+          </ListItemIcon>
+          <ListItemText>Delete</ListItemText>
+        </MenuItem>
         <Divider />
         {dom ? (
           <MenuItem onClick={handleAppExportClick}>

--- a/packages/toolpad-app/src/toolpad/Apps/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Apps/index.tsx
@@ -422,7 +422,7 @@ function AppCard({ app, activeDeployment, existingAppNames }: AppCardProps) {
       }}
     >
       <CardHeader
-        action={<AppOptions app={app} onRename={handleRename} />}
+        action={app ? <AppOptions app={app} onRename={handleRename} /> : null}
         disableTypography
         subheader={
           <Typography variant="body2" color="text.secondary">
@@ -482,9 +482,13 @@ function AppRow({ app, activeDeployment, existingAppNames }: AppRowProps) {
       </TableCell>
       <TableCell align="right">
         <Stack direction="row" spacing={1} justifyContent={'flex-end'}>
-          <AppEditButton app={app} />
-          <AppOpenButton app={app} activeDeployment={activeDeployment} />
-          <AppOptions app={app} onRename={handleRename} />
+          {app ? (
+            <React.Fragment>
+              <AppEditButton app={app} />
+              <AppOpenButton app={app} activeDeployment={activeDeployment} />
+              <AppOptions app={app} onRename={handleRename} />
+            </React.Fragment>
+          ) : null}
         </Stack>
       </TableCell>
     </TableRow>

--- a/packages/toolpad-app/src/toolpad/Apps/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Apps/index.tsx
@@ -422,7 +422,7 @@ function AppCard({ app, activeDeployment, existingAppNames }: AppCardProps) {
       }}
     >
       <CardHeader
-        action={<AppOptions app={app} allowDelete allowDuplicate onRename={handleRename} />}
+        action={<AppOptions app={app} onRename={handleRename} />}
         disableTypography
         subheader={
           <Typography variant="body2" color="text.secondary">
@@ -484,7 +484,7 @@ function AppRow({ app, activeDeployment, existingAppNames }: AppRowProps) {
         <Stack direction="row" spacing={1} justifyContent={'flex-end'}>
           <AppEditButton app={app} />
           <AppOpenButton app={app} activeDeployment={activeDeployment} />
-          <AppOptions app={app} allowDelete allowDuplicate onRename={handleRename} />
+          <AppOptions app={app} onRename={handleRename} />
         </Stack>
       </TableCell>
     </TableRow>

--- a/packages/toolpad-app/src/utils/useRisingEdge.ts
+++ b/packages/toolpad-app/src/utils/useRisingEdge.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import useEvent from './useEvent';
+
+export default function useRisingEdge(value: boolean, handler: () => void) {
+  const prevValue = React.useRef(value);
+  const stableHandler = useEvent(handler);
+  React.useEffect(() => {
+    if (!prevValue.current && value) {
+      stableHandler();
+    }
+    prevValue.current = value;
+  }, [stableHandler, value]);
+}


### PR DESCRIPTION
Current implementation leaves the user out of control. They may want to 
* only duplicate, not edit
* duplicate and edit in the same tab
* duplicate and edit in a new tab

And we shouldn't make that choice for them

This PR shows a snackbar instead with a link to open the duplicated app. similar to how e.g. figma does duplication

Now the user can
* ignore the snackbar
* click open to open in the same tab
* click Cmd+open to open in a new tab

Additionally:
* tighten the types to make more ergomic API
* make sure the app is always defined in the dialogs to ensure closing animations look ok
* reset the form on dialog open
* remove some unused props
* autoselect proposed name in dialog

https://user-images.githubusercontent.com/2109932/204859712-1e1774fc-a747-486f-ab6c-47f483fe3172.mov


