### PR TITLE
Make sure EditableText updates when underlying string changes

### DIFF
--- a/packages/toolpad-app/src/components/EditableText.tsx
+++ b/packages/toolpad-app/src/components/EditableText.tsx
@@ -45,10 +45,7 @@ const EditableText = React.forwardRef<HTMLInputElement, EditableTextProps>(
     const appTitleInput = React.useRef<HTMLInputElement | null>(null);
 
     React.useEffect(() => {
-      let inputElement: HTMLInputElement | null = appTitleInput.current;
-      if (ref) {
-        inputElement = (ref as React.MutableRefObject<HTMLInputElement>).current;
-      }
+      const inputElement = appTitleInput.current;
       if (inputElement) {
         if (editable) {
           inputElement.focus();
@@ -83,10 +80,7 @@ const EditableText = React.forwardRef<HTMLInputElement, EditableTextProps>(
 
     const handleInput = React.useCallback(
       (event: React.KeyboardEvent<HTMLInputElement>) => {
-        let inputElement: HTMLInputElement | null = appTitleInput.current;
-        if (ref) {
-          inputElement = (ref as React.MutableRefObject<HTMLInputElement>).current;
-        }
+        const inputElement = appTitleInput.current;
         if (inputElement) {
           if (event.key === 'Escape') {
             if (defaultValue) {
@@ -109,7 +103,7 @@ const EditableText = React.forwardRef<HTMLInputElement, EditableTextProps>(
           }
         }
       },
-      [defaultValue, onChange, onSave, onClose, ref],
+      [defaultValue, onChange, onSave, onClose],
     );
 
     return (
@@ -118,7 +112,8 @@ const EditableText = React.forwardRef<HTMLInputElement, EditableTextProps>(
         disabled={disabled || !editable}
         error={error}
         helperText={helperText}
-        inputRef={ref ?? appTitleInput}
+        ref={ref}
+        inputRef={appTitleInput}
         inputProps={{
           tabIndex: editable ? 0 : -1,
           'aria-readonly': !editable,

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -42,12 +42,7 @@ export default function PagePanel({ appId, className, sx }: ComponentPanelProps)
         {isLoading || !app ? (
           <Skeleton variant="text" width={70} />
         ) : (
-          <AppNameEditable
-            app={app}
-            editing={editingName}
-            setEditing={setEditingName}
-            loading={Boolean(!app)}
-          />
+          <AppNameEditable app={app} editing={editingName} setEditing={setEditingName} />
         )}
         {app ? (
           <AppOptions

--- a/packages/toolpad-app/src/toolpad/AppOptions/AppNameEditable.tsx
+++ b/packages/toolpad-app/src/toolpad/AppOptions/AppNameEditable.tsx
@@ -1,26 +1,21 @@
 import * as React from 'react';
-import Skeleton from '@mui/material/Skeleton';
 import type { AppMeta } from '../../server/data';
 import EditableText from '../../components/EditableText';
 import client from '../../api';
 
 interface AppNameEditableProps {
-  app?: AppMeta;
+  app: AppMeta;
   editing?: boolean;
   setEditing: (editing: boolean) => void;
-  loading?: boolean;
   existingAppNames?: string[];
 }
 
-function AppNameEditable({
-  app,
-  editing,
-  setEditing,
-  loading,
-  existingAppNames,
-}: AppNameEditableProps) {
+function AppNameEditable({ app, editing, setEditing, existingAppNames }: AppNameEditableProps) {
   const appNameInput = React.useRef<HTMLInputElement | null>(null);
-  const [appName, setAppName] = React.useState<string>(app?.name || '');
+  const [appName, setAppName] = React.useState<string>(app.name || '');
+  React.useEffect(() => {
+    setAppName(app.name);
+  }, [app.name]);
 
   const handleAppNameChange = React.useCallback(
     (newValue: string) => {
@@ -32,11 +27,11 @@ function AppNameEditable({
   const existingNames = React.useMemo(() => new Set(existingAppNames), [existingAppNames]);
 
   const nameError = React.useMemo(() => {
-    if (editing && appName !== app?.name && existingNames.has(appName)) {
+    if (editing && appName !== app.name && existingNames.has(appName)) {
       return 'An app with that name already exists.';
     }
     return null;
-  }, [editing, existingNames, appName, app?.name]);
+  }, [editing, existingNames, appName, app.name]);
 
   const handleAppRenameClose = React.useCallback(() => {
     setEditing(false);
@@ -48,7 +43,7 @@ function AppNameEditable({
         setEditing(true);
         return;
       }
-      if (app?.id) {
+      if (app.id) {
         try {
           await client.mutation.updateApp(app.id, { name });
           await client.invalidateQueries('getApps');
@@ -58,14 +53,12 @@ function AppNameEditable({
         }
       }
     },
-    [app?.id, setEditing, nameError, existingNames],
+    [app.id, setEditing, nameError, existingNames],
   );
 
-  return loading ? (
-    <Skeleton />
-  ) : (
+  return (
     <EditableText
-      defaultValue={app?.name}
+      defaultValue={app.name}
       editable={editing}
       helperText={nameError}
       error={!!nameError}

--- a/packages/toolpad-app/src/toolpad/Apps/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Apps/index.tsx
@@ -437,13 +437,16 @@ function AppCard({ app, activeDeployment, existingAppNames }: AppCardProps) {
         }
       />
       <CardContent sx={{ flexGrow: 1 }}>
-        <AppNameEditable
-          app={app}
-          editing={editingName}
-          setEditing={setEditingName}
-          loading={Boolean(!app)}
-          existingAppNames={existingAppNames}
-        />
+        {app ? (
+          <AppNameEditable
+            app={app}
+            editing={editingName}
+            setEditing={setEditingName}
+            existingAppNames={existingAppNames}
+          />
+        ) : (
+          <Skeleton />
+        )}
       </CardContent>
       <CardActions>
         <AppEditButton app={app} />
@@ -469,13 +472,16 @@ function AppRow({ app, activeDeployment, existingAppNames }: AppRowProps) {
   return (
     <TableRow hover role="row">
       <TableCell component="th" scope="row">
-        <AppNameEditable
-          loading={Boolean(!app)}
-          app={app}
-          editing={editingName}
-          setEditing={setEditingName}
-          existingAppNames={existingAppNames}
-        />
+        {app ? (
+          <AppNameEditable
+            app={app}
+            editing={editingName}
+            setEditing={setEditingName}
+            existingAppNames={existingAppNames}
+          />
+        ) : (
+          <Skeleton />
+        )}
         <Typography variant="caption">
           {app ? `Edited ${getReadableDuration(app.editedAt)}` : <Skeleton />}
         </Typography>


### PR DESCRIPTION
Having trouble with this with the connections view, where the name can be updated in the popup on  the same page. 

This demonstrates the fix on the app view, when renamed outside of the editable text. In the apps case it's a less urgent problem as the renaming happens on another page.

https://user-images.githubusercontent.com/2109932/205041779-04ad9794-b6a3-4aad-953c-b3a2602e3f18.mov

Also adding a few cleanups in there