### PR TITLE
Just re-export the prettier config

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,3 @@
 const baseline = require('@mui/monorepo/prettier.config');
 
-module.exports = {
-  ...baseline,
-  overrides: [...baseline.overrides],
-};
+module.exports = baseline;


### PR DESCRIPTION
Not necessary anymore after https://github.com/mui/mui-toolpad/commit/c1a68abb199dd5c1e7fc8c472cf6a4d706944a41