### PR TITLE
Remove onChangeHandler from Select and TextField

### DIFF
--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -8,17 +8,27 @@ export interface SelectOption {
   label?: string;
 }
 
-export type SelectProps = TextFieldProps & {
+export type SelectProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
+  value: string;
+  onChange: (newValue: string) => void;
   options: (string | SelectOption)[];
 };
 
-function Select({ options, value, defaultValue, fullWidth, sx, ...rest }: SelectProps) {
+function Select({ options, value, onChange, defaultValue, fullWidth, sx, ...rest }: SelectProps) {
+  const handleChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value);
+    },
+    [onChange],
+  );
+
   return (
     <TextField
       select
       sx={{ ...(!fullWidth && !value ? { width: 120 } : {}), ...sx }}
       fullWidth={fullWidth}
       value={value}
+      onChange={handleChange}
       {...rest}
     >
       {options.map((option) => {
@@ -49,7 +59,6 @@ export default createComponent(Select, {
       helperText: 'The currently selected value.',
       typeDef: { type: 'string' },
       onChangeProp: 'onChange',
-      onChangeHandler: (event: React.ChangeEvent<HTMLSelectElement>) => event.target.value,
       defaultValue: '',
       defaultValueProp: 'defaultValue',
     },

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -7,13 +7,22 @@ import {
 import { createComponent } from '@mui/toolpad-core';
 import { SX_PROP_HELPER_TEXT } from './constants';
 
-export type TextFieldProps = MuiTextFieldProps & {
+export type TextFieldProps = Omit<MuiTextFieldProps, 'value' | 'onChange'> & {
+  value: string;
+  onChange: (newValue: string) => void;
   alignItems?: BoxProps['alignItems'];
   justifyContent?: BoxProps['justifyContent'];
 };
 
-function TextField({ defaultValue, ...props }: TextFieldProps) {
-  return <MuiTextField {...props} />;
+function TextField({ defaultValue, onChange, ...props }: TextFieldProps) {
+  const handleChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value);
+    },
+    [onChange],
+  );
+
+  return <MuiTextField {...props} onChange={handleChange} />;
 }
 
 export default createComponent(TextField, {
@@ -24,7 +33,6 @@ export default createComponent(TextField, {
       helperText: 'The value that is controlled by this text input.',
       typeDef: { type: 'string' },
       onChangeProp: 'onChange',
-      onChangeHandler: (event: React.ChangeEvent<HTMLInputElement>) => event.target.value,
       defaultValue: '',
       defaultValueProp: 'defaultValue',
     },


### PR DESCRIPTION
In an effort to simplify argTypes, I'm removing `onChangeHandler`