### PR TITLE
Debounce text input changes

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -148,8 +148,8 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
 
     const handleRuntimeEvent = useEvent(onRuntimeEvent);
 
-    const iframeKeyDownHandler = React.useCallback(() => {
-      return (event: KeyboardEvent) => {
+    const keyDownHandler = React.useCallback(
+      (event: KeyboardEvent) => {
         const isZ = event.key.toLowerCase() === 'z';
 
         const undoShortcut = isZ && (event.metaKey || event.ctrlKey);
@@ -160,8 +160,9 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
         } else if (undoShortcut) {
           domApi.undo();
         }
-      };
-    }, [domApi]);
+      },
+      [domApi],
+    );
 
     const handleFrameLoad = React.useCallback(() => {
       invariant(frameRef.current, 'Iframe ref not attached');
@@ -173,13 +174,11 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
         return;
       }
 
-      const keyDownHandler = iframeKeyDownHandler();
-
       iframeWindow?.addEventListener('keydown', keyDownHandler);
       iframeWindow?.addEventListener('unload', () => {
         iframeWindow?.removeEventListener('keydown', keyDownHandler);
       });
-    }, [iframeKeyDownHandler]);
+    }, [keyDownHandler]);
 
     React.useEffect(() => {
       if (!contentWindow) {

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -156,8 +156,10 @@ export default React.forwardRef<EditorCanvasHostHandle, EditorCanvasHostProps>(
         const redoShortcut = undoShortcut && event.shiftKey;
 
         if (redoShortcut) {
+          event.preventDefault();
           domApi.redo();
         } else if (undoShortcut) {
+          event.preventDefault();
           domApi.undo();
         }
       },

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
@@ -14,7 +14,6 @@ import usePageTitle from '../../../utils/usePageTitle';
 import useLocalStorageState from '../../../utils/useLocalStorageState';
 import useDebouncedHandler from '../../../utils/useDebouncedHandler';
 import useShortcut from '../../../utils/useShortcut';
-import { hasFieldFocus } from '../../../utils/fields';
 
 const classes = {
   renderPanel: 'Toolpad_RenderPanel',
@@ -77,15 +76,9 @@ export default function PageEditor({ appId }: PageEditorProps) {
   const pageNode = appDom.getMaybeNode(dom, nodeId as NodeId, 'page');
 
   useShortcut({ key: 'z', metaKey: true, preventDefault: false }, () => {
-    if (hasFieldFocus()) {
-      return;
-    }
     domApi.undo();
   });
   useShortcut({ key: 'z', metaKey: true, shiftKey: true, preventDefault: false }, () => {
-    if (hasFieldFocus()) {
-      return;
-    }
     domApi.redo();
   });
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
@@ -75,10 +75,10 @@ export default function PageEditor({ appId }: PageEditorProps) {
   const { nodeId } = useParams();
   const pageNode = appDom.getMaybeNode(dom, nodeId as NodeId, 'page');
 
-  useShortcut({ key: 'z', metaKey: true, preventDefault: false }, () => {
+  useShortcut({ key: 'z', metaKey: true, preventDefault: true }, () => {
     domApi.undo();
   });
-  useShortcut({ key: 'z', metaKey: true, shiftKey: true, preventDefault: false }, () => {
+  useShortcut({ key: 'z', metaKey: true, shiftKey: true, preventDefault: true }, () => {
     domApi.redo();
   });
 

--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -385,7 +385,7 @@ export default function DomProvider({ appId, children }: DomContextProps) {
       });
   }, [appId, state]);
 
-  const debouncedHandleSave = useDebouncedHandler(handleSave, 1000);
+  const debouncedHandleSave = useDebouncedHandler(handleSave, 500);
 
   React.useEffect(() => {
     debouncedHandleSave();

--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -340,7 +340,7 @@ export default function DomProvider({ appId, children }: DomContextProps) {
     () =>
       debounce(() => {
         dispatch({ type: 'DOM_UPDATE_HISTORY' });
-      }, 1000),
+      }, 500),
     [],
   );
 

--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -385,7 +385,7 @@ export default function DomProvider({ appId, children }: DomContextProps) {
       });
   }, [appId, state]);
 
-  const debouncedHandleSave = useDebouncedHandler(handleSave, 500);
+  const debouncedHandleSave = useDebouncedHandler(handleSave, 1000);
 
   React.useEffect(() => {
     debouncedHandleSave();

--- a/test/integration/undo-redo/index.spec.ts
+++ b/test/integration/undo-redo/index.spec.ts
@@ -68,7 +68,7 @@ test('test batching text input actions into single undo entry', async ({
   await page.keyboard.type('some value');
 
   // Wait for undo stack to be updated
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(500);
 
   await page.keyboard.type(' hello');
 
@@ -77,7 +77,7 @@ test('test batching text input actions into single undo entry', async ({
   await expect(input).toHaveValue('some value hello');
 
   // Wait for undo stack to be updated
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(500);
 
   // Undo changes
   await page.keyboard.press('Control+Z');

--- a/test/integration/undo-redo/index.spec.ts
+++ b/test/integration/undo-redo/index.spec.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { ToolpadEditor } from '../../models/ToolpadEditor';
 import { test, expect } from '../../playwright/test';
 import { readJsonFile } from '../../utils/fs';
+import clickCenter from '../../utils/clickCenter';
 import generateId from '../../utils/generateId';
 
 test('test basic undo and redo', async ({ page, browserName, api }) => {
@@ -40,4 +41,47 @@ test('test basic undo and redo', async ({ page, browserName, api }) => {
 
   // Redo should bring back text field
   await expect(canvasInputLocator).toHaveCount(3);
+});
+
+test('test batching text input actions into single undo entry', async ({
+  page,
+  browserName,
+  api,
+}) => {
+  const dom = await readJsonFile(path.resolve(__dirname, './dom.json'));
+
+  const app = await api.mutation.createApp(`App ${generateId()}`, {
+    from: { kind: 'dom', dom },
+  });
+
+  const editorModel = new ToolpadEditor(page, browserName);
+  await editorModel.goto(app.id);
+
+  await editorModel.waitForOverlay();
+
+  const input = editorModel.appCanvas.locator('input').first();
+
+  clickCenter(page, input);
+
+  await editorModel.componentEditor.getByLabel('defaultValue').click();
+
+  await page.keyboard.type('some value');
+
+  // Wait for undo stack to be updated
+  await page.waitForTimeout(1000);
+
+  await page.keyboard.type(' hello');
+
+  await editorModel.componentEditor.getByLabel('defaultValue').blur();
+
+  await expect(input).toHaveValue('some value hello');
+
+  // Wait for undo stack to be updated
+  await page.waitForTimeout(1000);
+
+  // Undo changes
+  await page.keyboard.press('Control+Z');
+
+  // Asssert that batched changes were reverted
+  await expect(input).toHaveValue('some value');
 });


### PR DESCRIPTION
I think that a simple debounce should work for now, as per the benchmark in https://github.com/mui/mui-toolpad/issues/226.
Also we can just override the native undo/redo in text inputs with our own logic to make things more controllable and predictable?

Will merge this branch into the atomic undo/redo already if CI passes, as this PR is pretty small.