### PR TITLE
Fix URL for Default template

### DIFF
--- a/packages/toolpad-app/src/server/appTemplateDoms/default.json
+++ b/packages/toolpad-app/src/server/appTemplateDoms/default.json
@@ -13,7 +13,7 @@
           "value": {
             "url": {
               "type": "const",
-              "value": "http://localhost:3000/static/employees.json"
+              "value": "https://demo.toolpad.io/static/employees.json"
             },
             "method": "GET",
             "browser": true,


### PR DESCRIPTION
Replace the `localhost` URL in the `default.json` file with a path to the remote asset