### PR TITLE
Fix DatePicker localization issues

### DIFF
--- a/packages/toolpad-components/package.json
+++ b/packages/toolpad-components/package.json
@@ -33,6 +33,8 @@
     "@mui/material": "^5.11.5",
     "@mui/toolpad-core": "^0.0.35",
     "@mui/x-data-grid-pro": "^5.17.19",
+    "@mui/x-date-pickers": "^5.0.14",
+    "dayjs": "^1.11.7",
     "react-markdown": "^8.0.4"
   },
   "devDependencies": {

--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -28,6 +28,7 @@ export interface DatePickerProps
 function DatePicker({ format, onChange, ...props }: DatePickerProps) {
   const handleChange = React.useCallback(
     (value: dayjs.Dayjs | null) => {
+      // date-only form of ISO8601. See https://tc39.es/ecma262/#sec-date-time-string-format
       const stringValue = value?.format('YYYY-MM-DD') || '';
       onChange(stringValue);
     },

--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -4,7 +4,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DesktopDatePicker, DesktopDatePickerProps } from '@mui/x-date-pickers/DesktopDatePicker';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { createComponent } from '@mui/toolpad-core';
-import * as dayjs from 'dayjs';
+import { Dayjs } from 'dayjs';
 import { SX_PROP_HELPER_TEXT } from './constants';
 
 const LOCALE_LOADERS = new Map([
@@ -14,7 +14,7 @@ const LOCALE_LOADERS = new Map([
 ]);
 
 export interface DatePickerProps
-  extends Omit<DesktopDatePickerProps<string, dayjs.Dayjs>, 'value' | 'onChange'> {
+  extends Omit<DesktopDatePickerProps<string, Dayjs>, 'value' | 'onChange'> {
   value: string;
   onChange: (newValue: string) => void;
   format: string;
@@ -27,7 +27,7 @@ export interface DatePickerProps
 
 function DatePicker({ format, onChange, ...props }: DatePickerProps) {
   const handleChange = React.useCallback(
-    (value: dayjs.Dayjs | null) => {
+    (value: Dayjs | null) => {
       // date-only form of ISO8601. See https://tc39.es/ecma262/#sec-date-time-string-format
       const stringValue = value?.format('YYYY-MM-DD') || '';
       onChange(stringValue);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,6 +2112,24 @@
     react-transition-group "^4.4.5"
     rifm "^0.12.1"
 
+"@mui/x-date-pickers@^5.0.14":
+  version "5.0.14"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.14.tgz#acfc3ef9be914e2f0127484442063f7300deeebf"
+  integrity sha512-+k+YOL++wEwuF6XRhF3uMLOXlHkUjMHmbXOXWWZ9wJppaGFolj9fNmUvydCp3Z0E9dPRt8J5Vv0z+upZ9KyQZg==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@date-io/core" "^2.15.0"
+    "@date-io/date-fns" "^2.15.0"
+    "@date-io/dayjs" "^2.15.0"
+    "@date-io/luxon" "^2.15.0"
+    "@date-io/moment" "^2.15.0"
+    "@mui/utils" "^5.10.3"
+    "@types/react-transition-group" "^4.4.5"
+    clsx "^1.2.1"
+    prop-types "^15.7.2"
+    react-transition-group "^4.4.5"
+    rifm "^0.12.1"
+
 "@mui/x-license-pro@5.17.12":
   version "5.17.12"
   resolved "https://registry.yarnpkg.com/@mui/x-license-pro/-/x-license-pro-5.17.12.tgz#d069416b7191f9f5b77b2bf7375d2c51aead497c"


### PR DESCRIPTION
Wanted to remove `onChangeHandler`, then noticed a few bugs:

* The DatePicker doesn't show in my locale even though I have `format` unset. I fixed the `LocalizationProvider` and added async loading of locales. More locales to be added to the list. Locale detection has to be improved, this PR just suggests the methodology.
* Missing dependencies for `@mui/toolpad-components`
* Removed `as any`, there seems to be an issue with our dependency tree. Never use `as any` to "fix" problems that are not well understood. Use `@ts-expect-error` and provide a path towards a solution. Usually it will be a link to a github ticket.
* Added helper text for `value`
* Fix types of `value` and `onChange` to be a string
