### PR TITLE
Restructure installation docs

### DIFF
--- a/docs/data/toolpad/getting-started/installation.md
+++ b/docs/data/toolpad/getting-started/installation.md
@@ -2,26 +2,26 @@
 
 <p class="description">Setup Toolpad to run on your own machine.</p>
 
-## Installing Docker
+## With Docker
 
-In order to run Toolpad you will need to have Docker set up on your machine. Follow [official instructions](https://www.docker.com/get-started/) to get started.
+### Prerequisites
 
-## Downloading Toolpad
+- A Docker and Docker Compose installation. Follow [official instructions](https://www.docker.com/get-started/) to get started.
 
-Toolpad runs inside a docker container so you first need to download the docker compose file. Run following command in your terminal:
+### Steps
 
-```sh
-curl -LO https://raw.githubusercontent.com/mui/mui-toolpad/master/docker/compose/docker-compose.yml
-```
+1. Download our basic Docker Compose configuration:
 
-## Running Toolpad
+   ```sh
+   curl -LO https://raw.githubusercontent.com/mui/mui-toolpad/master/docker/compose/docker-compose.yml
+   ```
 
-Now you need to run the docker container by running the following command:
+   This file contains a basic configuration, setting up a database and the Toolpad application server. You can use it as a starting point or for local development.
 
-```sh
-docker-compose -f docker-compose.yml up -d
-```
+2. Run the docker compose services with:
 
-## Opening Toolpad
+   ```sh
+   docker-compose -f docker-compose.yml up -d
+   ```
 
-You should now be able to open Toolpad on http://localhost:3000/.
+3. Build and deploy applications on http://localhost:3000/.

--- a/docs/data/toolpad/getting-started/installation.md
+++ b/docs/data/toolpad/getting-started/installation.md
@@ -18,10 +18,10 @@
 
    This file contains a basic configuration, setting up a database and the Toolpad application server. You can use it as a starting point or for local development.
 
-2. Run the docker compose services with:
+1. Run the docker compose services with:
 
    ```sh
    docker-compose -f docker-compose.yml up -d
    ```
 
-3. Build and deploy applications on http://localhost:3000/.
+1. Build and deploy applications on http://localhost:3000/.


### PR DESCRIPTION
Restructure so that we can add instructions for other installation targets, e.g.

- With Kubernetes (https://github.com/mui/mui-toolpad/pull/1496)
- With render.com
- With Heroku
- With AWS
- ...

The idea is to have a section per target. And under each section we have
- prerequisites: This is what is expected to be there at the start, with external links on how to set it up
- steps: short step by steps explaining how to download and deploy Toolpad for this target