### PR TITLE
Support dynamic app templates

### DIFF
--- a/packages/toolpad-app/src/server/appTemplateDoms/doms.ts
+++ b/packages/toolpad-app/src/server/appTemplateDoms/doms.ts
@@ -1,3 +1,4 @@
+import { NodeId } from '@mui/toolpad-core';
 import * as path from 'path';
 import * as appDom from '../../appDom';
 import { migrateUp } from '../../appDom/migrations';
@@ -7,22 +8,25 @@ import config from '../config';
 import projectRoot from '../projectRoot';
 
 const DOMS_DIR_PATH = './src/server/appTemplateDoms';
+const getAppTemplateDomFromPath = (templatePath: string): Promise<appDom.AppDom> =>
+  readJsonFile(path.resolve(projectRoot, DOMS_DIR_PATH, templatePath));
 
-const APP_TEMPLATE_DOM_PATHS: Record<AppTemplateId, string | null> = {
-  blank: null,
-  images: path.resolve(
-    projectRoot,
-    DOMS_DIR_PATH,
-    // @TODO: Remove demo template once demo supports server-side queries
-    config.isDemo ? './images-demo.json' : './images.json',
-  ),
-  default: path.resolve(projectRoot, DOMS_DIR_PATH, './default.json'),
+const appTemplates: Record<AppTemplateId, () => Promise<appDom.AppDom | null>> = {
+  blank: async () => null,
+  images: async () =>
+    getAppTemplateDomFromPath(config.isDemo ? './images-demo.json' : './images.json'),
+  default: async () => {
+    const template = await getAppTemplateDomFromPath('./default.json');
+    (
+      template.nodes['1313wn3' as NodeId] as appDom.QueryNode
+    ).attributes.query.value.url.value = `${config.externalUrl}/static/employees.json`;
+    return template;
+  },
 };
 
 export async function getAppTemplateDom(
   appTemplateId: AppTemplateId,
 ): Promise<appDom.AppDom | null> {
-  const domPath = APP_TEMPLATE_DOM_PATHS[appTemplateId];
-  const dom = domPath ? await readJsonFile(domPath) : null;
+  const dom = await appTemplates[appTemplateId]();
   return dom ? migrateUp(dom) : null;
 }


### PR DESCRIPTION
Allows dynamic app templates that we can pass Javascript variables to.
Also fixes default template for multiple environments.

Had this idea from the discussion in https://github.com/mui/mui-toolpad/pull/1429, should also be a long-term fix for these types of issues.