### PR TITLE
Fix flaky rest-basics test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,14 +181,7 @@ jobs:
             # See https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command
             TAG=$CIRCLE_SHA1 docker-compose -f ./docker-compose.test.yml up -d
             yarn workspace @mui/toolpad-app waitForApp --url=http://172.17.0.1:3000/
-            docker run -it --rm \
-              --ipc=host \
-              -v "$CIRCLE_WORKING_DIRECTORY:/tests" \
-              -w /tests \
-              -e PLAYWRIGHT_TEST_BASE_URL=http://172.17.0.1:3000/ \
-              -e HTTPBIN_BASEURL=http://httpbin/ \
-              mcr.microsoft.com/playwright:v1.29.0-focal \
-              yarn test:integration --forbid-only
+            docker-compose -f ./docker-compose.test.yml run -it --rm playwright yarn test:integration --forbid-only
             docker-compose -f ./docker-compose.test.yml logs toolpad
             docker-compose -f ./docker-compose.test.yml down
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If you would like to hack on MUI Toolpad or want to run the latest version, you 
    TOOLPAD_DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
    # For a custom port:
    # PORT=3004
-   # EXTERNAL_URL=http://localhost:3004/
+   # TOOLPAD_EXTERNAL_URL=http://localhost:3004/
    ```
 
 1. Now you can run the MUI Toolpad dev command to start the application

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.9'
 
 services:
   toolpad:
@@ -7,10 +7,11 @@ services:
       - TOOLPAD_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres?connect_timeout=10
       - TOOLPAD_ENABLE_CREATE_BY_DOM=1
       - PORT=3000
-      - EXTERNAL_URL=http://localhost:3000/
-      - TOOLPAD_EXTERNAL_URL=http://172.17.0.1:3000/
+      - TOOLPAD_EXTERNAL_URL=http://toolpad:3000/
     ports:
       - '3000:3000'
+    depends_on:
+      - postgres
 
   postgres:
     image: postgres:14.5
@@ -29,3 +30,15 @@ services:
     image: kennethreitz/httpbin
     ports:
       - '80'
+
+  playwright:
+    profiles:
+      - test
+    image: mcr.microsoft.com/playwright:v1.29.0-focal
+    environment:
+      - PLAYWRIGHT_TEST_BASE_URL=http://toolpad:3000/
+      - HTTPBIN_BASEURL=http://httpbin/
+    working_dir: /tests
+    volumes:
+      - .:/tests
+    command: yarn test:integration --forbid-only

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - TOOLPAD_DATABASE_URL=postgresql://toolpad-app:secretpw@postgres:5432/postgres?connect_timeout=10
       - PORT=3000
-      - EXTERNAL_URL=http://localhost:3000/
+      - TOOLPAD_EXTERNAL_URL=http://localhost:3000/
     ports:
       - '3000:3000'
 

--- a/packages/toolpad-app/src/server/appTemplateDoms/doms.ts
+++ b/packages/toolpad-app/src/server/appTemplateDoms/doms.ts
@@ -17,9 +17,8 @@ const appTemplates: Record<AppTemplateId, () => Promise<appDom.AppDom | null>> =
     getAppTemplateDomFromPath(config.isDemo ? './images-demo.json' : './images.json'),
   default: async () => {
     const template = await getAppTemplateDomFromPath('./default.json');
-    (
-      template.nodes['1313wn3' as NodeId] as appDom.QueryNode
-    ).attributes.query.value.url.value = `${config.externalUrl}/static/employees.json`;
+    (template.nodes['1313wn3' as NodeId] as appDom.QueryNode).attributes.query.value.url.value =
+      new URL('/static/employees.json', config.externalUrl).href;
     return template;
   },
 };

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -14,7 +14,8 @@ if (customHttbinBaseUrl) {
   console.log(`Running tests with custom httpbin service: ${customHttbinBaseUrl}`);
 }
 
-const HTTPBIN_BASEURL = customHttbinBaseUrl || 'https://httpbin.org/';
+const HTTPBIN_SOURCE_URL = 'https://httpbin.org/';
+const HTTPBIN_TARGET_URL = customHttbinBaseUrl || HTTPBIN_SOURCE_URL;
 
 test.use({
   ignoreConsoleErrors: [
@@ -25,16 +26,16 @@ test.use({
 });
 
 test('rest basics', async ({ page, browserName, api }) => {
-  const dom = await readJsonFile(path.resolve(__dirname, './restDom.json'));
+  const dom = await readJsonFile(path.resolve(__dirname, './restDom.json'), (key, value) => {
+    if (typeof value === 'string') {
+      return value.replaceAll(HTTPBIN_SOURCE_URL, HTTPBIN_TARGET_URL);
+    }
+    return value;
+  });
 
   const app = await api.mutation.createApp(`App ${generateId()}`, {
     from: { kind: 'dom', dom },
   });
-
-  const httpbinConnection: any = Object.values(dom.nodes).find(
-    (node: any) => node.name === 'httpbin',
-  );
-  httpbinConnection.attributes.params.value.baseUrl = HTTPBIN_BASEURL;
 
   const runtimeModel = new ToolpadRuntime(page);
   await runtimeModel.gotoPage(app.id, 'page1');

--- a/test/utils/fs.ts
+++ b/test/utils/fs.ts
@@ -1,9 +1,8 @@
 import * as fs from 'fs/promises';
 
-export async function readJsonFile(
-  path: string,
-  reviver?: (this: any, key: string, value: any) => any,
-): Promise<any> {
+export type Reviver = NonNullable<Parameters<typeof JSON.parse>[1]>;
+
+export async function readJsonFile(path: string, reviver?: Reviver): Promise<any> {
   const content = await fs.readFile(path, { encoding: 'utf-8' });
   return JSON.parse(content, reviver);
 }

--- a/test/utils/fs.ts
+++ b/test/utils/fs.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs/promises';
 
-export async function readJsonFile(path: string): Promise<any> {
+export async function readJsonFile(
+  path: string,
+  reviver?: (this: any, key: string, value: any) => any,
+): Promise<any> {
   const content = await fs.readFile(path, { encoding: 'utf-8' });
-  return JSON.parse(content);
+  return JSON.parse(content, reviver);
 }


### PR DESCRIPTION
Part of the rest-basics test is still trying to access httpbin.org instead of our own hosted instance. This leads to flaky tests as in https://app.circleci.com/pipelines/github/mui/mui-toolpad/5219/workflows/f98e7c8d-ff94-48c5-a47b-488ae4c8090f/jobs/21186

In this PR I'm making sure that
- All httpbin urls point to our own instance
- Both playwright and toolpad container can access the httpbin service under the same host 