### PR TITLE
Replace gridcolumns editor dialog with popover

### DIFF
--- a/packages/toolpad-app/src/toolpad/propertyControls/GridColumns.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/GridColumns.tsx
@@ -1,9 +1,6 @@
 import {
+  Box,
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   IconButton,
   List,
   ListItem,
@@ -11,6 +8,7 @@ import {
   ListItemText,
   Menu,
   MenuItem,
+  Popover,
   Stack,
   TextField,
   Tooltip,
@@ -62,15 +60,9 @@ function GridColumnsPropEditor({
   disabled,
 }: EditorProps<SerializableGridColumns>) {
   const { bindings } = usePageEditorState();
-  const [editColumnsDialogOpen, setEditColumnsDialogOpen] = React.useState(false);
   const [editedIndex, setEditedIndex] = React.useState<number | null>(null);
 
   const editedColumn = typeof editedIndex === 'number' ? value[editedIndex] : null;
-  React.useEffect(() => {
-    if (editColumnsDialogOpen) {
-      setEditedIndex(null);
-    }
-  }, [editColumnsDialogOpen]);
 
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<null | HTMLElement>(null);
   const menuOpen = Boolean(menuAnchorEl);
@@ -135,23 +127,50 @@ function GridColumnsPropEditor({
     }
   }, [hasColumnSuggestions, inferredColumns, onChange]);
 
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
+
+  const handlePopoverClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
+  };
+  const open = Boolean(anchorEl);
+  const popoverIdValue = React.useId();
+  const popoverId = open ? popoverIdValue : undefined;
+
+  React.useEffect(() => {
+    if (open) {
+      setEditedIndex(null);
+    }
+  }, [open]);
+
   return (
     <React.Fragment>
-      <Button onClick={() => setEditColumnsDialogOpen(true)}>{label}</Button>
-      <Dialog
-        fullWidth
-        open={editColumnsDialogOpen}
-        onClose={() => setEditColumnsDialogOpen(false)}
+      <Button aria-describedby={popoverId} onClick={handlePopoverClick}>
+        {label}
+      </Button>
+      <Popover
+        id={popoverId}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handlePopoverClose}
+        anchorOrigin={{
+          vertical: 'center',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'center',
+          horizontal: 'left',
+        }}
       >
-        {editedColumn ? (
-          <React.Fragment>
-            <DialogTitle>
+        <Box sx={{ minWidth: 300, p: 2 }}>
+          {editedColumn ? (
+            <React.Fragment>
               <IconButton aria-label="Back" onClick={() => setEditedIndex(null)}>
                 <ArrowBackIcon />
               </IconButton>
-              Edit column {editedColumn.field}
-            </DialogTitle>
-            <DialogContent>
               <Stack gap={1} py={1}>
                 <TextField
                   label="field"
@@ -284,12 +303,9 @@ function GridColumnsPropEditor({
                   }
                 />
               </Stack>
-            </DialogContent>
-          </React.Fragment>
-        ) : (
-          <React.Fragment>
-            <DialogTitle>Edit columns</DialogTitle>
-            <DialogContent>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
               <Tooltip describeChild title="Recreate columns">
                 <span>
                   <IconButton
@@ -346,15 +362,10 @@ function GridColumnsPropEditor({
                   );
                 })}
               </List>
-            </DialogContent>
-          </React.Fragment>
-        )}
-        <DialogActions>
-          <Button color="inherit" variant="text" onClick={() => setEditColumnsDialogOpen(false)}>
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
+            </React.Fragment>
+          )}
+        </Box>
+      </Popover>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
Proposal: I'm just replacing the Dialog, the content remains unchanged for now. We can iterate on that later.


https://user-images.githubusercontent.com/2109932/207836659-5f7ad93e-dda3-4cd4-9f0d-fd0cef632140.mov

