### PR TITLE
Avoid resubscribing in useSyncExternalStore on every render

### DIFF
--- a/packages/toolpad-app/src/components/NoSsr.tsx
+++ b/packages/toolpad-app/src/components/NoSsr.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
 
+function subscribe() {
+  return () => {};
+}
+
+function getSnapshot() {
+  return false;
+}
+
+function getServerSnapshot() {
+  return true;
+}
+
 /**
  * Returns true when serverside rendering, or when hydrating.
  */
 export function useIsSsr(defer: boolean = false): boolean {
-  const isSsrInitialValue = React.useSyncExternalStore(
-    () => () => {},
-    () => false,
-    () => true,
-  );
+  const isSsrInitialValue = React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const [isSsr, setIsSsr] = React.useState(defer ? true : isSsrInitialValue);
   React.useEffect(() => setIsSsr(false), []);
   return isSsr;

--- a/packages/toolpad-app/src/utils/useLocalStorageState.ts
+++ b/packages/toolpad-app/src/utils/useLocalStorageState.ts
@@ -71,10 +71,16 @@ export default function useLocalStorageState<V>(
   initialValue: V,
 ): [V, React.Dispatch<React.SetStateAction<V>>] {
   const subscribeKey = React.useCallback((cb: () => void) => subscribe(key, cb), [key]);
+  const getKeySnapshot = React.useCallback(
+    () => getSnapshot<V>(key) ?? initialValue,
+    [initialValue, key],
+  );
+  const getKeyServerSnapshot = React.useCallback(() => initialValue, [initialValue]);
+
   const storedValue: V = React.useSyncExternalStore(
     subscribeKey,
-    () => getSnapshot(key) ?? initialValue,
-    () => initialValue,
+    getKeySnapshot,
+    getKeyServerSnapshot,
   );
 
   const setStoredValue = React.useCallback(

--- a/packages/toolpad-app/src/utils/useLocalStorageState.ts
+++ b/packages/toolpad-app/src/utils/useLocalStorageState.ts
@@ -70,8 +70,9 @@ export default function useLocalStorageState<V>(
   key: string,
   initialValue: V,
 ): [V, React.Dispatch<React.SetStateAction<V>>] {
+  const subscribeKey = React.useCallback((cb: () => void) => subscribe(key, cb), [key]);
   const storedValue: V = React.useSyncExternalStore(
-    (cb) => subscribe(key, cb),
+    subscribeKey,
     () => getSnapshot(key) ?? initialValue,
     () => initialValue,
   );


### PR DESCRIPTION
Realized we're currently a bit wasteful while reading through https://beta.reactjs.org/reference/react/useSyncExternalStore