### PR TITLE
Fix display of errors during loading of data

### DIFF
--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -68,6 +68,7 @@ import { execDataSourceQuery, useDataQuery, UseDataQueryConfig, UseFetch } from 
 import { useAppContext, AppContextProvider } from './AppContext';
 import { CanvasHooksContext, NavigateToPage } from './CanvasHooksContext';
 import useBoolean from '../utils/useBoolean';
+import { errorFrom } from '../utils/errors';
 
 const ReactQueryDevtoolsProduction = React.lazy(() =>
   import('@tanstack/react-query-devtools/build/lib/index.prod.js').then((d) => ({
@@ -226,7 +227,7 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
       if (errorProp) {
         hookResult[errorProp] = error;
       } else {
-        console.error(error);
+        console.error(errorFrom(error));
       }
     }
 

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -209,10 +209,11 @@ function RenderedNodeContent({ node, childNodeGroups, Component }: RenderedNodeC
       const binding = liveBindings[bindingId];
       if (binding) {
         hookResult[propName] = binding.value;
-        error = error || binding.error;
 
         if (binding.loading && loadingPropSourceSet.has(propName)) {
           loading = true;
+        } else {
+          error = error || binding.error;
         }
       }
 

--- a/test/integration/appDuplicate.spec.ts
+++ b/test/integration/appDuplicate.spec.ts
@@ -4,8 +4,6 @@ import { ToolpadHome } from '../models/ToolpadHome';
 import { ToolpadRuntime } from '../models/ToolpadRuntime';
 import { readJsonFile } from '../utils/fs';
 
-test.use({ ignoreConsoleErrors: [/.*/] });
-
 test('duplicate app from home flow', async ({ page }) => {
   const dom = await readJsonFile(path.resolve(__dirname, './duplicateNavigationDom.json'));
 

--- a/test/integration/duplication/index.spec.ts
+++ b/test/integration/duplication/index.spec.ts
@@ -4,8 +4,6 @@ import { test, expect } from '../../playwright/test';
 import { readJsonFile } from '../../utils/fs';
 import generateId from '../../utils/generateId';
 
-test.use({ ignoreConsoleErrors: [/.*/] });
-
 test('duplication', async ({ page, browserName, api }) => {
   const dom = await readJsonFile(path.resolve(__dirname, './dom.json'));
 

--- a/test/integration/function-basic/index.spec.ts
+++ b/test/integration/function-basic/index.spec.ts
@@ -4,7 +4,16 @@ import { ToolpadRuntime } from '../../models/ToolpadRuntime';
 import { readJsonFile } from '../../utils/fs';
 import generateId from '../../utils/generateId';
 
-test.use({ ignoreConsoleErrors: [/Cannot read properties of null/, /BOOM!/] });
+test.use({
+  ignoreConsoleErrors: [
+    // Chrome:
+    /Cannot read properties of null/,
+    // firefox:
+    /throws\.error is null/,
+    // Intentionally thrown
+    /BOOM!/,
+  ],
+});
 
 test('functions basics', async ({ page, api }) => {
   const dom = await readJsonFile(path.resolve(__dirname, './functionDom.json'));

--- a/test/integration/function-basic/index.spec.ts
+++ b/test/integration/function-basic/index.spec.ts
@@ -4,7 +4,7 @@ import { ToolpadRuntime } from '../../models/ToolpadRuntime';
 import { readJsonFile } from '../../utils/fs';
 import generateId from '../../utils/generateId';
 
-test.use({ ignoreConsoleErrors: [/.*/] });
+test.use({ ignoreConsoleErrors: [/Cannot read properties of null/, /BOOM!/] });
 
 test('functions basics', async ({ page, api }) => {
   const dom = await readJsonFile(path.resolve(__dirname, './functionDom.json'));

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -29,44 +29,20 @@ test('rest basics', async ({ page, browserName, api }) => {
   httpbinConnection.attributes.params.value.baseUrl = HTTPBIN_BASEURL;
 
   const runtimeModel = new ToolpadRuntime(page);
-  // eslint-disable-next-line no-console
-  console.log(0);
   await runtimeModel.gotoPage(app.id, 'page1');
-  // eslint-disable-next-line no-console
-  console.log(1);
   await expect(page.locator('text="query1: query1_value"')).toBeVisible();
-  // eslint-disable-next-line no-console
-  console.log(2);
   await expect(page.locator('text="query2: undefined"')).toBeVisible();
-  // eslint-disable-next-line no-console
-  console.log(3);
   await page.locator('button:has-text("fetch query2")').click();
-  // eslint-disable-next-line no-console
-  console.log(4);
   await expect(page.locator('text="query2: query2_value"')).toBeVisible();
-  // eslint-disable-next-line no-console
-  console.log(5);
   await expect(page.locator('text="browserQuery: browserQuery_value"')).toBeVisible();
-  // eslint-disable-next-line no-console
-  console.log(6);
   await expect(page.locator('text="browserQuery: browserQuery_value"')).toBeVisible();
-  // eslint-disable-next-line no-console
-  console.log(7);
 
   const editorModel = new ToolpadEditor(page, browserName);
   await editorModel.goto(app.id);
-  // eslint-disable-next-line no-console
-  console.log(8);
 
   await editorModel.componentEditor.getByRole('button', { name: 'browserQuery' }).click();
-  // eslint-disable-next-line no-console
-  console.log(9);
   const queryEditor = page.getByRole('dialog', { name: 'browserQuery' });
   await queryEditor.getByRole('button', { name: 'Preview' }).click();
-  // eslint-disable-next-line no-console
-  console.log(10);
   const networkTab = queryEditor.getByRole('tabpanel', { name: 'Network' });
   await expect(networkTab.getByText('/get?browserQuery_param1=browserQuery_value')).not.toBeEmpty();
-  // eslint-disable-next-line no-console
-  console.log(11);
 });

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -14,6 +14,14 @@ if (customHttbinBaseUrl) {
   console.log(`Running tests with custom httpbin service: ${customHttbinBaseUrl}`);
 }
 
+test.use({
+  ignoreConsoleErrors: [
+    // For some reason this shows error in chrome in CI only
+    // Needs to be investigated
+    /Invariant Violation: canvas ref not attached/,
+  ],
+});
+
 const HTTPBIN_BASEURL = customHttbinBaseUrl || 'https://httpbin.org/';
 
 test('rest basics', async ({ page, browserName, api }) => {

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -14,6 +14,8 @@ if (customHttbinBaseUrl) {
   console.log(`Running tests with custom httpbin service: ${customHttbinBaseUrl}`);
 }
 
+const HTTPBIN_BASEURL = customHttbinBaseUrl || 'https://httpbin.org/';
+
 test.use({
   ignoreConsoleErrors: [
     // For some reason this shows error in chrome in CI only
@@ -21,8 +23,6 @@ test.use({
     /Invariant Violation: canvas ref not attached/,
   ],
 });
-
-const HTTPBIN_BASEURL = customHttbinBaseUrl || 'https://httpbin.org/';
 
 test('rest basics', async ({ page, browserName, api }) => {
   const dom = await readJsonFile(path.resolve(__dirname, './restDom.json'));

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as path from 'path';
 import { test, expect } from '../../playwright/test';
 import { ToolpadRuntime } from '../../models/ToolpadRuntime';
@@ -30,32 +29,44 @@ test('rest basics', async ({ page, browserName, api }) => {
   httpbinConnection.attributes.params.value.baseUrl = HTTPBIN_BASEURL;
 
   const runtimeModel = new ToolpadRuntime(page);
+  // eslint-disable-next-line no-console
   console.log(0);
   await runtimeModel.gotoPage(app.id, 'page1');
+  // eslint-disable-next-line no-console
   console.log(1);
   await expect(page.locator('text="query1: query1_value"')).toBeVisible();
+  // eslint-disable-next-line no-console
   console.log(2);
   await expect(page.locator('text="query2: undefined"')).toBeVisible();
+  // eslint-disable-next-line no-console
   console.log(3);
   await page.locator('button:has-text("fetch query2")').click();
+  // eslint-disable-next-line no-console
   console.log(4);
   await expect(page.locator('text="query2: query2_value"')).toBeVisible();
+  // eslint-disable-next-line no-console
   console.log(5);
   await expect(page.locator('text="browserQuery: browserQuery_value"')).toBeVisible();
+  // eslint-disable-next-line no-console
   console.log(6);
   await expect(page.locator('text="browserQuery: browserQuery_value"')).toBeVisible();
+  // eslint-disable-next-line no-console
   console.log(7);
 
   const editorModel = new ToolpadEditor(page, browserName);
   await editorModel.goto(app.id);
+  // eslint-disable-next-line no-console
   console.log(8);
 
   await editorModel.componentEditor.getByRole('button', { name: 'browserQuery' }).click();
+  // eslint-disable-next-line no-console
   console.log(9);
   const queryEditor = page.getByRole('dialog', { name: 'browserQuery' });
   await queryEditor.getByRole('button', { name: 'Preview' }).click();
+  // eslint-disable-next-line no-console
   console.log(10);
   const networkTab = queryEditor.getByRole('tabpanel', { name: 'Network' });
   await expect(networkTab.getByText('/get?browserQuery_param1=browserQuery_value')).not.toBeEmpty();
+  // eslint-disable-next-line no-console
   console.log(11);
 });

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as path from 'path';
 import { test, expect } from '../../playwright/test';
 import { ToolpadRuntime } from '../../models/ToolpadRuntime';
@@ -29,21 +30,32 @@ test('rest basics', async ({ page, browserName, api }) => {
   httpbinConnection.attributes.params.value.baseUrl = HTTPBIN_BASEURL;
 
   const runtimeModel = new ToolpadRuntime(page);
+  console.log(0);
   await runtimeModel.gotoPage(app.id, 'page1');
-
+  console.log(1);
   await expect(page.locator('text="query1: query1_value"')).toBeVisible();
+  console.log(2);
   await expect(page.locator('text="query2: undefined"')).toBeVisible();
+  console.log(3);
   await page.locator('button:has-text("fetch query2")').click();
+  console.log(4);
   await expect(page.locator('text="query2: query2_value"')).toBeVisible();
+  console.log(5);
   await expect(page.locator('text="browserQuery: browserQuery_value"')).toBeVisible();
+  console.log(6);
   await expect(page.locator('text="browserQuery: browserQuery_value"')).toBeVisible();
+  console.log(7);
 
   const editorModel = new ToolpadEditor(page, browserName);
   await editorModel.goto(app.id);
+  console.log(8);
 
   await editorModel.componentEditor.getByRole('button', { name: 'browserQuery' }).click();
+  console.log(9);
   const queryEditor = page.getByRole('dialog', { name: 'browserQuery' });
   await queryEditor.getByRole('button', { name: 'Preview' }).click();
+  console.log(10);
   const networkTab = queryEditor.getByRole('tabpanel', { name: 'Network' });
   await expect(networkTab.getByText('/get?browserQuery_param1=browserQuery_value')).not.toBeEmpty();
+  console.log(11);
 });

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -16,8 +16,6 @@ if (customHttbinBaseUrl) {
 
 const HTTPBIN_BASEURL = customHttbinBaseUrl || 'https://httpbin.org/';
 
-test.use({ ignoreConsoleErrors: [/.*/] });
-
 test('rest basics', async ({ page, browserName, api }) => {
   const dom = await readJsonFile(path.resolve(__dirname, './restDom.json'));
 

--- a/test/playwright/test.ts
+++ b/test/playwright/test.ts
@@ -29,8 +29,6 @@ export const test = base.extend<Options & { api: RpcClient<ServerDefinition> }>(
     const entryPromises: Promise<ConsoleEntry>[] = [];
 
     const consoleHandler = (msg: ConsoleMessage) => {
-      // eslint-disable-next-line no-console
-      console.log(`console: ${msg.text()}`);
       entryPromises.push(
         Promise.all(
           msg.args().map(async (argHandle) => argHandle.jsonValue().catch(() => '<circular>')),

--- a/test/playwright/test.ts
+++ b/test/playwright/test.ts
@@ -52,7 +52,12 @@ export const test = base.extend<Options & { api: RpcClient<ServerDefinition> }>(
     const entries = await Promise.all(entryPromises);
     const ignoredEntries = [...IGNORED_ERRORS, ...ignoreConsoleErrors];
     for (const entry of entries) {
-      if (entry.type === 'error' && !ignoredEntries.some((regex) => regex.test(entry.text))) {
+      if (
+        entry.type === 'error' &&
+        !ignoredEntries.some(
+          (regex) => regex.test(entry.text) || entry.args.some((arg) => regex.test(arg)),
+        )
+      ) {
         // Currently a catch-all for console error messages. Expecting us to add a way of blacklisting
         // expected error messages at some point here
         throw new Error(`Console error message detected\n${JSON.stringify(entry, null, 2)}`);

--- a/test/playwright/test.ts
+++ b/test/playwright/test.ts
@@ -29,6 +29,8 @@ export const test = base.extend<Options & { api: RpcClient<ServerDefinition> }>(
     const entryPromises: Promise<ConsoleEntry>[] = [];
 
     const consoleHandler = (msg: ConsoleMessage) => {
+      // eslint-disable-next-line no-console
+      console.log(`console: ${msg.text()}`);
       entryPromises.push(
         Promise.all(
           msg.args().map(async (argHandle) => argHandle.jsonValue().catch(() => '<circular>')),


### PR DESCRIPTION
Our expressions evaluate to values with 3 states:
* loading
* error
* resolved

When the `rows` property of the datagrid uses any value that is in loading state, it itself should resolve as "loading" and show the grid in loading state instead of error.

I sharpened the integration test to detect the behavior

before:

https://user-images.githubusercontent.com/2109932/207881467-b344ed8b-ea00-44ae-9377-030d74a8bb84.mov

after:

https://user-images.githubusercontent.com/2109932/207881536-0baea6cd-599b-4d2b-8ec8-065f86b735f7.mov

