### PR TITLE
Fix: Demo reCaptcha v2 fallback does not work

### DIFF
--- a/packages/toolpad-app/src/toolpad/Apps/index.tsx
+++ b/packages/toolpad-app/src/toolpad/Apps/index.tsx
@@ -151,7 +151,7 @@ function CreateAppDialog({
   const [name, setName] = React.useState('');
   const [appTemplateId, setAppTemplateId] = React.useState<AppTemplateId>('default');
   const [dom, setDom] = React.useState('');
-  const [recaptachaApiLoaded, setRecaptachaApiLoaded] = React.useState(false);
+  const [recaptchaApiLoaded, setRecaptchaApiLoaded] = React.useState(false);
   const [requestRecaptchaV2, setRequestRecaptchaV2] = React.useState(false);
   const [recaptchaV2Token, setRecaptchaV2Token] = React.useState('');
 
@@ -214,7 +214,7 @@ function CreateAppDialog({
 
   const recaptchaSubmitEnabled =
     config.recaptchaV2SiteKey || config.recaptchaV3SiteKey
-      ? recaptachaApiLoaded && ((requestRecaptchaV2 && recaptchaV2Token) || !requestRecaptchaV2)
+      ? recaptchaApiLoaded && ((requestRecaptchaV2 && recaptchaV2Token) || !requestRecaptchaV2)
       : true;
 
   const handleSubmit = React.useCallback(
@@ -223,7 +223,9 @@ function CreateAppDialog({
 
       event.preventDefault();
 
-      // Check if captcha checkbox was solved
+      // Fallback: request validation with RecaptchaV2 instead, so requestRecaptchaV2 will be true
+
+      // Check if this is the fallback scenario
       let recaptchaToken = requestRecaptchaV2 ? recaptchaV2Token : '';
 
       if (config.recaptchaV3SiteKey && !requestRecaptchaV2) {
@@ -263,7 +265,7 @@ function CreateAppDialog({
       } catch (rawError) {
         const error = errorFrom(rawError);
         if (config.recaptchaV2SiteKey && error.code === ERR_VALIDATE_CAPTCHA_FAILED) {
-          // Show captcha checkbox
+          // Show recaptcha v2 checkbox as a fallback
           setRequestRecaptchaV2(true);
         } else {
           throw error;
@@ -304,7 +306,7 @@ function CreateAppDialog({
                   },
                 });
               }
-              setRecaptachaApiLoaded(true);
+              setRecaptchaApiLoaded(true);
             });
           }}
         />

--- a/packages/toolpad-app/src/utils/errors.ts
+++ b/packages/toolpad-app/src/utils/errors.ts
@@ -3,8 +3,8 @@ import { hasOwnProperty } from './collections';
 import { truncate } from './strings';
 
 export function serializeError(error: Error): SerializedError {
-  const { message, name, stack } = error;
-  return { message, name, stack };
+  const { message, name, stack, code } = error;
+  return { message, name, stack, code };
 }
 
 /**

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -306,6 +306,7 @@ export interface SerializedError {
   message: string;
   name: string;
   stack?: string;
+  code?: unknown;
 }
 
 export type ExecFetchResult<T = any> = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


There is a fallback reCaptcha v2 verification present in the demo, which loads if the reCaptcha v3 verification fails. However, this fallback UI will not load at all (due to a bug in the way errors are being sent to the client), resulting in a user getting stuck.


Adding `code` to `SerializedError` allows the `code` to be present in the error on the client, and the fallback scenario to be handled.

- Visual demonstration 

Before

https://user-images.githubusercontent.com/19550456/209332323-fb3fb9a5-db15-46b6-b6f3-47d8690e4622.mov


After

https://user-images.githubusercontent.com/19550456/209332914-36652901-d250-4846-bd2f-3ad4cdfe99e3.mov


Next step is to add an integration test to verify that the captcha checkbox loads in case the reCaptcha v3 verification fails.




