### PR TITLE
Do not rename nodes when migrating Typography components

### DIFF
--- a/packages/toolpad-app/src/appDom/migrations/v4.ts
+++ b/packages/toolpad-app/src/appDom/migrations/v4.ts
@@ -6,7 +6,6 @@ function replaceTypographyWithText(node: appDom.AppDomNode): appDom.AppDomNode {
   if (node.type === 'element' && node.attributes.component.value === 'Typography') {
     return {
       ...node,
-      name: node.name.replace(/Typography|Link/gi, 'text'),
       attributes: {
         component: {
           ...node.attributes.component,

--- a/packages/toolpad-app/src/appDom/migrations/v5.ts
+++ b/packages/toolpad-app/src/appDom/migrations/v5.ts
@@ -6,7 +6,6 @@ function replaceLinkWithText(node: appDom.AppDomNode): appDom.AppDomNode {
   if (node.type === 'element' && node.attributes.component.value === 'Link') {
     return {
       ...node,
-      name: node.name.replace(/Link/gi, 'text'),
       attributes: {
         component: {
           ...node.attributes.component,


### PR DESCRIPTION
This would break bindings that reference it.