### PR TITLE
Non permanent root redirection

### DIFF
--- a/packages/toolpad-app/pages/index.tsx
+++ b/packages/toolpad-app/pages/index.tsx
@@ -2,7 +2,7 @@ import type { GetServerSideProps } from 'next';
 
 export const getServerSideProps: GetServerSideProps<{}> = async () => {
   return {
-    redirect: { destination: '/_toolpad', permanent: true },
+    redirect: { destination: '/_toolpad', permanent: false },
   };
 };
 


### PR DESCRIPTION
I saw that https://demo.toolpad.io/ is a 308 to https://demo.toolpad.io/_toolpad in an SEO crawl. I wonder if this isn't too bold, maybe a 307 would keep our option more often in the future. We could also make the argument that it doesn't matter. 