### PR TITLE
Make sure npm package is splitted out correctly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,8 @@
     },
     {
       "groupName": "playwright",
-      "matchPackageNames": ["playwright", "^@playwright/", "mcr.microsoft.com/playwright"]
+      "matchPackageNames": ["playwright", "mcr.microsoft.com/playwright"],
+      "matchPackagePatterns": ["^@playwright/"]
     },
     {
       "groupName": "node",


### PR DESCRIPTION
There was a pattern used under `packageNames`.
This should help with https://github.com/mui/mui-toolpad/pull/1494#issuecomment-1364635127