### PR TITLE
Correct types in Datepicker

### DIFF
--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -14,6 +14,7 @@ export interface Props extends DesktopDatePickerProps<string, Dayjs> {
   variant: 'outlined' | 'filled' | 'standard';
   size: 'small' | 'medium';
   sx: any;
+  defaultValue: string;
 }
 
 function DatePicker(props: Props) {
@@ -61,7 +62,6 @@ export default createComponent(DatePicker, {
       },
       defaultValue: '',
     },
-    // @ts-ignore no idea why it complains even though it's done exactly same as TextField
     defaultValue: {
       typeDef: { type: 'string' },
       defaultValue: '',

--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -8,7 +8,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { createComponent } from '@mui/toolpad-core';
 import { Dayjs } from 'dayjs';
 
-export interface Props extends DesktopDatePickerProps<string, Dayjs> {
+export interface DatePickerProps extends DesktopDatePickerProps<string, Dayjs> {
   format: string;
   fullWidth: boolean;
   variant: 'outlined' | 'filled' | 'standard';
@@ -17,7 +17,7 @@ export interface Props extends DesktopDatePickerProps<string, Dayjs> {
   defaultValue: string;
 }
 
-function DatePicker(props: Props) {
+function DatePicker(props: DatePickerProps) {
   const customProps: any = {};
 
   if (props.format) {


### PR DESCRIPTION
The types of `argTypes` is derived from the type of the component properties. 

