### PR TITLE
Revert react-router-dom to 6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
   "engines": {
     "npm": "please-use-yarn",
     "node": ">=16.17"
+  },
+  "resolutions": {
+    "react-router-dom": "~6.3.0"
   }
 }

--- a/packages/toolpad-app/src/components/MonacoEditor.tsx
+++ b/packages/toolpad-app/src/components/MonacoEditor.tsx
@@ -225,6 +225,7 @@ interface MonacoEditorBaseProps {
   onBlur?: () => void;
   options?: EditorOptions;
   className?: string;
+  'data-testid'?: string;
 }
 
 export type MonacoEditorProps = MonacoEditorBaseProps &
@@ -264,6 +265,7 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
     disabled,
     options,
     autoFocus,
+    ...props
   },
   ref,
 ) {
@@ -318,7 +320,6 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
 
   React.useEffect(() => {
     invariant(rootRef.current, 'Ref not attached');
-
     const extraOptions: EditorOptions = {
       readOnly: disabled,
       theme: monacoTheme,
@@ -443,7 +444,7 @@ export default React.forwardRef<MonacoEditorHandle, MonacoEditorProps>(function 
   );
 
   return (
-    <EditorRoot className={clsx({ [classes.disabled]: disabled }, className)} sx={sx}>
+    <EditorRoot className={clsx({ [classes.disabled]: disabled }, className)} sx={sx} {...props}>
       <div className={classes.monacoHost} ref={rootRef} />
       <div className={classes.overlay} />
     </EditorRoot>

--- a/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
@@ -261,12 +261,7 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
             />
 
             <SplitPane split="horizontal" allowResize size="20%" primary="second">
-              <CanvasFrame
-                data-testid="code component viewer"
-                ref={frameRef}
-                title="Code component sandbox"
-                onLoad={onLoad}
-              />
+              <CanvasFrame ref={frameRef} title="Code component sandbox" onLoad={onLoad} />
               <PropertiesEditor argTypes={argTypes} value={props} onChange={setProps} />
             </SplitPane>
           </SplitPane>

--- a/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/CodeComponentEditor/index.tsx
@@ -246,6 +246,7 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
           <SplitPane split="vertical" allowResize size="50%">
             <TypescriptEditor
               value={input.attributes.code.value}
+              data-testid="codecomponent editor"
               onChange={(newValue) =>
                 setInput((existing) =>
                   appDom.setNamespacedProp(
@@ -260,7 +261,12 @@ function CodeComponentEditorContent({ codeComponentNode }: CodeComponentEditorCo
             />
 
             <SplitPane split="horizontal" allowResize size="20%" primary="second">
-              <CanvasFrame ref={frameRef} title="Code component sandbox" onLoad={onLoad} />
+              <CanvasFrame
+                data-testid="code component viewer"
+                ref={frameRef}
+                title="Code component sandbox"
+                onLoad={onLoad}
+              />
               <PropertiesEditor argTypes={argTypes} value={props} onChange={setProps} />
             </SplitPane>
           </SplitPane>

--- a/test/integration/codeComponents/dom.json
+++ b/test/integration/codeComponents/dom.json
@@ -1,0 +1,43 @@
+{
+  "root": "2i0dd5d",
+  "nodes": {
+    "2i0dd5d": {
+      "id": "2i0dd5d",
+      "name": "Application",
+      "type": "app",
+      "parentId": null,
+      "attributes": {},
+      "parentProp": null,
+      "parentIndex": null
+    },
+    "2i1ddtk": {
+      "id": "2i1ddtk",
+      "name": "page1",
+      "type": "page",
+      "parentId": "2i0dd5d",
+      "attributes": {
+        "title": {
+          "type": "const",
+          "value": "Page 1"
+        }
+      },
+      "parentProp": "pages",
+      "parentIndex": "a0"
+    },
+    "8y03tu0": {
+      "name": "myComponent",
+      "attributes": {
+        "code": {
+          "type": "const",
+          "value": "import * as React from \"react\";\nimport { Typography } from \"@mui/material\";\nimport { createComponent } from \"@mui/toolpad-core\";\n\nexport interface myComponentProps {\n  msg: string;\n}\n\nfunction myComponent({ msg }: myComponentProps) {\n  return <Typography>{msg}</Typography>;\n}\n\nexport default createComponent(myComponent, {\n  argTypes: {\n    msg: {\n      typeDef: { type: \"string\" },\n      defaultValue: \"Hello world!\",\n    },\n  },\n});\n"
+        }
+      },
+      "id": "8y03tu0",
+      "type": "codeComponent",
+      "parentId": "2i0dd5d",
+      "parentProp": "codeComponents",
+      "parentIndex": "a0"
+    }
+  },
+  "version": 3
+}

--- a/test/integration/codeComponents/index.spec.ts
+++ b/test/integration/codeComponents/index.spec.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { ToolpadEditor } from '../../models/ToolpadEditor';
-import { FrameLocator, Page, test, expect } from '../../playwright/test';
+import { test, expect } from '../../playwright/test';
 import { readJsonFile } from '../../utils/fs';
 import generateId from '../../utils/generateId';
 

--- a/test/integration/codeComponents/index.spec.ts
+++ b/test/integration/codeComponents/index.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '../../playwright/test';
 import { readJsonFile } from '../../utils/fs';
 import generateId from '../../utils/generateId';
 
-test.only('components', async ({ page, browserName, api }) => {
+test('components', async ({ page, browserName, api }) => {
   const dom = await readJsonFile(path.resolve(__dirname, './dom.json'));
 
   const app = await api.mutation.createApp(`App ${generateId()}`, {

--- a/test/integration/codeComponents/index.spec.ts
+++ b/test/integration/codeComponents/index.spec.ts
@@ -1,0 +1,29 @@
+import * as path from 'path';
+import { ToolpadEditor } from '../../models/ToolpadEditor';
+import { FrameLocator, Page, test, expect } from '../../playwright/test';
+import { readJsonFile } from '../../utils/fs';
+import generateId from '../../utils/generateId';
+
+test.only('components', async ({ page, browserName, api }) => {
+  const dom = await readJsonFile(path.resolve(__dirname, './dom.json'));
+
+  const app = await api.mutation.createApp(`App ${generateId()}`, {
+    from: { kind: 'dom', dom },
+  });
+
+  const editorModel = new ToolpadEditor(page, browserName);
+  await editorModel.goto(app.id);
+
+  await editorModel.hierarchyItem('components', 'myCOmponent').click();
+
+  await page.getByTestId('codecomponent editor').click();
+  await page.keyboard.press('Control+A');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.type('export default () => "hello everybody!!!"');
+
+  const output = page
+    .frameLocator('[title="Code component sandbox"]')
+    .getByText('hello everybody!!!');
+
+  await expect(output).toBeVisible();
+});

--- a/test/models/ToolpadEditor.ts
+++ b/test/models/ToolpadEditor.ts
@@ -197,15 +197,11 @@ export class ToolpadEditor {
   }
 
   hierarchyItem(group: string, name: string): Locator {
-    return (
-      this.explorer
-        // @ts-expect-error https://github.com/microsoft/playwright/pull/17952
-        .getByRole('treeitem')
-        .filter({ hasText: group })
-        // @ts-expect-error https://github.com/microsoft/playwright/pull/17952
-        .getByRole('treeitem')
-        .filter({ hasText: name })
-    );
+    return this.explorer
+      .getByRole('treeitem')
+      .filter({ hasText: group })
+      .getByRole('treeitem')
+      .filter({ hasText: name });
   }
 
   async openHierarchyMenu(group: string, name: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7028,7 +7028,7 @@ hexoid@^1.0.0:
   resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
   integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
-history@^5.3.0:
+history@^5.2.0, history@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
@@ -10561,15 +10561,22 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-router-dom@^6.3.0, react-router-dom@^6.4.4:
-  version "6.4.4"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.4.4.tgz#4271ec66333c440d1754477e4e6a3a5acb5487f8"
-  integrity sha512-0Axverhw5d+4SBhLqLpzPhNkmv7gahUwlUVIOrRLGJ4/uwt30JVajVJXqv2Qr/LCwyvHhQc7YyK1Do8a9Jj7qA==
+react-router-dom@^6.3.0, react-router-dom@^6.4.4, react-router-dom@~6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
   dependencies:
-    "@remix-run/router" "1.0.4"
-    react-router "6.4.4"
+    history "^5.2.0"
+    react-router "6.3.0"
 
-react-router@6.4.4, react-router@^6.4.4:
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
+
+react-router@^6.4.4:
   version "6.4.4"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.4.4.tgz#8e7794f55ccc7050cb03937c87ff3720ce9f8b60"
   integrity sha512-SA6tSrUCRfuLWeYsTJDuriRqfFIsrSvuH7SqAJHegx9ZgxadE119rU8oOX/rG5FYEthpdEaEljdjDlnBxvfr+Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7028,7 +7028,7 @@ hexoid@^1.0.0:
   resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
   integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
-history@^5.2.0, history@^5.3.0:
+history@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
@@ -10561,28 +10561,13 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-router-dom@^6.4.4:
+react-router-dom@^6.3.0, react-router-dom@^6.4.4:
   version "6.4.4"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.4.4.tgz#4271ec66333c440d1754477e4e6a3a5acb5487f8"
   integrity sha512-0Axverhw5d+4SBhLqLpzPhNkmv7gahUwlUVIOrRLGJ4/uwt30JVajVJXqv2Qr/LCwyvHhQc7YyK1Do8a9Jj7qA==
   dependencies:
     "@remix-run/router" "1.0.4"
     react-router "6.4.4"
-
-react-router-dom@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
-  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
-  dependencies:
-    history "^5.2.0"
-    react-router "6.3.0"
-
-react-router@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
-  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
-  dependencies:
-    history "^5.2.0"
 
 react-router@6.4.4, react-router@^6.4.4:
   version "6.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7028,7 +7028,7 @@ hexoid@^1.0.0:
   resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
   integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
-history@^5.3.0:
+history@^5.2.0, history@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
@@ -10561,13 +10561,28 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-router-dom@^6.3.0, react-router-dom@^6.4.4:
+react-router-dom@^6.4.4:
   version "6.4.4"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.4.4.tgz#4271ec66333c440d1754477e4e6a3a5acb5487f8"
   integrity sha512-0Axverhw5d+4SBhLqLpzPhNkmv7gahUwlUVIOrRLGJ4/uwt30JVajVJXqv2Qr/LCwyvHhQc7YyK1Do8a9Jj7qA==
   dependencies:
     "@remix-run/router" "1.0.4"
     react-router "6.4.4"
+
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-router@6.4.4, react-router@^6.4.4:
   version "6.4.4"


### PR DESCRIPTION
Second stab at https://github.com/mui/mui-toolpad/pull/1426

Not sure why renovatebot reverted this in https://github.com/mui/mui-toolpad/pull/1435 but let's assume `resolutions` will prevent this in the future.

Nevertheless, I added a long overdue code components editor smoke test which covers the regression as well.