### PR TITLE
Fix templates after dog API changed

### DIFF
--- a/packages/toolpad-app/src/server/appTemplateDoms/images-demo.json
+++ b/packages/toolpad-app/src/server/appTemplateDoms/images-demo.json
@@ -87,8 +87,8 @@
               "value": "`https://dog.ceo/api/breed/${query.breed}/list`\n"
             },
             "method": "GET",
-            "headers": [],
-            "browser": true
+            "browser": true,
+            "headers": []
           }
         },
         "dataSource": {
@@ -122,7 +122,7 @@
       "attributes": {
         "component": {
           "type": "const",
-          "value": "Typography"
+          "value": "Text"
         }
       },
       "parentProp": "children",
@@ -143,8 +143,8 @@
               "value": "https://dog.ceo/api/breeds/list/all"
             },
             "method": "GET",
-            "headers": [],
-            "browser": true
+            "browser": true,
+            "headers": []
           }
         },
         "dataSource": {
@@ -210,8 +210,8 @@
               "value": "`https://dog.ceo/api/breed/${\n  query.subBreed\n    ? `${query.breed}/${query.subBreed}/images/random`\n    : `${query.breed}/images/random`\n}`\n"
             },
             "method": "GET",
-            "headers": [],
-            "browser": true
+            "browser": true,
+            "headers": []
           }
         },
         "dataSource": {
@@ -270,7 +270,7 @@
       "attributes": {
         "component": {
           "type": "const",
-          "value": "Typography"
+          "value": "Text"
         }
       },
       "parentProp": "children",
@@ -395,7 +395,7 @@
       "attributes": {
         "component": {
           "type": "const",
-          "value": "Typography"
+          "value": "Text"
         }
       },
       "parentProp": "children",
@@ -500,7 +500,7 @@
         },
         "options": {
           "type": "jsExpression",
-          "value": "allDogSubBreeds.error ? [] : allDogSubBreeds.data?.message\n"
+          "value": "allDogSubBreeds.error ? [] : allDogSubBreeds.data?.message[selectBreed.value]\n"
         },
         "disabled": {
           "type": "jsExpression",
@@ -541,5 +541,5 @@
       "parentIndex": "a0"
     }
   },
-  "version": 3
+  "version": 5
 }

--- a/packages/toolpad-app/src/server/appTemplateDoms/images.json
+++ b/packages/toolpad-app/src/server/appTemplateDoms/images.json
@@ -68,12 +68,15 @@
       "id": "3m13snf",
       "name": "allDogSubBreeds",
       "type": "query",
-      "params": {
-        "breed": {
-          "type": "jsExpression",
-          "value": "selectBreed.value\n"
-        }
-      },
+      "params": [
+        [
+          "breed",
+          {
+            "type": "jsExpression",
+            "value": "selectBreed.value\n"
+          }
+        ]
+      ],
       "parentId": "cl27arb1i00043g693pzhex2r",
       "attributes": {
         "query": {
@@ -120,7 +123,7 @@
       "attributes": {
         "component": {
           "type": "const",
-          "value": "Typography"
+          "value": "Text"
         }
       },
       "parentProp": "children",
@@ -130,7 +133,7 @@
       "id": "hw03swm",
       "name": "allDogBreeds",
       "type": "query",
-      "params": {},
+      "params": [],
       "parentId": "cl27arb1i00043g693pzhex2r",
       "attributes": {
         "query": {
@@ -183,16 +186,22 @@
       "id": "q8a3s7e",
       "name": "randomDogImage",
       "type": "query",
-      "params": {
-        "breed": {
-          "type": "jsExpression",
-          "value": "selectBreed.value\n"
-        },
-        "subBreed": {
-          "type": "jsExpression",
-          "value": "selectSubBreed.value\n"
-        }
-      },
+      "params": [
+        [
+          "breed",
+          {
+            "type": "jsExpression",
+            "value": "selectBreed.value\n"
+          }
+        ],
+        [
+          "subBreed",
+          {
+            "type": "jsExpression",
+            "value": "selectSubBreed.value\n"
+          }
+        ]
+      ],
       "parentId": "cl27arb1i00043g693pzhex2r",
       "attributes": {
         "query": {
@@ -264,7 +273,7 @@
       "attributes": {
         "component": {
           "type": "const",
-          "value": "Typography"
+          "value": "Text"
         }
       },
       "parentProp": "children",
@@ -415,7 +424,7 @@
       "attributes": {
         "component": {
           "type": "const",
-          "value": "Typography"
+          "value": "Text"
         }
       },
       "parentProp": "children",
@@ -520,7 +529,7 @@
         },
         "options": {
           "type": "jsExpression",
-          "value": "allDogSubBreeds.error ? [] : allDogSubBreeds.data?.message\n"
+          "value": "allDogSubBreeds.error ? [] : allDogSubBreeds.data?.message[selectBreed.value]\n"
         },
         "disabled": {
           "type": "jsExpression",
@@ -560,5 +569,6 @@
       "parentProp": "themes",
       "parentIndex": "a0"
     }
-  }
+  },
+  "version": 5
 }


### PR DESCRIPTION
There seems to be a change in the dog api for subbreeds.

This reveals at least two things:
1. We could use validation of some sort of binding output to alert users they're trying to bind invalid stuff. And prevent passing invalid values to components to avoid unhelpful error messages. If we encourage users to rely on their types we should prevent incompatible values from arriving in the component
2. It's not the best to rely on externalities that we don't control