### PR TITLE
add manifests to deploy toolpad on kubernetes

### DIFF
--- a/docs/data/toolpad/getting-started/installation.md
+++ b/docs/data/toolpad/getting-started/installation.md
@@ -25,3 +25,39 @@
    ```
 
 1. Build and deploy applications on http://localhost:3000/.
+
+## With Kubernetes
+
+### Prerequisites
+
+- A Kubernetes cluster (a local one via `kind` or a remote one)
+- The `kind` command line tool installed on your machine. Follow the [official instructions](https://kind.sigs.k8s.io/docs/user/quick-start/) to install `kind`.
+- The `kubectl` command line tool installed on your machine. Follow the [official instructions](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to install `kubectl`.
+
+### Steps
+
+1. Download the Toolpad Kubernetes manifest file:
+
+   ```sh
+   curl -LO https://raw.githubusercontent.com/mui/mui-toolpad/master/kubernetes/toolpad.yml
+   ```
+
+1. Create a Kubernetes cluster with `kind`:
+
+   ```sh
+   kind create cluster
+   ```
+
+1. Deploy Toolpad to the cluster using `kubectl`:
+
+   ```sh
+   kubectl apply -f kubernetes/toolpad.yaml
+   ```
+
+1. Forward a local port to the Toolpad application server:
+
+   ```sh
+   kubectl -n toolpad port-forward deployment/toolpad 3000:3000
+   ```
+
+1. Browse at http://localhost:3000/.

--- a/kubernetes/toolpad.yaml
+++ b/kubernetes/toolpad.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: toolpad
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: toolpad
+  labels:
+    app: postgres
+spec:
+  ports:
+    - port: 5432
+      name: postgres
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: toolpad
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:14.5
+          env:
+            - name: POSTGRES_USER
+              value: toolpad-app
+            - name: POSTGRES_PASSWORD
+              value: secretpw
+          ports:
+            - containerPort: 5432
+              name: postgres
+          volumeMounts:
+            - name: postgres-persistent-storage
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-persistent-storage
+      spec:
+        accessModes: ['ReadWriteOnce']
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: toolpad
+  namespace: toolpad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: toolpad
+  template:
+    metadata:
+      labels:
+        app: toolpad
+    spec:
+      containers:
+        - name: toolpad
+          image: muicom/toolpad:latest
+          env:
+            - name: TOOLPAD_DATABASE_URL
+              value: postgresql://toolpad-app:secretpw@postgres:5432/postgres?connect_timeout=10
+            - name: PORT
+              value: '3000'
+            - name: TOOLPAD_EXTERNAL_URL
+              value: http://localhost:3000/
+          ports:
+            - containerPort: 3000
+              name: toolpad


### PR DESCRIPTION
Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes https://github.com/mui/mui-toolpad/issues/1495

Deployment tested on a local KIND cluster.
![image](https://user-images.githubusercontent.com/10666/209467674-b73fb8cf-bd67-4a70-bd84-0272bd2b33c2.png)

How to test this PR:
- `kind create cluster`
- `kubectl apply -f kubernetes/toolpad.yaml`
- `kubectl -n toolpad port-forward deployment/toolpad 3000:3000`
- Browse http://localhost:3000