### PR TITLE
New canvas bridge implementation

### DIFF
--- a/packages/toolpad-app/src/canvas/ToolpadBridge.tsx
+++ b/packages/toolpad-app/src/canvas/ToolpadBridge.tsx
@@ -1,0 +1,82 @@
+import type { RuntimeEvents } from '@mui/toolpad-core';
+import mitt, { Emitter } from 'mitt';
+import type { AppCanvasState } from '.';
+import type { PageViewState } from '../types';
+
+export const TOOLPAD_BRIDGE_GLOBAL = '__TOOLPAD_BRIDGE__';
+
+declare global {
+  interface Window {
+    [TOOLPAD_BRIDGE_GLOBAL]?: ToolpadBridge;
+  }
+}
+
+const COMMAND_HANDLERS = Symbol('hidden property to hold the command handlers');
+
+type Commands<T extends Record<string, Function>> = T & {
+  [COMMAND_HANDLERS]: Partial<T>;
+};
+
+function createCommands<T extends Record<string, Function>>(): Commands<T> {
+  return new Proxy(
+    {
+      [COMMAND_HANDLERS]: {} as Partial<T>,
+    },
+    {
+      get(target, prop, receiver) {
+        if (typeof prop !== 'string') {
+          return Reflect.get(target, prop, receiver);
+        }
+
+        return (...args: any[]): any => {
+          const handler = target[COMMAND_HANDLERS][prop];
+          if (typeof handler !== 'function') {
+            throw new Error(`Command "${prop}" not recognized.`);
+          }
+          return handler(...args);
+        };
+      },
+    },
+  ) as Commands<T>;
+}
+
+export function setCommandHandler<T extends Record<string, Function>, K extends keyof T & string>(
+  commands: Commands<T>,
+  name: K,
+  handler: T[K],
+) {
+  if (typeof commands[COMMAND_HANDLERS][name] !== 'undefined') {
+    throw new Error(`"${name}" is already handled`);
+  }
+  commands[COMMAND_HANDLERS][name] = handler;
+  return () => {
+    delete commands[COMMAND_HANDLERS][name];
+  };
+}
+
+// Interface to communicate between editor and canvas
+export interface ToolpadBridge {
+  // Events fired in the editor, listened in the canvas
+  editorEvents: Emitter<{}>;
+  // Commands executed from the canvas, ran in the editor
+  editorCommands: Commands<{}>;
+  // Events fired in the canvas, listened in the editor
+  canvasEvents: Emitter<RuntimeEvents>;
+  // Commands executed from the editor, ran in the canvas
+  canvasCommands: Commands<{
+    update(updates: AppCanvasState): void;
+    getViewCoordinates(clientX: number, clientY: number): { x: number; y: number } | null;
+    getPageViewState: () => PageViewState;
+  }>;
+}
+
+export const bridge: ToolpadBridge = {
+  editorEvents: mitt(),
+  editorCommands: createCommands(),
+  canvasEvents: mitt(),
+  canvasCommands: createCommands(),
+};
+
+if (typeof window !== 'undefined') {
+  window[TOOLPAD_BRIDGE_GLOBAL] = bridge;
+}

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -137,7 +137,5 @@ export default function AppCanvas({ basename }: AppCanvasProps) {
         />
       </CanvasEventsContext.Provider>
     </CanvasHooksContext.Provider>
-  ) : (
-    <div>loading...</div>
-  );
+  ) : null;
 }

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -34,7 +34,6 @@ import {
 } from 'react-router-dom';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import {
-  fireEvent,
   NodeErrorProps,
   NodeRuntimeWrapper,
   ResetNodeErrorsKeyProvider,
@@ -54,6 +53,7 @@ import AppThemeProvider from './AppThemeProvider';
 import evalJsBindings, {
   BindingEvaluationResult,
   buildGlobalScope,
+  EvaluatedBinding,
   evaluateExpression,
   ParsedBinding,
 } from './evalJsBindings';
@@ -70,6 +70,7 @@ import { useAppContext, AppContextProvider } from './AppContext';
 import { CanvasHooksContext, NavigateToPage } from './CanvasHooksContext';
 import useBoolean from '../utils/useBoolean';
 import { errorFrom } from '../utils/errors';
+import { bridge } from '../canvas/ToolpadBridge';
 
 const ReactQueryDevtoolsProduction = React.lazy(() =>
   import('@tanstack/react-query-devtools/build/lib/index.prod.js').then((d) => ({
@@ -588,7 +589,10 @@ interface ParseBindingOptions {
   scopePath?: string;
 }
 
-function parseBinding(bindable: BindableAttrValue<any>, { scopePath }: ParseBindingOptions = {}) {
+function parseBinding(
+  bindable: BindableAttrValue<any>,
+  { scopePath }: ParseBindingOptions = {},
+): ParsedBinding | EvaluatedBinding {
   if (bindable?.type === 'const') {
     return {
       scopePath,
@@ -615,7 +619,7 @@ function parseBindings(
 ) {
   const elements = appDom.getDescendants(dom, page);
 
-  const parsedBindingsMap = new Map<string, ParsedBinding>();
+  const parsedBindingsMap = new Map<string, ParsedBinding | EvaluatedBinding>();
   const controlled = new Set<string>();
   const globalScopeMeta: GlobalScopeMeta = {};
 
@@ -749,7 +753,8 @@ function parseBindings(
     });
   }
 
-  const parsedBindings: Record<string, ParsedBinding> = Object.fromEntries(parsedBindingsMap);
+  const parsedBindings: Record<string, ParsedBinding | EvaluatedBinding> =
+    Object.fromEntries(parsedBindingsMap);
 
   return { parsedBindings, controlled, globalScopeMeta };
 }
@@ -770,7 +775,7 @@ function RenderedPage({ nodeId }: RenderedNodeProps) {
   );
 
   const [pageBindings, setPageBindings] =
-    React.useState<Record<string, ParsedBinding>>(parsedBindings);
+    React.useState<Record<string, ParsedBinding | EvaluatedBinding>>(parsedBindings);
 
   const prevDom = React.useRef(dom);
   React.useEffect(() => {
@@ -784,7 +789,7 @@ function RenderedPage({ nodeId }: RenderedNodeProps) {
 
     setPageBindings((existingBindings) => {
       // Make sure to patch page bindings after dom nodes have been added or removed
-      const updated: Record<string, ParsedBinding> = {};
+      const updated: Record<string, ParsedBinding | EvaluatedBinding> = {};
       for (const [key, binding] of Object.entries(parsedBindings)) {
         updated[key] = controlled.has(key) ? existingBindings[key] || binding : binding;
       }
@@ -794,8 +799,8 @@ function RenderedPage({ nodeId }: RenderedNodeProps) {
 
   const setControlledBinding = React.useCallback(
     (id: string, result: BindingEvaluationResult) => {
-      const parsedBinding = parsedBindings[id];
-      setPageBindings((existing) => {
+      const { expression, initializer, ...parsedBinding } = parsedBindings[id];
+      setPageBindings((existing): Record<string, ParsedBinding | EvaluatedBinding> => {
         if (!controlled.has(id)) {
           throw new Error(`Not a controlled binding "${id}"`);
         }
@@ -833,11 +838,11 @@ function RenderedPage({ nodeId }: RenderedNodeProps) {
   );
 
   React.useEffect(() => {
-    fireEvent({ type: 'pageStateUpdated', pageState, globalScopeMeta });
+    bridge.canvasEvents.emit('pageStateUpdated', { pageState, globalScopeMeta });
   }, [pageState, globalScopeMeta]);
 
   React.useEffect(() => {
-    fireEvent({ type: 'pageBindingsUpdated', bindings: liveBindings });
+    bridge.canvasEvents.emit('pageBindingsUpdated', { bindings: liveBindings });
   }, [liveBindings]);
 
   return (

--- a/packages/toolpad-app/src/runtime/evalJsBindings.ts
+++ b/packages/toolpad-app/src/runtime/evalJsBindings.ts
@@ -43,7 +43,7 @@ export type BindingEvaluationResult<T = unknown> = {
  * Represents the state of a binding. It both describes which place it takes in the gobal scope
  * and how to obtain the result
  */
-export interface ParsedBinding<T = unknown> {
+export interface ParsedBinding {
   /**
    * How this binding presents itself to expressions in the global scope.
    * Path in the form that is accepted by lodash.set
@@ -53,14 +53,23 @@ export interface ParsedBinding<T = unknown> {
    * javascript expression that evaluates to the value of this binding
    */
   expression?: string;
-  /**
-   * actual evaluated result of the binding
-   */
-  result?: BindingEvaluationResult<T>;
+  dependencies?: undefined;
+  result?: undefined;
   /**
    * javascript expression that evaluates to the initial value of this binding if it doesn't have one
    */
   initializer?: string;
+}
+
+export interface EvaluatedBinding<T = unknown> {
+  scopePath?: string;
+  expression?: undefined;
+  dependencies?: string[];
+  /**
+   * actual evaluated result of the binding
+   */
+  result?: BindingEvaluationResult<T>;
+  initializer?: undefined;
 }
 
 type Dependencies = Map<string, Set<string>>;
@@ -129,11 +138,6 @@ function bubbleLoading(
   return false;
 }
 
-export interface EvaluatedBinding<T = unknown> {
-  scopePath?: string;
-  result?: BindingEvaluationResult<T>;
-}
-
 export function buildGlobalScope(
   base: Record<string, unknown>,
   bindings: Record<string, { result?: BindingEvaluationResult; scopePath?: string }>,
@@ -152,7 +156,7 @@ export function buildGlobalScope(
  * Evaluates the expressions and replace with their result
  */
 export default function evalJsBindings(
-  bindings: Record<string, ParsedBinding>,
+  bindings: Record<string, ParsedBinding | EvaluatedBinding>,
   globalScope: Record<string, unknown>,
 ): Record<string, EvaluatedBinding> {
   const bindingsMap = new Map(Object.entries(bindings));
@@ -214,6 +218,9 @@ export default function evalJsBindings(
     }
 
     if (binding.result) {
+      if (binding.dependencies) {
+        dependencies.set(bindingId, new Set(binding.dependencies));
+      }
       // From input value on the page
       return binding.result;
     }
@@ -270,6 +277,7 @@ export default function evalJsBindings(
 
     return {
       scopePath,
+      dependencies: Array.from(flatDependencies.get(bindingId) ?? []),
       result: {
         ...results[bindingId],
         error: bubbleError(flatDependencies, results, bindingId),

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box, CircularProgress, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import { NodeId } from '@mui/toolpad-core';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -92,23 +92,20 @@ export default function EditorCanvasHost({
   const [contentWindow, setContentWindow] = React.useState<Window | null>(null);
   const [editorOverlayRoot, setEditorOverlayRoot] = React.useState<HTMLElement | null>(null);
 
-  const keyDownHandler = React.useCallback(
-    (event: KeyboardEvent) => {
-      const isZ = event.key.toLowerCase() === 'z';
+  const handleKeyDown = useEvent((event: KeyboardEvent) => {
+    const isZ = event.key.toLowerCase() === 'z';
 
-      const undoShortcut = isZ && (event.metaKey || event.ctrlKey);
-      const redoShortcut = undoShortcut && event.shiftKey;
+    const undoShortcut = isZ && (event.metaKey || event.ctrlKey);
+    const redoShortcut = undoShortcut && event.shiftKey;
 
-      if (redoShortcut) {
-        event.preventDefault();
-        domApi.redo();
-      } else if (undoShortcut) {
-        event.preventDefault();
-        domApi.undo();
-      }
-    },
-    [domApi],
-  );
+    if (redoShortcut) {
+      event.preventDefault();
+      domApi.redo();
+    } else if (undoShortcut) {
+      event.preventDefault();
+      domApi.undo();
+    }
+  });
 
   const handleInit = useEvent(onInit ?? (() => {}));
 
@@ -129,11 +126,11 @@ export default function EditorCanvasHost({
       return;
     }
 
-    iframeWindow?.addEventListener('keydown', keyDownHandler);
+    iframeWindow?.addEventListener('keydown', handleKeyDown);
     iframeWindow?.addEventListener('unload', () => {
-      iframeWindow?.removeEventListener('keydown', keyDownHandler);
+      iframeWindow?.removeEventListener('keydown', handleKeyDown);
     });
-  }, [handleInit, keyDownHandler]);
+  }, [handleInit, handleKeyDown]);
 
   React.useEffect(() => {
     if (!contentWindow) {

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -184,18 +184,6 @@ export default function EditorCanvasHost({
 
   return (
     <CanvasRoot className={className}>
-      <Box
-        sx={{
-          position: 'absolute',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <CircularProgress />
-      </Box>
       <CanvasFrame
         ref={frameRef}
         name="data-toolpad-canvas"

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHost.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@mui/material';
+import { Fade, styled } from '@mui/material';
 import { NodeId } from '@mui/toolpad-core';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
@@ -199,11 +199,11 @@ export default function EditorCanvasHost({
           )
         : null}
 
-      {loading ? (
+      <Fade in={loading} appear={false} timeout={{ enter: 0, exit: 100 }}>
         <CanvasOverlay>
           <CenteredSpinner />
         </CanvasOverlay>
-      ) : null}
+      </Fade>
     </CanvasRoot>
   );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -41,7 +41,7 @@ import NodeHud from './NodeHud';
 import { OverlayGrid, OverlayGridHandle } from './OverlayGrid';
 import { NodeInfo } from '../../../../types';
 import NodeDropArea from './NodeDropArea';
-import { ToolpadBridge } from '../../../../canvas';
+import { ToolpadBridge } from '../../../../canvas/ToolpadBridge';
 
 const HORIZONTAL_RESIZE_SNAP_UNITS = 4; // px
 const SNAP_TO_GRID_COLUMN_MARGIN = 10; // px
@@ -380,7 +380,7 @@ export default function RenderOverlay({ bridge }: RenderOverlayProps) {
 
   const handleNodeMouseUp = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      const cursorPos = bridge?.getViewCoordinates(event.clientX, event.clientY);
+      const cursorPos = bridge?.canvasCommands.getViewCoordinates(event.clientX, event.clientY);
 
       if (!cursorPos || draggedNodeId) {
         return;
@@ -748,7 +748,7 @@ export default function RenderOverlay({ bridge }: RenderOverlayProps) {
     (event: React.DragEvent<Element>) => {
       event.preventDefault();
 
-      const cursorPos = bridge?.getViewCoordinates(event.clientX, event.clientY);
+      const cursorPos = bridge?.canvasCommands.getViewCoordinates(event.clientX, event.clientY);
 
       if (!cursorPos || !draggedNode) {
         return;
@@ -914,7 +914,7 @@ export default function RenderOverlay({ bridge }: RenderOverlayProps) {
 
   const handleNodeDrop = React.useCallback(
     (event: React.DragEvent<Element>) => {
-      const cursorPos = bridge?.getViewCoordinates(event.clientX, event.clientY);
+      const cursorPos = bridge?.canvasCommands.getViewCoordinates(event.clientX, event.clientY);
 
       if (
         !draggedNode ||
@@ -1287,7 +1287,7 @@ export default function RenderOverlay({ bridge }: RenderOverlayProps) {
       const parentInfo = parent ? nodesInfo[parent.id] : null;
       const parentRect = parentInfo?.rect;
 
-      const cursorPos = bridge?.getViewCoordinates(event.clientX, event.clientY);
+      const cursorPos = bridge?.canvasCommands.getViewCoordinates(event.clientX, event.clientY);
 
       if (draggedNodeRect && parentRect && resizePreviewElement && cursorPos) {
         if (draggedEdge === RECTANGLE_EDGE_LEFT || draggedEdge === RECTANGLE_EDGE_RIGHT) {

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderPanel.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { styled } from '@mui/material';
-import { RuntimeEvent, NodeId } from '@mui/toolpad-core';
+import { NodeId } from '@mui/toolpad-core';
 import * as appDom from '../../../../appDom';
 import EditorCanvasHost from '../EditorCanvasHost';
 import { getNodeHashes, useDom, useDomApi, useDomLoader } from '../../../DomLoader';
 import { usePageEditorApi, usePageEditorState } from '../PageEditorProvider';
 import RenderOverlay from './RenderOverlay';
 import { NodeHashes } from '../../../../types';
-import { ToolpadBridge } from '../../../../canvas';
 import useEvent from '../../../../utils/useEvent';
+import { ToolpadBridge } from '../../../../canvas/ToolpadBridge';
 
 const classes = {
   view: 'Toolpad_View',
@@ -42,50 +42,42 @@ export default function RenderPanel({ className }: RenderPanelProps) {
   );
 
   const handleInit = useEvent((initializedBridge: ToolpadBridge) => {
-    initializedBridge.onRuntimeEvent((event: RuntimeEvent) => {
-      switch (event.type) {
-        case 'propUpdated': {
-          const node = appDom.getNode(dom, event.nodeId as NodeId, 'element');
-          const actual = node.props?.[event.prop];
-          if (actual && actual.type !== 'const') {
-            console.warn(`Can't update a non-const prop "${event.prop}" on node "${node.id}"`);
-            return;
-          }
-
-          const newValue: unknown =
-            typeof event.value === 'function' ? event.value(actual?.value) : event.value;
-
-          domApi.update((draft) =>
-            appDom.setNodeNamespacedProp(draft, node, 'props', event.prop, {
-              type: 'const',
-              value: newValue,
-            }),
-          );
-          return;
-        }
-        case 'pageStateUpdated': {
-          api.pageStateUpdate(event.pageState, event.globalScopeMeta);
-          return;
-        }
-        case 'pageBindingsUpdated': {
-          api.pageBindingsUpdate(event.bindings);
-          return;
-        }
-        case 'screenUpdate': {
-          const pageViewState = initializedBridge.getPageViewState();
-          api.pageViewStateUpdate(pageViewState);
-          return;
-        }
-        case 'pageNavigationRequest': {
-          domApi.setView({ kind: 'page', nodeId: event.pageNodeId });
-          return;
-        }
-        default:
-          throw new Error(
-            `received unrecognized event "${(event as RuntimeEvent).type}" from editor runtime`,
-          );
+    initializedBridge.canvasEvents.on('propUpdated', (event) => {
+      const node = appDom.getNode(dom, event.nodeId as NodeId, 'element');
+      const actual = node.props?.[event.prop];
+      if (actual && actual.type !== 'const') {
+        console.warn(`Can't update a non-const prop "${event.prop}" on node "${node.id}"`);
+        return;
       }
+
+      const newValue: unknown =
+        typeof event.value === 'function' ? event.value(actual?.value) : event.value;
+
+      domApi.update((draft) =>
+        appDom.setNodeNamespacedProp(draft, node, 'props', event.prop, {
+          type: 'const',
+          value: newValue,
+        }),
+      );
     });
+
+    initializedBridge.canvasEvents.on('pageStateUpdated', (event) => {
+      api.pageStateUpdate(event.pageState, event.globalScopeMeta);
+    });
+
+    initializedBridge.canvasEvents.on('pageBindingsUpdated', (event) => {
+      api.pageBindingsUpdate(event.bindings);
+    });
+
+    initializedBridge.canvasEvents.on('screenUpdate', () => {
+      const pageViewState = initializedBridge.canvasCommands.getPageViewState();
+      api.pageViewStateUpdate(pageViewState);
+    });
+
+    initializedBridge.canvasEvents.on('pageNavigationRequest', (event) => {
+      domApi.setView({ kind: 'page', nodeId: event.pageNodeId });
+    });
+
     setBridge(initializedBridge);
   });
 

--- a/packages/toolpad-core/package.json
+++ b/packages/toolpad-core/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.20.9",
+    "mitt": "^3.0.0",
     "quickjs-emscripten": "^0.21.1",
     "react-error-boundary": "^3.1.4"
   },

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
-import { ToolpadComponents } from './types';
+import mitt, { Emitter } from 'mitt';
+import { RuntimeEvents, ToolpadComponents } from './types';
 import { RUNTIME_PROP_NODE_ID, RUNTIME_PROP_SLOTS } from './constants.js';
 import type { SlotType, ComponentConfig, RuntimeEvent, RuntimeError } from './types';
 
@@ -19,6 +20,7 @@ declare global {
 }
 
 export const NodeRuntimeContext = React.createContext<string | null>(null);
+export const CanvasEventsContext = React.createContext<Emitter<RuntimeEvents>>(mitt());
 
 // NOTE: These props aren't used, they are only there to transfer information from the
 // React elements to the fibers.
@@ -130,47 +132,9 @@ export interface NodeRuntime<P> {
   ) => void;
 }
 
-export function fireEvent(event: RuntimeEvent) {
-  // eslint-disable-next-line no-underscore-dangle
-  if (!window.__TOOLPAD_RUNTIME_EVENT__) {
-    // eslint-disable-next-line no-underscore-dangle
-    window.__TOOLPAD_RUNTIME_EVENT__ = [] as RuntimeEvent[];
-  }
-  // eslint-disable-next-line no-underscore-dangle
-  if (typeof window.__TOOLPAD_RUNTIME_EVENT__ === 'function') {
-    // eslint-disable-next-line no-underscore-dangle
-    window.__TOOLPAD_RUNTIME_EVENT__(event);
-  } else {
-    // eslint-disable-next-line no-underscore-dangle
-    window.__TOOLPAD_RUNTIME_EVENT__.push(event);
-  }
-}
-
-export function setEventHandler(window: Window, handleEvent: (event: RuntimeEvent) => void) {
-  // eslint-disable-next-line no-underscore-dangle
-  if (typeof window.__TOOLPAD_RUNTIME_EVENT__ === 'function') {
-    throw new Error(`Event handler already attached.`);
-  }
-
-  // eslint-disable-next-line no-underscore-dangle
-  const queuedEvents = Array.isArray(window.__TOOLPAD_RUNTIME_EVENT__)
-    ? // eslint-disable-next-line no-underscore-dangle
-      window.__TOOLPAD_RUNTIME_EVENT__
-    : [];
-
-  queuedEvents.forEach((event) => handleEvent(event));
-
-  // eslint-disable-next-line no-underscore-dangle
-  window.__TOOLPAD_RUNTIME_EVENT__ = (event) => handleEvent(event);
-
-  return () => {
-    // eslint-disable-next-line no-underscore-dangle
-    delete window.__TOOLPAD_RUNTIME_EVENT__;
-  };
-}
-
 export function useNode<P = {}>(): NodeRuntime<P> | null {
   const nodeId = React.useContext(NodeRuntimeContext);
+  const canvasEvents = React.useContext(CanvasEventsContext);
 
   return React.useMemo(() => {
     if (!nodeId) {
@@ -178,15 +142,14 @@ export function useNode<P = {}>(): NodeRuntime<P> | null {
     }
     return {
       updateAppDomConstProp: (prop, value) => {
-        fireEvent({
-          type: 'propUpdated',
+        canvasEvents.emit('propUpdated', {
           nodeId,
           prop,
           value,
         });
       },
     };
-  }, [nodeId]);
+  }, [canvasEvents, nodeId]);
 }
 
 export interface PlaceholderProps {

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -255,6 +255,7 @@ export type RuntimeEvents = {
     bindings: LiveBindings;
   };
   screenUpdate: {};
+  ready: {};
   pageNavigationRequest: { pageNodeId: NodeId };
 };
 


### PR DESCRIPTION
Trying to set up a system where the editor can run expressions inside of the canvas. The goal of which is to improve debuggability of bindings. Running the watch expressions in the actual execution engine allows us to attach information about the page state it's depending on.

This PR aims to simplify the bridge that communicates between the editor and canvas by just having a single instance in the module scope of the page. It's always there, so it can be reached immediately on iframe `onload`. It also make the bridge more expressive and allow two-way communication by separating events and commands both in the direction of the editor and the direction of the canvas.

The init workflow is:

- canvas sets up bridge on the window during page load (not async)
  - Some of the canvas initialization, rendering and setup is asynchronous in nature, when ready it will emit a `ready` event, it will also make ready state available synchronously through `isReady()`.
- editor waits for the onload of the iframe containing the canvas
- editor accesses the bridge object from the contentWindow of the iframe
- editor inspects canvas ready state synchrounously and waits for the ready event if not.
- canvas is initialized, the bridge is usable in the editor.

We keep the bridge a stable object during the full lifetime of a page. For this I introduced a new primitive `Commands`.