### PR TITLE
Disable flaky undo spec

### DIFF
--- a/test/integration/undo-redo/index.spec.ts
+++ b/test/integration/undo-redo/index.spec.ts
@@ -43,7 +43,7 @@ test('test basic undo and redo', async ({ page, browserName }) => {
   await expect(canvasInputLocator).toHaveCount(3);
 });
 
-test('test batching quick actions into single undo entry', async ({ page, browserName }) => {
+test.skip('test batching quick actions into single undo entry', async ({ page, browserName }) => {
   const homeModel = new ToolpadHome(page);
   const editorModel = new ToolpadEditor(page, browserName);
 


### PR DESCRIPTION
Since the spec randomly fails in CI, I've decided to disable it until I can find a way to fix it