### PR TITLE
Remove obsolete dom reducer actions

### DIFF
--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -26,7 +26,7 @@ export const RESERVED_NODE_PROPERTIES = [
   'parentProp',
   'parentIndex',
 ] as const;
-export type ReservedNodeProperty = typeof RESERVED_NODE_PROPERTIES[number];
+export type ReservedNodeProperty = (typeof RESERVED_NODE_PROPERTIES)[number];
 
 export function createFractionalIndex(index1: string | null, index2: string | null) {
   return generateKeyBetween(index1, index2);
@@ -1031,7 +1031,7 @@ const RENDERTREE_NODES = [
   'codeComponent',
 ] as const;
 
-export type RenderTreeNodeType = typeof RENDERTREE_NODES[number];
+export type RenderTreeNodeType = (typeof RENDERTREE_NODES)[number];
 export type RenderTreeNode = { [K in RenderTreeNodeType]: AppDomNodeOfType<K> }[RenderTreeNodeType];
 export type RenderTreeNodes = Record<NodeId, RenderTreeNode>;
 

--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -742,21 +742,6 @@ export function setNodeNamespacedProp<
   });
 }
 
-export function setNodeNamespace<Node extends AppDomNode, Namespace extends PropNamespaces<Node>>(
-  dom: AppDom,
-  node: Node,
-  namespace: Namespace,
-  value: Node[Namespace] | null,
-): AppDom {
-  return update(dom, {
-    nodes: update(dom.nodes, {
-      [node.id]: update(node, {
-        [namespace]: value ? (value as Partial<Node[Namespace]>) : {},
-      } as Partial<Node>),
-    }),
-  });
-}
-
 function setNodeParent<N extends AppDomNode>(
   dom: AppDom,
   node: N,

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeDropArea.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeDropArea.tsx
@@ -129,7 +129,7 @@ function getChildNodeHighlightedZone(parentFlowDirection: FlowDirection): DropZo
 
 function getHighlightedZoneOverlayClass(
   highlightedZone: DropZone,
-): typeof dropAreaHighlightClasses[keyof typeof dropAreaHighlightClasses] | null {
+): (typeof dropAreaHighlightClasses)[keyof typeof dropAreaHighlightClasses] | null {
   switch (highlightedZone) {
     case DROP_ZONE_TOP:
       return dropAreaHighlightClasses.highlightedTop;

--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NodeId, BindableAttrValues, createProvidedContext } from '@mui/toolpad-core';
+import { NodeId, createProvidedContext } from '@mui/toolpad-core';
 import invariant from 'invariant';
 import { debounce, DebouncedFunc } from 'lodash-es';
 import * as appDom from '../appDom';
@@ -45,17 +45,6 @@ export type DomAction =
       error: string;
     }
   | {
-      type: 'DOM_SET_NODE_NAME';
-      nodeId: NodeId;
-      name: string;
-    }
-  | {
-      type: 'DOM_SET_NODE_NAMESPACE';
-      node: appDom.AppDomNode;
-      namespace: string;
-      value: BindableAttrValues | null;
-    }
-  | {
       type: 'DOM_UPDATE';
       updater: (dom: appDom.AppDom) => appDom.AppDom;
       selectedNodeId?: NodeId | null;
@@ -70,10 +59,6 @@ export type DomAction =
       tab: ComponentPanelTab;
     }
   | {
-      type: 'DOM_SAVE_NODE';
-      node: appDom.AppDomNode;
-    }
-  | {
       type: 'SELECT_NODE';
       nodeId: NodeId;
     }
@@ -83,19 +68,8 @@ export type DomAction =
 
 export function domReducer(dom: appDom.AppDom, action: DomAction): appDom.AppDom {
   switch (action.type) {
-    case 'DOM_SET_NODE_NAME': {
-      // TODO: Also update all bindings on the page that use this name
-      const node = appDom.getNode(dom, action.nodeId);
-      return appDom.setNodeName(dom, node, action.name);
-    }
-    case 'DOM_SET_NODE_NAMESPACE': {
-      return appDom.setNodeNamespace<any, any>(dom, action.node, action.namespace, action.value);
-    }
     case 'DOM_UPDATE': {
       return action.updater(dom);
-    }
-    case 'DOM_SAVE_NODE': {
-      return appDom.saveNode(dom, action.node);
     }
     default:
       return dom;
@@ -255,7 +229,13 @@ function createDomApi(
       dispatch({ type: 'DOM_REDO' });
     },
     setNodeName(nodeId: NodeId, name: string) {
-      dispatch({ type: 'DOM_SET_NODE_NAME', nodeId, name });
+      dispatch({
+        type: 'DOM_UPDATE',
+        updater(dom) {
+          const node = appDom.getNode(dom, nodeId);
+          return appDom.setNodeName(dom, node, name);
+        },
+      });
     },
     update(
       updater: (dom: appDom.AppDom) => appDom.AppDom,
@@ -284,8 +264,10 @@ function createDomApi(
     },
     saveNode(node: appDom.AppDomNode) {
       dispatch({
-        type: 'DOM_SAVE_NODE',
-        node,
+        type: 'DOM_UPDATE',
+        updater(dom) {
+          return appDom.saveNode(dom, node);
+        },
       });
     },
     setNodeNamespace<Node extends appDom.AppDomNode, Namespace extends appDom.PropNamespaces<Node>>(
@@ -294,10 +276,10 @@ function createDomApi(
       value: Node[Namespace] | null,
     ) {
       dispatch({
-        type: 'DOM_SET_NODE_NAMESPACE',
-        namespace,
-        node,
-        value: value as BindableAttrValues | null,
+        type: 'DOM_UPDATE',
+        updater(dom) {
+          return appDom.setNodeNamespace(dom, node, namespace, value);
+        },
       });
     },
     selectNode(nodeId: NodeId) {
@@ -381,13 +363,14 @@ export interface DomContextProps {
   children?: React.ReactNode;
 }
 
-const SKIP_UNDO_ACTIONS = new Set([
-  'DOM_UPDATE_HISTORY',
-  'DOM_UNDO',
-  'DOM_REDO',
-  'DOM_SAVED',
-  'DOM_SAVING',
-  'DOM_SAVING_ERROR',
+type DomActionType = DomAction['type'];
+
+const UNDOABLE_ACTIONS = new Set<DomActionType>([
+  'DOM_UPDATE',
+  'DOM_SET_VIEW',
+  'DOM_SET_TAB',
+  'SELECT_NODE',
+  'DESELECT_NODE',
 ]);
 
 export default function DomProvider({ appId, children }: DomContextProps) {
@@ -424,22 +407,15 @@ export default function DomProvider({ appId, children }: DomContextProps) {
     [],
   );
 
-  const scheduleHistoryUpdate = React.useMemo(
-    () => () => {
-      if (!hasFieldFocus()) {
-        dispatch({ type: 'DOM_UPDATE_HISTORY' });
-      } else {
-        scheduleTextInputHistoryUpdate();
-      }
-    },
-    [scheduleTextInputHistoryUpdate],
-  );
-
   const dispatchWithHistory = useEvent((action: DomAction) => {
     dispatch(action);
 
-    if (!SKIP_UNDO_ACTIONS.has(action.type)) {
-      scheduleHistoryUpdate();
+    if (UNDOABLE_ACTIONS.has(action.type)) {
+      if (hasFieldFocus()) {
+        scheduleTextInputHistoryUpdate();
+      } else {
+        dispatch({ type: 'DOM_UPDATE_HISTORY' });
+      }
     }
   });
 

--- a/packages/toolpad-app/src/toolpad/DomLoader.tsx
+++ b/packages/toolpad-app/src/toolpad/DomLoader.tsx
@@ -270,18 +270,6 @@ function createDomApi(
         },
       });
     },
-    setNodeNamespace<Node extends appDom.AppDomNode, Namespace extends appDom.PropNamespaces<Node>>(
-      node: Node,
-      namespace: Namespace,
-      value: Node[Namespace] | null,
-    ) {
-      dispatch({
-        type: 'DOM_UPDATE',
-        updater(dom) {
-          return appDom.setNodeNamespace(dom, node, namespace, value);
-        },
-      });
-    },
     selectNode(nodeId: NodeId) {
       dispatch({
         type: 'SELECT_NODE',


### PR DESCRIPTION
Taking a look at the undo/redo logic. Trying to move more of the logic inside of the reducer. Saw an opportunity to simplify some of the logic (always prefer positive logic) and remove some of the actions. Having a single `DOM_UPDATE` action should hopefully make it easier to detect the nature of an update (updating the same property, or a new one)
