### PR TITLE
Fix webpack missing exports warnings

### DIFF
--- a/packages/toolpad-app/next.config.mjs
+++ b/packages/toolpad-app/next.config.mjs
@@ -136,6 +136,9 @@ export default withSentryConfig(
           path: false,
         };
 
+        config.module = config.module ?? {};
+        config.module.strictExportPresence = true;
+
         if (!USE_EXPERIMENTAL_TRANSPILE_PACKAGES) {
           // Support global CSS in monaco-editor
           // Adapted from next-transpile-modules.
@@ -144,7 +147,6 @@ export default withSentryConfig(
             path.resolve(path.dirname(require.resolve('monaco-editor/package.json')), './esm'),
           ];
 
-          config.module = config.module ?? {};
           config.module.rules = config.module.rules ?? [];
           const nextCssLoaders = /** @type {import('webpack').RuleSetRule} */ (
             config.module.rules.find(

--- a/packages/toolpad-app/src/runtime/muiExports.tsx
+++ b/packages/toolpad-app/src/runtime/muiExports.tsx
@@ -1,7 +1,7 @@
 import DayJsDefault, * as DayJs from 'dayjs';
-import muiToolpadCoreDefault, * as muiToolpadCore from '@mui/toolpad-core';
+import /* muiToolpadCoreDefault, */ * as muiToolpadCore from '@mui/toolpad-core';
 // eslint-disable-next-line no-restricted-imports
-import muiIconsMaterialDefault, * as muiIconsMaterial from '@mui/icons-material';
+import /* muiIconsMaterialDefault, */ * as muiIconsMaterial from '@mui/icons-material';
 
 import muiMaterialDefault, * as muiMaterial from '@mui/material';
 import muiMaterialAccordionDefault, * as muiMaterialAccordion from '@mui/material/Accordion';
@@ -43,12 +43,12 @@ import muiMaterialAutocompleteDefault, * as muiMaterialAutocomplete from '@mui/m
 import muiMaterialDrawerDefault, * as muiMaterialDrawer from '@mui/material/Drawer';
 import muiMaterialListSubheaderDefault, * as muiMaterialListSubheader from '@mui/material/ListSubheader';
 import muiMaterialStepButtonDefault, * as muiMaterialStepButton from '@mui/material/StepButton';
-import muiMaterialclassNameDefault, * as muiMaterialclassName from '@mui/material/className';
+import /* muiMaterialclassNameDefault, */ * as muiMaterialclassName from '@mui/material/className';
 import muiMaterialAvatarDefault, * as muiMaterialAvatar from '@mui/material/Avatar';
 import muiMaterialFabDefault, * as muiMaterialFab from '@mui/material/Fab';
 import muiMaterialMenuDefault, * as muiMaterialMenu from '@mui/material/Menu';
 import muiMaterialStepConnectorDefault, * as muiMaterialStepConnector from '@mui/material/StepConnector';
-import muiMaterialcolorsDefault, * as muiMaterialcolors from '@mui/material/colors';
+import /* muiMaterialcolorsDefault, */ * as muiMaterialcolors from '@mui/material/colors';
 import muiMaterialAvatarGroupDefault, * as muiMaterialAvatarGroup from '@mui/material/AvatarGroup';
 import muiMaterialFadeDefault, * as muiMaterialFade from '@mui/material/Fade';
 import muiMaterialMenuItemDefault, * as muiMaterialMenuItem from '@mui/material/MenuItem';
@@ -74,7 +74,7 @@ import muiMaterialBoxDefault, * as muiMaterialBox from '@mui/material/Box';
 import muiMaterialFormHelperTextDefault, * as muiMaterialFormHelperText from '@mui/material/FormHelperText';
 import muiMaterialNoSsrDefault, * as muiMaterialNoSsr from '@mui/material/NoSsr';
 import muiMaterialSvgIconDefault, * as muiMaterialSvgIcon from '@mui/material/SvgIcon';
-import muiMateriallocaleDefault, * as muiMateriallocale from '@mui/material/locale';
+import /* muiMateriallocaleDefault, */ * as muiMateriallocale from '@mui/material/locale';
 import muiMaterialBreadcrumbsDefault, * as muiMaterialBreadcrumbs from '@mui/material/Breadcrumbs';
 import muiMaterialFormLabelDefault, * as muiMaterialFormLabel from '@mui/material/FormLabel';
 import muiMaterialOutlinedInputDefault, * as muiMaterialOutlinedInput from '@mui/material/OutlinedInput';
@@ -93,7 +93,7 @@ import muiMaterialTabScrollButtonDefault, * as muiMaterialTabScrollButton from '
 import muiMaterialHiddenDefault, * as muiMaterialHidden from '@mui/material/Hidden';
 import muiMaterialPaperDefault, * as muiMaterialPaper from '@mui/material/Paper';
 import muiMaterialTableDefault, * as muiMaterialTable from '@mui/material/Table';
-import muiMaterialstylesDefault, * as muiMaterialstyles from '@mui/material/styles';
+import /* muiMaterialstylesDefault, */ * as muiMaterialstyles from '@mui/material/styles';
 import muiMaterialCardDefault, * as muiMaterialCard from '@mui/material/Card';
 import muiMaterialIconDefault, * as muiMaterialIcon from '@mui/material/Icon';
 import muiMaterialPopoverDefault, * as muiMaterialPopover from '@mui/material/Popover';
@@ -102,7 +102,7 @@ import muiMaterialCardActionAreaDefault, * as muiMaterialCardActionArea from '@m
 import muiMaterialIconButtonDefault, * as muiMaterialIconButton from '@mui/material/IconButton';
 import muiMaterialPopperDefault, * as muiMaterialPopper from '@mui/material/Popper';
 import muiMaterialTableCellDefault, * as muiMaterialTableCell from '@mui/material/TableCell';
-import muiMaterialtransitionsDefault, * as muiMaterialtransitions from '@mui/material/transitions';
+import /* muiMaterialtransitionsDefault, */ * as muiMaterialtransitions from '@mui/material/transitions';
 import muiMaterialCardActionsDefault, * as muiMaterialCardActions from '@mui/material/CardActions';
 import muiMaterialImageListDefault, * as muiMaterialImageList from '@mui/material/ImageList';
 import muiMaterialPortalDefault, * as muiMaterialPortal from '@mui/material/Portal';
@@ -148,460 +148,469 @@ import muiMaterialLinkDefault, * as muiMaterialLink from '@mui/material/Link';
 import muiMaterialSliderDefault, * as muiMaterialSlider from '@mui/material/Slider';
 import muiMaterialToggleButtonDefault, * as muiMaterialToggleButton from '@mui/material/ToggleButton';
 
-import muiXDatePickersDefault, * as muiXDatePickers from '@mui/x-date-pickers';
-import muiXDatePickersCalendarPickerSkeletonDefault, * as muiXDatePickersCalendarPickerSkeleton from '@mui/x-date-pickers/CalendarPickerSkeleton';
-import muiXDatePickersDesktopTimePickerDefault, * as muiXDatePickersDesktopTimePicker from '@mui/x-date-pickers/DesktopTimePicker';
-import muiXDatePickersMonthPickerDefault, * as muiXDatePickersMonthPicker from '@mui/x-date-pickers/MonthPicker';
-import muiXDatePickersStaticTimePickerDefault, * as muiXDatePickersStaticTimePicker from '@mui/x-date-pickers/StaticTimePicker';
-import muiXDatePickersAdapterDayjsDefault, * as muiXDatePickersAdapterDayjs from '@mui/x-date-pickers/AdapterDayjs';
-import muiXDatePickersClockPickerDefault, * as muiXDatePickersClockPicker from '@mui/x-date-pickers/ClockPicker';
-import muiXDatePickersPickersActionBarDefault, * as muiXDatePickersPickersActionBar from '@mui/x-date-pickers/PickersActionBar';
-import muiXDatePickersTimePickerDefault, * as muiXDatePickersTimePicker from '@mui/x-date-pickers/TimePicker';
-import muiXDatePickerslocalesDefault, * as muiXDatePickerslocales from '@mui/x-date-pickers/locales';
-import muiXDatePickersDatePickerDefault, * as muiXDatePickersDatePicker from '@mui/x-date-pickers/DatePicker';
-import muiXDatePickersLocalizationProviderDefault, * as muiXDatePickersLocalizationProvider from '@mui/x-date-pickers/LocalizationProvider';
-import muiXDatePickersPickersDayDefault, * as muiXDatePickersPickersDay from '@mui/x-date-pickers/PickersDay';
-import muiXDatePickersYearPickerDefault, * as muiXDatePickersYearPicker from '@mui/x-date-pickers/YearPicker';
-import muiXDatePickersDateTimePickerDefault, * as muiXDatePickersDateTimePicker from '@mui/x-date-pickers/DateTimePicker';
-import muiXDatePickersMobileDatePickerDefault, * as muiXDatePickersMobileDatePicker from '@mui/x-date-pickers/MobileDatePicker';
-import muiXDatePickersDesktopDatePickerDefault, * as muiXDatePickersDesktopDatePicker from '@mui/x-date-pickers/DesktopDatePicker';
-import muiXDatePickersMobileDateTimePickerDefault, * as muiXDatePickersMobileDateTimePicker from '@mui/x-date-pickers/MobileDateTimePicker';
-import muiXDatePickersStaticDatePickerDefault, * as muiXDatePickersStaticDatePicker from '@mui/x-date-pickers/StaticDatePicker';
-import muiXDatePickersCalendarPickerDefault, * as muiXDatePickersCalendarPicker from '@mui/x-date-pickers/CalendarPicker';
-import muiXDatePickersDesktopDateTimePickerDefault, * as muiXDatePickersDesktopDateTimePicker from '@mui/x-date-pickers/DesktopDateTimePicker';
-import muiXDatePickersMobileTimePickerDefault, * as muiXDatePickersMobileTimePicker from '@mui/x-date-pickers/MobileTimePicker';
-import muiXDatePickersStaticDateTimePickerDefault, * as muiXDatePickersStaticDateTimePicker from '@mui/x-date-pickers/StaticDateTimePicker';
+import /* muiXDatePickersDefault, */ * as muiXDatePickers from '@mui/x-date-pickers';
+import /* muiXDatePickersCalendarPickerSkeletonDefault, */ * as muiXDatePickersCalendarPickerSkeleton from '@mui/x-date-pickers/CalendarPickerSkeleton';
+import /* muiXDatePickersDesktopTimePickerDefault, */ * as muiXDatePickersDesktopTimePicker from '@mui/x-date-pickers/DesktopTimePicker';
+import /* muiXDatePickersMonthPickerDefault, */ * as muiXDatePickersMonthPicker from '@mui/x-date-pickers/MonthPicker';
+import /* muiXDatePickersStaticTimePickerDefault, */ * as muiXDatePickersStaticTimePicker from '@mui/x-date-pickers/StaticTimePicker';
+import /* muiXDatePickersAdapterDayjsDefault, */ * as muiXDatePickersAdapterDayjs from '@mui/x-date-pickers/AdapterDayjs';
+import /* muiXDatePickersClockPickerDefault, */ * as muiXDatePickersClockPicker from '@mui/x-date-pickers/ClockPicker';
+import /* muiXDatePickersPickersActionBarDefault, */ * as muiXDatePickersPickersActionBar from '@mui/x-date-pickers/PickersActionBar';
+import /* muiXDatePickersTimePickerDefault, */ * as muiXDatePickersTimePicker from '@mui/x-date-pickers/TimePicker';
+import /* muiXDatePickerslocalesDefault, */ * as muiXDatePickerslocales from '@mui/x-date-pickers/locales';
+import /* muiXDatePickersDatePickerDefault, */ * as muiXDatePickersDatePicker from '@mui/x-date-pickers/DatePicker';
+import /* muiXDatePickersLocalizationProviderDefault, */ * as muiXDatePickersLocalizationProvider from '@mui/x-date-pickers/LocalizationProvider';
+import /* muiXDatePickersPickersDayDefault, */ * as muiXDatePickersPickersDay from '@mui/x-date-pickers/PickersDay';
+import /* muiXDatePickersYearPickerDefault, */ * as muiXDatePickersYearPicker from '@mui/x-date-pickers/YearPicker';
+import /* muiXDatePickersDateTimePickerDefault, */ * as muiXDatePickersDateTimePicker from '@mui/x-date-pickers/DateTimePicker';
+import /* muiXDatePickersMobileDatePickerDefault, */ * as muiXDatePickersMobileDatePicker from '@mui/x-date-pickers/MobileDatePicker';
+import /* muiXDatePickersDesktopDatePickerDefault, */ * as muiXDatePickersDesktopDatePicker from '@mui/x-date-pickers/DesktopDatePicker';
+import /* muiXDatePickersMobileDateTimePickerDefault, */ * as muiXDatePickersMobileDateTimePicker from '@mui/x-date-pickers/MobileDateTimePicker';
+import /* muiXDatePickersStaticDatePickerDefault, */ * as muiXDatePickersStaticDatePicker from '@mui/x-date-pickers/StaticDatePicker';
+import /* muiXDatePickersCalendarPickerDefault, */ * as muiXDatePickersCalendarPicker from '@mui/x-date-pickers/CalendarPicker';
+import /* muiXDatePickersDesktopDateTimePickerDefault, */ * as muiXDatePickersDesktopDateTimePicker from '@mui/x-date-pickers/DesktopDateTimePicker';
+import /* muiXDatePickersMobileTimePickerDefault, */ * as muiXDatePickersMobileTimePicker from '@mui/x-date-pickers/MobileTimePicker';
+import /* muiXDatePickersStaticDateTimePickerDefault, */ * as muiXDatePickersStaticDateTimePicker from '@mui/x-date-pickers/StaticDateTimePicker';
 
-import muiXDatePickersProDefault, * as muiXDatePickersPro from '@mui/x-date-pickers-pro';
-import muiXDatePickersProDateRangePickerDefault, * as muiXDatePickersProDateRangePicker from '@mui/x-date-pickers-pro/DateRangePicker';
-import muiXDatePickersProMultiInputDateRangeFieldDefault, * as muiXDatePickersProMultiInputDateRangeField from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
-import muiXDatePickersProAdapterDayjsDefault, * as muiXDatePickersProAdapterDayjs from '@mui/x-date-pickers-pro/AdapterDayjs';
-import muiXDatePickersProDateRangePickerDayDefault, * as muiXDatePickersProDateRangePickerDay from '@mui/x-date-pickers-pro/DateRangePickerDay';
-import muiXDatePickersProDesktopDateRangePickerDefault, * as muiXDatePickersProDesktopDateRangePicker from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
-import muiXDatePickersProSingleInputDateRangeFieldDefault, * as muiXDatePickersProSingleInputDateRangeField from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
-import muiXDatePickersProStaticDateRangePickerDefault, * as muiXDatePickersProStaticDateRangePicker from '@mui/x-date-pickers-pro/StaticDateRangePicker';
-import muiXDatePickersProMobileDateRangePickerDefault, * as muiXDatePickersProMobileDateRangePicker from '@mui/x-date-pickers-pro/MobileDateRangePicker';
+import /* muiXDatePickersProDefault, */ * as muiXDatePickersPro from '@mui/x-date-pickers-pro';
+import /* muiXDatePickersProDateRangePickerDefault, */ * as muiXDatePickersProDateRangePicker from '@mui/x-date-pickers-pro/DateRangePicker';
+import /* muiXDatePickersProMultiInputDateRangeFieldDefault, */ * as muiXDatePickersProMultiInputDateRangeField from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
+import /* muiXDatePickersProAdapterDayjsDefault, */ * as muiXDatePickersProAdapterDayjs from '@mui/x-date-pickers-pro/AdapterDayjs';
+import /* muiXDatePickersProDateRangePickerDayDefault, */ * as muiXDatePickersProDateRangePickerDay from '@mui/x-date-pickers-pro/DateRangePickerDay';
+import /* muiXDatePickersProDesktopDateRangePickerDefault, */ * as muiXDatePickersProDesktopDateRangePicker from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
+import /* muiXDatePickersProSingleInputDateRangeFieldDefault, */ * as muiXDatePickersProSingleInputDateRangeField from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
+import /* muiXDatePickersProStaticDateRangePickerDefault, */ * as muiXDatePickersProStaticDateRangePicker from '@mui/x-date-pickers-pro/StaticDateRangePicker';
+import /* muiXDatePickersProMobileDateRangePickerDefault, */ * as muiXDatePickersProMobileDateRangePicker from '@mui/x-date-pickers-pro/MobileDateRangePicker';
 
-import muiXDataGridDefault, * as muiXDataGrid from '@mui/x-data-grid';
-import muiXDataGridDataGridDefault, * as muiXDataGridDataGrid from '@mui/x-data-grid/DataGrid';
+import /* muiXDataGridDefault, */ * as muiXDataGrid from '@mui/x-data-grid';
+import /* muiXDataGridDataGridDefault, */ * as muiXDataGridDataGrid from '@mui/x-data-grid/DataGrid';
 
-import muiXDataGridProDefault, * as muiXDataGridPro from '@mui/x-data-grid-pro';
-import muiXDataGridProDataGridProDefault, * as muiXDataGridProDataGridPro from '@mui/x-data-grid-pro/DataGridPro';
+import /* muiXDataGridProDefault, */ * as muiXDataGridPro from '@mui/x-data-grid-pro';
+import /* muiXDataGridProDataGridProDefault, */ * as muiXDataGridProDataGridPro from '@mui/x-data-grid-pro/DataGridPro';
 
-import muiXDataGridGeneratorDefault, * as muiXDataGridGenerator from '@mui/x-data-grid-generator';
+import /* muiXDataGridGeneratorDefault, */ * as muiXDataGridGenerator from '@mui/x-data-grid-generator';
 
-function esm(defaultExport: any, namedExports: any) {
+function esm(namedExports: any, defaultExport?: any) {
   return { ...namedExports, default: defaultExport, __esModule: true };
 }
 
 const muiMaterialExports = new Map([
-  ['@mui/material', esm(muiMaterialDefault, muiMaterial)],
-  ['@mui/material/Accordion', esm(muiMaterialAccordionDefault, muiMaterialAccordion)],
-  ['@mui/material/CssBaseline', esm(muiMaterialCssBaselineDefault, muiMaterialCssBaseline)],
-  ['@mui/material/List', esm(muiMaterialListDefault, muiMaterialList)],
-  ['@mui/material/Snackbar', esm(muiMaterialSnackbarDefault, muiMaterialSnackbar)],
+  ['@mui/material', esm(muiMaterial, muiMaterialDefault)],
+  ['@mui/material/Accordion', esm(muiMaterialAccordion, muiMaterialAccordionDefault)],
+  ['@mui/material/CssBaseline', esm(muiMaterialCssBaseline, muiMaterialCssBaselineDefault)],
+  ['@mui/material/List', esm(muiMaterialList, muiMaterialListDefault)],
+  ['@mui/material/Snackbar', esm(muiMaterialSnackbar, muiMaterialSnackbarDefault)],
   [
     '@mui/material/ToggleButtonGroup',
-    esm(muiMaterialToggleButtonGroupDefault, muiMaterialToggleButtonGroup),
+    esm(muiMaterialToggleButtonGroup, muiMaterialToggleButtonGroupDefault),
   ],
   [
     '@mui/material/AccordionActions',
-    esm(muiMaterialAccordionActionsDefault, muiMaterialAccordionActions),
+    esm(muiMaterialAccordionActions, muiMaterialAccordionActionsDefault),
   ],
-  ['@mui/material/Dialog', esm(muiMaterialDialogDefault, muiMaterialDialog)],
-  ['@mui/material/ListItem', esm(muiMaterialListItemDefault, muiMaterialListItem)],
+  ['@mui/material/Dialog', esm(muiMaterialDialog, muiMaterialDialogDefault)],
+  ['@mui/material/ListItem', esm(muiMaterialListItem, muiMaterialListItemDefault)],
   [
     '@mui/material/SnackbarContent',
-    esm(muiMaterialSnackbarContentDefault, muiMaterialSnackbarContent),
+    esm(muiMaterialSnackbarContent, muiMaterialSnackbarContentDefault),
   ],
-  ['@mui/material/Toolbar', esm(muiMaterialToolbarDefault, muiMaterialToolbar)],
+  ['@mui/material/Toolbar', esm(muiMaterialToolbar, muiMaterialToolbarDefault)],
   [
     '@mui/material/AccordionDetails',
-    esm(muiMaterialAccordionDetailsDefault, muiMaterialAccordionDetails),
+    esm(muiMaterialAccordionDetails, muiMaterialAccordionDetailsDefault),
   ],
-  ['@mui/material/DialogActions', esm(muiMaterialDialogActionsDefault, muiMaterialDialogActions)],
+  ['@mui/material/DialogActions', esm(muiMaterialDialogActions, muiMaterialDialogActionsDefault)],
   [
     '@mui/material/ListItemAvatar',
-    esm(muiMaterialListItemAvatarDefault, muiMaterialListItemAvatar),
+    esm(muiMaterialListItemAvatar, muiMaterialListItemAvatarDefault),
   ],
-  ['@mui/material/SpeedDial', esm(muiMaterialSpeedDialDefault, muiMaterialSpeedDial)],
-  ['@mui/material/Tooltip', esm(muiMaterialTooltipDefault, muiMaterialTooltip)],
+  ['@mui/material/SpeedDial', esm(muiMaterialSpeedDial, muiMaterialSpeedDialDefault)],
+  ['@mui/material/Tooltip', esm(muiMaterialTooltip, muiMaterialTooltipDefault)],
   [
     '@mui/material/AccordionSummary',
-    esm(muiMaterialAccordionSummaryDefault, muiMaterialAccordionSummary),
+    esm(muiMaterialAccordionSummary, muiMaterialAccordionSummaryDefault),
   ],
-  ['@mui/material/DialogContent', esm(muiMaterialDialogContentDefault, muiMaterialDialogContent)],
+  ['@mui/material/DialogContent', esm(muiMaterialDialogContent, muiMaterialDialogContentDefault)],
   [
     '@mui/material/ListItemButton',
-    esm(muiMaterialListItemButtonDefault, muiMaterialListItemButton),
+    esm(muiMaterialListItemButton, muiMaterialListItemButtonDefault),
   ],
   [
     '@mui/material/SpeedDialAction',
-    esm(muiMaterialSpeedDialActionDefault, muiMaterialSpeedDialAction),
+    esm(muiMaterialSpeedDialAction, muiMaterialSpeedDialActionDefault),
   ],
-  ['@mui/material/Typography', esm(muiMaterialTypographyDefault, muiMaterialTypography)],
-  ['@mui/material/Alert', esm(muiMaterialAlertDefault, muiMaterialAlert)],
+  ['@mui/material/Typography', esm(muiMaterialTypography, muiMaterialTypographyDefault)],
+  ['@mui/material/Alert', esm(muiMaterialAlert, muiMaterialAlertDefault)],
   [
     '@mui/material/DialogContentText',
-    esm(muiMaterialDialogContentTextDefault, muiMaterialDialogContentText),
+    esm(muiMaterialDialogContentText, muiMaterialDialogContentTextDefault),
   ],
-  ['@mui/material/ListItemIcon', esm(muiMaterialListItemIconDefault, muiMaterialListItemIcon)],
-  ['@mui/material/SpeedDialIcon', esm(muiMaterialSpeedDialIconDefault, muiMaterialSpeedDialIcon)],
+  ['@mui/material/ListItemIcon', esm(muiMaterialListItemIcon, muiMaterialListItemIconDefault)],
+  ['@mui/material/SpeedDialIcon', esm(muiMaterialSpeedDialIcon, muiMaterialSpeedDialIconDefault)],
   [
     '@mui/material/Unstable_Grid2',
-    esm(muiMaterialUnstable_Grid2Default, muiMaterialUnstable_Grid2),
+    esm(muiMaterialUnstable_Grid2, muiMaterialUnstable_Grid2Default),
   ],
-  ['@mui/material/AlertTitle', esm(muiMaterialAlertTitleDefault, muiMaterialAlertTitle)],
-  ['@mui/material/DialogTitle', esm(muiMaterialDialogTitleDefault, muiMaterialDialogTitle)],
+  ['@mui/material/AlertTitle', esm(muiMaterialAlertTitle, muiMaterialAlertTitleDefault)],
+  ['@mui/material/DialogTitle', esm(muiMaterialDialogTitle, muiMaterialDialogTitleDefault)],
   [
     '@mui/material/ListItemSecondaryAction',
-    esm(muiMaterialListItemSecondaryActionDefault, muiMaterialListItemSecondaryAction),
+    esm(muiMaterialListItemSecondaryAction, muiMaterialListItemSecondaryActionDefault),
   ],
-  ['@mui/material/Stack', esm(muiMaterialStackDefault, muiMaterialStack)],
+  ['@mui/material/Stack', esm(muiMaterialStack, muiMaterialStackDefault)],
   [
     '@mui/material/Unstable_TrapFocus',
-    esm(muiMaterialUnstable_TrapFocusDefault, muiMaterialUnstable_TrapFocus),
+    esm(muiMaterialUnstable_TrapFocus, muiMaterialUnstable_TrapFocusDefault),
   ],
-  ['@mui/material/AppBar', esm(muiMaterialAppBarDefault, muiMaterialAppBar)],
-  ['@mui/material/Divider', esm(muiMaterialDividerDefault, muiMaterialDivider)],
-  ['@mui/material/ListItemText', esm(muiMaterialListItemTextDefault, muiMaterialListItemText)],
-  ['@mui/material/Step', esm(muiMaterialStepDefault, muiMaterialStep)],
-  ['@mui/material/Zoom', esm(muiMaterialZoomDefault, muiMaterialZoom)],
-  ['@mui/material/Autocomplete', esm(muiMaterialAutocompleteDefault, muiMaterialAutocomplete)],
-  ['@mui/material/Drawer', esm(muiMaterialDrawerDefault, muiMaterialDrawer)],
-  ['@mui/material/ListSubheader', esm(muiMaterialListSubheaderDefault, muiMaterialListSubheader)],
-  ['@mui/material/StepButton', esm(muiMaterialStepButtonDefault, muiMaterialStepButton)],
-  ['@mui/material/className', esm(muiMaterialclassNameDefault, muiMaterialclassName)],
-  ['@mui/material/Avatar', esm(muiMaterialAvatarDefault, muiMaterialAvatar)],
-  ['@mui/material/Fab', esm(muiMaterialFabDefault, muiMaterialFab)],
-  ['@mui/material/Menu', esm(muiMaterialMenuDefault, muiMaterialMenu)],
-  ['@mui/material/StepConnector', esm(muiMaterialStepConnectorDefault, muiMaterialStepConnector)],
-  ['@mui/material/colors', esm(muiMaterialcolorsDefault, muiMaterialcolors)],
-  ['@mui/material/AvatarGroup', esm(muiMaterialAvatarGroupDefault, muiMaterialAvatarGroup)],
-  ['@mui/material/Fade', esm(muiMaterialFadeDefault, muiMaterialFade)],
-  ['@mui/material/MenuItem', esm(muiMaterialMenuItemDefault, muiMaterialMenuItem)],
-  ['@mui/material/StepContent', esm(muiMaterialStepContentDefault, muiMaterialStepContent)],
-  ['@mui/material/darkScrollbar', esm(muiMaterialdarkScrollbarDefault, muiMaterialdarkScrollbar)],
-  ['@mui/material/Backdrop', esm(muiMaterialBackdropDefault, muiMaterialBackdrop)],
-  ['@mui/material/FilledInput', esm(muiMaterialFilledInputDefault, muiMaterialFilledInput)],
-  ['@mui/material/MenuList', esm(muiMaterialMenuListDefault, muiMaterialMenuList)],
-  ['@mui/material/StepIcon', esm(muiMaterialStepIconDefault, muiMaterialStepIcon)],
-  ['@mui/material/Badge', esm(muiMaterialBadgeDefault, muiMaterialBadge)],
-  ['@mui/material/FormControl', esm(muiMaterialFormControlDefault, muiMaterialFormControl)],
-  ['@mui/material/MobileStepper', esm(muiMaterialMobileStepperDefault, muiMaterialMobileStepper)],
-  ['@mui/material/StepLabel', esm(muiMaterialStepLabelDefault, muiMaterialStepLabel)],
+  ['@mui/material/AppBar', esm(muiMaterialAppBar, muiMaterialAppBarDefault)],
+  ['@mui/material/Divider', esm(muiMaterialDivider, muiMaterialDividerDefault)],
+  ['@mui/material/ListItemText', esm(muiMaterialListItemText, muiMaterialListItemTextDefault)],
+  ['@mui/material/Step', esm(muiMaterialStep, muiMaterialStepDefault)],
+  ['@mui/material/Zoom', esm(muiMaterialZoom, muiMaterialZoomDefault)],
+  ['@mui/material/Autocomplete', esm(muiMaterialAutocomplete, muiMaterialAutocompleteDefault)],
+  ['@mui/material/Drawer', esm(muiMaterialDrawer, muiMaterialDrawerDefault)],
+  ['@mui/material/ListSubheader', esm(muiMaterialListSubheader, muiMaterialListSubheaderDefault)],
+  ['@mui/material/StepButton', esm(muiMaterialStepButton, muiMaterialStepButtonDefault)],
+  ['@mui/material/className', esm(muiMaterialclassName /* , muiMaterialclassNameDefault */)],
+  ['@mui/material/Avatar', esm(muiMaterialAvatar, muiMaterialAvatarDefault)],
+  ['@mui/material/Fab', esm(muiMaterialFab, muiMaterialFabDefault)],
+  ['@mui/material/Menu', esm(muiMaterialMenu, muiMaterialMenuDefault)],
+  ['@mui/material/StepConnector', esm(muiMaterialStepConnector, muiMaterialStepConnectorDefault)],
+  ['@mui/material/colors', esm(muiMaterialcolors /* , muiMaterialcolorsDefault */)],
+  ['@mui/material/AvatarGroup', esm(muiMaterialAvatarGroup, muiMaterialAvatarGroupDefault)],
+  ['@mui/material/Fade', esm(muiMaterialFade, muiMaterialFadeDefault)],
+  ['@mui/material/MenuItem', esm(muiMaterialMenuItem, muiMaterialMenuItemDefault)],
+  ['@mui/material/StepContent', esm(muiMaterialStepContent, muiMaterialStepContentDefault)],
+  ['@mui/material/darkScrollbar', esm(muiMaterialdarkScrollbar, muiMaterialdarkScrollbarDefault)],
+  ['@mui/material/Backdrop', esm(muiMaterialBackdrop, muiMaterialBackdropDefault)],
+  ['@mui/material/FilledInput', esm(muiMaterialFilledInput, muiMaterialFilledInputDefault)],
+  ['@mui/material/MenuList', esm(muiMaterialMenuList, muiMaterialMenuListDefault)],
+  ['@mui/material/StepIcon', esm(muiMaterialStepIcon, muiMaterialStepIconDefault)],
+  ['@mui/material/Badge', esm(muiMaterialBadge, muiMaterialBadgeDefault)],
+  ['@mui/material/FormControl', esm(muiMaterialFormControl, muiMaterialFormControlDefault)],
+  ['@mui/material/MobileStepper', esm(muiMaterialMobileStepper, muiMaterialMobileStepperDefault)],
+  ['@mui/material/StepLabel', esm(muiMaterialStepLabel, muiMaterialStepLabelDefault)],
   [
     '@mui/material/BottomNavigation',
-    esm(muiMaterialBottomNavigationDefault, muiMaterialBottomNavigation),
+    esm(muiMaterialBottomNavigation, muiMaterialBottomNavigationDefault),
   ],
   [
     '@mui/material/FormControlLabel',
-    esm(muiMaterialFormControlLabelDefault, muiMaterialFormControlLabel),
+    esm(muiMaterialFormControlLabel, muiMaterialFormControlLabelDefault),
   ],
-  ['@mui/material/Modal', esm(muiMaterialModalDefault, muiMaterialModal)],
-  ['@mui/material/Stepper', esm(muiMaterialStepperDefault, muiMaterialStepper)],
+  ['@mui/material/Modal', esm(muiMaterialModal, muiMaterialModalDefault)],
+  ['@mui/material/Stepper', esm(muiMaterialStepper, muiMaterialStepperDefault)],
   [
     '@mui/material/BottomNavigationAction',
-    esm(muiMaterialBottomNavigationActionDefault, muiMaterialBottomNavigationAction),
+    esm(muiMaterialBottomNavigationAction, muiMaterialBottomNavigationActionDefault),
   ],
-  ['@mui/material/FormGroup', esm(muiMaterialFormGroupDefault, muiMaterialFormGroup)],
-  ['@mui/material/NativeSelect', esm(muiMaterialNativeSelectDefault, muiMaterialNativeSelect)],
+  ['@mui/material/FormGroup', esm(muiMaterialFormGroup, muiMaterialFormGroupDefault)],
+  ['@mui/material/NativeSelect', esm(muiMaterialNativeSelect, muiMaterialNativeSelectDefault)],
   [
     '@mui/material/StyledEngineProvider',
-    esm(muiMaterialStyledEngineProviderDefault, muiMaterialStyledEngineProvider),
+    esm(muiMaterialStyledEngineProvider, muiMaterialStyledEngineProviderDefault),
   ],
-  ['@mui/material/Box', esm(muiMaterialBoxDefault, muiMaterialBox)],
+  ['@mui/material/Box', esm(muiMaterialBox, muiMaterialBoxDefault)],
   [
     '@mui/material/FormHelperText',
-    esm(muiMaterialFormHelperTextDefault, muiMaterialFormHelperText),
+    esm(muiMaterialFormHelperText, muiMaterialFormHelperTextDefault),
   ],
-  ['@mui/material/NoSsr', esm(muiMaterialNoSsrDefault, muiMaterialNoSsr)],
-  ['@mui/material/SvgIcon', esm(muiMaterialSvgIconDefault, muiMaterialSvgIcon)],
-  ['@mui/material/locale', esm(muiMateriallocaleDefault, muiMateriallocale)],
-  ['@mui/material/Breadcrumbs', esm(muiMaterialBreadcrumbsDefault, muiMaterialBreadcrumbs)],
-  ['@mui/material/FormLabel', esm(muiMaterialFormLabelDefault, muiMaterialFormLabel)],
-  ['@mui/material/OutlinedInput', esm(muiMaterialOutlinedInputDefault, muiMaterialOutlinedInput)],
+  ['@mui/material/NoSsr', esm(muiMaterialNoSsr, muiMaterialNoSsrDefault)],
+  ['@mui/material/SvgIcon', esm(muiMaterialSvgIcon, muiMaterialSvgIconDefault)],
+  ['@mui/material/locale', esm(muiMateriallocale /* , muiMateriallocaleDefault */)],
+  ['@mui/material/Breadcrumbs', esm(muiMaterialBreadcrumbs, muiMaterialBreadcrumbsDefault)],
+  ['@mui/material/FormLabel', esm(muiMaterialFormLabel, muiMaterialFormLabelDefault)],
+  ['@mui/material/OutlinedInput', esm(muiMaterialOutlinedInput, muiMaterialOutlinedInputDefault)],
   [
     '@mui/material/SwipeableDrawer',
-    esm(muiMaterialSwipeableDrawerDefault, muiMaterialSwipeableDrawer),
+    esm(muiMaterialSwipeableDrawer, muiMaterialSwipeableDrawerDefault),
   ],
-  ['@mui/material/Button', esm(muiMaterialButtonDefault, muiMaterialButton)],
-  ['@mui/material/GlobalStyles', esm(muiMaterialGlobalStylesDefault, muiMaterialGlobalStyles)],
-  ['@mui/material/Switch', esm(muiMaterialSwitchDefault, muiMaterialSwitch)],
-  ['@mui/material/ButtonBase', esm(muiMaterialButtonBaseDefault, muiMaterialButtonBase)],
-  ['@mui/material/Grid', esm(muiMaterialGridDefault, muiMaterialGrid)],
-  ['@mui/material/Pagination', esm(muiMaterialPaginationDefault, muiMaterialPagination)],
-  ['@mui/material/Tab', esm(muiMaterialTabDefault, muiMaterialTab)],
-  ['@mui/material/ButtonGroup', esm(muiMaterialButtonGroupDefault, muiMaterialButtonGroup)],
-  ['@mui/material/Grow', esm(muiMaterialGrowDefault, muiMaterialGrow)],
+  ['@mui/material/Button', esm(muiMaterialButton, muiMaterialButtonDefault)],
+  ['@mui/material/GlobalStyles', esm(muiMaterialGlobalStyles, muiMaterialGlobalStylesDefault)],
+  ['@mui/material/Switch', esm(muiMaterialSwitch, muiMaterialSwitchDefault)],
+  ['@mui/material/ButtonBase', esm(muiMaterialButtonBase, muiMaterialButtonBaseDefault)],
+  ['@mui/material/Grid', esm(muiMaterialGrid, muiMaterialGridDefault)],
+  ['@mui/material/Pagination', esm(muiMaterialPagination, muiMaterialPaginationDefault)],
+  ['@mui/material/Tab', esm(muiMaterialTab, muiMaterialTabDefault)],
+  ['@mui/material/ButtonGroup', esm(muiMaterialButtonGroup, muiMaterialButtonGroupDefault)],
+  ['@mui/material/Grow', esm(muiMaterialGrow, muiMaterialGrowDefault)],
   [
     '@mui/material/PaginationItem',
-    esm(muiMaterialPaginationItemDefault, muiMaterialPaginationItem),
+    esm(muiMaterialPaginationItem, muiMaterialPaginationItemDefault),
   ],
   [
     '@mui/material/TabScrollButton',
-    esm(muiMaterialTabScrollButtonDefault, muiMaterialTabScrollButton),
+    esm(muiMaterialTabScrollButton, muiMaterialTabScrollButtonDefault),
   ],
-  ['@mui/material/Hidden', esm(muiMaterialHiddenDefault, muiMaterialHidden)],
-  ['@mui/material/Paper', esm(muiMaterialPaperDefault, muiMaterialPaper)],
-  ['@mui/material/Table', esm(muiMaterialTableDefault, muiMaterialTable)],
-  ['@mui/material/styles', esm(muiMaterialstylesDefault, muiMaterialstyles)],
-  ['@mui/material/Card', esm(muiMaterialCardDefault, muiMaterialCard)],
-  ['@mui/material/Icon', esm(muiMaterialIconDefault, muiMaterialIcon)],
-  ['@mui/material/Popover', esm(muiMaterialPopoverDefault, muiMaterialPopover)],
-  ['@mui/material/TableBody', esm(muiMaterialTableBodyDefault, muiMaterialTableBody)],
+  ['@mui/material/Hidden', esm(muiMaterialHidden, muiMaterialHiddenDefault)],
+  ['@mui/material/Paper', esm(muiMaterialPaper, muiMaterialPaperDefault)],
+  ['@mui/material/Table', esm(muiMaterialTable, muiMaterialTableDefault)],
+  ['@mui/material/styles', esm(muiMaterialstyles /* , muiMaterialstylesDefault */)],
+  ['@mui/material/Card', esm(muiMaterialCard, muiMaterialCardDefault)],
+  ['@mui/material/Icon', esm(muiMaterialIcon, muiMaterialIconDefault)],
+  ['@mui/material/Popover', esm(muiMaterialPopover, muiMaterialPopoverDefault)],
+  ['@mui/material/TableBody', esm(muiMaterialTableBody, muiMaterialTableBodyDefault)],
   [
     '@mui/material/CardActionArea',
-    esm(muiMaterialCardActionAreaDefault, muiMaterialCardActionArea),
+    esm(muiMaterialCardActionArea, muiMaterialCardActionAreaDefault),
   ],
-  ['@mui/material/IconButton', esm(muiMaterialIconButtonDefault, muiMaterialIconButton)],
-  ['@mui/material/Popper', esm(muiMaterialPopperDefault, muiMaterialPopper)],
-  ['@mui/material/TableCell', esm(muiMaterialTableCellDefault, muiMaterialTableCell)],
-  ['@mui/material/transitions', esm(muiMaterialtransitionsDefault, muiMaterialtransitions)],
-  ['@mui/material/CardActions', esm(muiMaterialCardActionsDefault, muiMaterialCardActions)],
-  ['@mui/material/ImageList', esm(muiMaterialImageListDefault, muiMaterialImageList)],
-  ['@mui/material/Portal', esm(muiMaterialPortalDefault, muiMaterialPortal)],
+  ['@mui/material/IconButton', esm(muiMaterialIconButton, muiMaterialIconButtonDefault)],
+  ['@mui/material/Popper', esm(muiMaterialPopper, muiMaterialPopperDefault)],
+  ['@mui/material/TableCell', esm(muiMaterialTableCell, muiMaterialTableCellDefault)],
+  ['@mui/material/transitions', esm(muiMaterialtransitions /* , muiMaterialtransitionsDefault */)],
+  ['@mui/material/CardActions', esm(muiMaterialCardActions, muiMaterialCardActionsDefault)],
+  ['@mui/material/ImageList', esm(muiMaterialImageList, muiMaterialImageListDefault)],
+  ['@mui/material/Portal', esm(muiMaterialPortal, muiMaterialPortalDefault)],
   [
     '@mui/material/TableContainer',
-    esm(muiMaterialTableContainerDefault, muiMaterialTableContainer),
+    esm(muiMaterialTableContainer, muiMaterialTableContainerDefault),
   ],
-  ['@mui/material/CardContent', esm(muiMaterialCardContentDefault, muiMaterialCardContent)],
-  ['@mui/material/ImageListItem', esm(muiMaterialImageListItemDefault, muiMaterialImageListItem)],
-  ['@mui/material/TableFooter', esm(muiMaterialTableFooterDefault, muiMaterialTableFooter)],
+  ['@mui/material/CardContent', esm(muiMaterialCardContent, muiMaterialCardContentDefault)],
+  ['@mui/material/ImageListItem', esm(muiMaterialImageListItem, muiMaterialImageListItemDefault)],
+  ['@mui/material/TableFooter', esm(muiMaterialTableFooter, muiMaterialTableFooterDefault)],
   [
     '@mui/material/useAutocomplete',
-    esm(muiMaterialuseAutocompleteDefault, muiMaterialuseAutocomplete),
+    esm(muiMaterialuseAutocomplete, muiMaterialuseAutocompleteDefault),
   ],
-  ['@mui/material/CardHeader', esm(muiMaterialCardHeaderDefault, muiMaterialCardHeader)],
+  ['@mui/material/CardHeader', esm(muiMaterialCardHeader, muiMaterialCardHeaderDefault)],
   [
     '@mui/material/ImageListItemBar',
-    esm(muiMaterialImageListItemBarDefault, muiMaterialImageListItemBar),
+    esm(muiMaterialImageListItemBar, muiMaterialImageListItemBarDefault),
   ],
-  ['@mui/material/Radio', esm(muiMaterialRadioDefault, muiMaterialRadio)],
-  ['@mui/material/TableHead', esm(muiMaterialTableHeadDefault, muiMaterialTableHead)],
-  ['@mui/material/useMediaQuery', esm(muiMaterialuseMediaQueryDefault, muiMaterialuseMediaQuery)],
-  ['@mui/material/CardMedia', esm(muiMaterialCardMediaDefault, muiMaterialCardMedia)],
-  ['@mui/material/Input', esm(muiMaterialInputDefault, muiMaterialInput)],
-  ['@mui/material/RadioGroup', esm(muiMaterialRadioGroupDefault, muiMaterialRadioGroup)],
+  ['@mui/material/Radio', esm(muiMaterialRadio, muiMaterialRadioDefault)],
+  ['@mui/material/TableHead', esm(muiMaterialTableHead, muiMaterialTableHeadDefault)],
+  ['@mui/material/useMediaQuery', esm(muiMaterialuseMediaQuery, muiMaterialuseMediaQueryDefault)],
+  ['@mui/material/CardMedia', esm(muiMaterialCardMedia, muiMaterialCardMediaDefault)],
+  ['@mui/material/Input', esm(muiMaterialInput, muiMaterialInputDefault)],
+  ['@mui/material/RadioGroup', esm(muiMaterialRadioGroup, muiMaterialRadioGroupDefault)],
   [
     '@mui/material/TablePagination',
-    esm(muiMaterialTablePaginationDefault, muiMaterialTablePagination),
+    esm(muiMaterialTablePagination, muiMaterialTablePaginationDefault),
   ],
-  ['@mui/material/usePagination', esm(muiMaterialusePaginationDefault, muiMaterialusePagination)],
-  ['@mui/material/Checkbox', esm(muiMaterialCheckboxDefault, muiMaterialCheckbox)],
+  ['@mui/material/usePagination', esm(muiMaterialusePagination, muiMaterialusePaginationDefault)],
+  ['@mui/material/Checkbox', esm(muiMaterialCheckbox, muiMaterialCheckboxDefault)],
   [
     '@mui/material/InputAdornment',
-    esm(muiMaterialInputAdornmentDefault, muiMaterialInputAdornment),
+    esm(muiMaterialInputAdornment, muiMaterialInputAdornmentDefault),
   ],
-  ['@mui/material/Rating', esm(muiMaterialRatingDefault, muiMaterialRating)],
-  ['@mui/material/TableRow', esm(muiMaterialTableRowDefault, muiMaterialTableRow)],
+  ['@mui/material/Rating', esm(muiMaterialRating, muiMaterialRatingDefault)],
+  ['@mui/material/TableRow', esm(muiMaterialTableRow, muiMaterialTableRowDefault)],
   [
     '@mui/material/useScrollTrigger',
-    esm(muiMaterialuseScrollTriggerDefault, muiMaterialuseScrollTrigger),
+    esm(muiMaterialuseScrollTrigger, muiMaterialuseScrollTriggerDefault),
   ],
-  ['@mui/material/Chip', esm(muiMaterialChipDefault, muiMaterialChip)],
-  ['@mui/material/InputBase', esm(muiMaterialInputBaseDefault, muiMaterialInputBase)],
+  ['@mui/material/Chip', esm(muiMaterialChip, muiMaterialChipDefault)],
+  ['@mui/material/InputBase', esm(muiMaterialInputBase, muiMaterialInputBaseDefault)],
   [
     '@mui/material/ScopedCssBaseline',
-    esm(muiMaterialScopedCssBaselineDefault, muiMaterialScopedCssBaseline),
+    esm(muiMaterialScopedCssBaseline, muiMaterialScopedCssBaselineDefault),
   ],
   [
     '@mui/material/TableSortLabel',
-    esm(muiMaterialTableSortLabelDefault, muiMaterialTableSortLabel),
+    esm(muiMaterialTableSortLabel, muiMaterialTableSortLabelDefault),
   ],
   [
     '@mui/material/useTouchRipple',
-    esm(muiMaterialuseTouchRippleDefault, muiMaterialuseTouchRipple),
+    esm(muiMaterialuseTouchRipple, muiMaterialuseTouchRippleDefault),
   ],
   [
     '@mui/material/CircularProgress',
-    esm(muiMaterialCircularProgressDefault, muiMaterialCircularProgress),
+    esm(muiMaterialCircularProgress, muiMaterialCircularProgressDefault),
   ],
-  ['@mui/material/InputLabel', esm(muiMaterialInputLabelDefault, muiMaterialInputLabel)],
-  ['@mui/material/Select', esm(muiMaterialSelectDefault, muiMaterialSelect)],
-  ['@mui/material/Tabs', esm(muiMaterialTabsDefault, muiMaterialTabs)],
-  ['@mui/material/utils', esm(muiMaterialutilsDefault, muiMaterialutils)],
+  ['@mui/material/InputLabel', esm(muiMaterialInputLabel, muiMaterialInputLabelDefault)],
+  ['@mui/material/Select', esm(muiMaterialSelect, muiMaterialSelectDefault)],
+  ['@mui/material/Tabs', esm(muiMaterialTabs, muiMaterialTabsDefault)],
+  ['@mui/material/utils', esm(muiMaterialutils, muiMaterialutilsDefault)],
   [
     '@mui/material/ClickAwayListener',
-    esm(muiMaterialClickAwayListenerDefault, muiMaterialClickAwayListener),
+    esm(muiMaterialClickAwayListener, muiMaterialClickAwayListenerDefault),
   ],
-  ['@mui/material/Skeleton', esm(muiMaterialSkeletonDefault, muiMaterialSkeleton)],
-  ['@mui/material/TextField', esm(muiMaterialTextFieldDefault, muiMaterialTextField)],
-  ['@mui/material/Collapse', esm(muiMaterialCollapseDefault, muiMaterialCollapse)],
+  ['@mui/material/Skeleton', esm(muiMaterialSkeleton, muiMaterialSkeletonDefault)],
+  ['@mui/material/TextField', esm(muiMaterialTextField, muiMaterialTextFieldDefault)],
+  ['@mui/material/Collapse', esm(muiMaterialCollapse, muiMaterialCollapseDefault)],
   [
     '@mui/material/LinearProgress',
-    esm(muiMaterialLinearProgressDefault, muiMaterialLinearProgress),
+    esm(muiMaterialLinearProgress, muiMaterialLinearProgressDefault),
   ],
-  ['@mui/material/Slide', esm(muiMaterialSlideDefault, muiMaterialSlide)],
+  ['@mui/material/Slide', esm(muiMaterialSlide, muiMaterialSlideDefault)],
   [
     '@mui/material/TextareaAutosize',
-    esm(muiMaterialTextareaAutosizeDefault, muiMaterialTextareaAutosize),
+    esm(muiMaterialTextareaAutosize, muiMaterialTextareaAutosizeDefault),
   ],
-  ['@mui/material/Container', esm(muiMaterialContainerDefault, muiMaterialContainer)],
-  ['@mui/material/Link', esm(muiMaterialLinkDefault, muiMaterialLink)],
-  ['@mui/material/Slider', esm(muiMaterialSliderDefault, muiMaterialSlider)],
-  ['@mui/material/ToggleButton', esm(muiMaterialToggleButtonDefault, muiMaterialToggleButton)],
+  ['@mui/material/Container', esm(muiMaterialContainer, muiMaterialContainerDefault)],
+  ['@mui/material/Link', esm(muiMaterialLink, muiMaterialLinkDefault)],
+  ['@mui/material/Slider', esm(muiMaterialSlider, muiMaterialSliderDefault)],
+  ['@mui/material/ToggleButton', esm(muiMaterialToggleButton, muiMaterialToggleButtonDefault)],
 ]);
 
 const muiDatePickersExports = new Map([
-  ['@mui/x-date-pickers', esm(muiXDatePickersDefault, muiXDatePickers)],
-  // ['@mui/x-date-pickers/AdapterDateFns', esm(muiXDatePickersAdapterDateFnsDefault, muiXDatePickersAdapterDateFns)],
+  ['@mui/x-date-pickers', esm(muiXDatePickers /* , muiXDatePickersDefault */)],
+  // ['@mui/x-date-pickers/AdapterDateFns', esm(muiXDatePickersAdapterDateFns, muiXDatePickersAdapterDateFnsDefault)],
   [
     '@mui/x-date-pickers/CalendarPickerSkeleton',
-    esm(muiXDatePickersCalendarPickerSkeletonDefault, muiXDatePickersCalendarPickerSkeleton),
+    esm(muiXDatePickersCalendarPickerSkeleton /* , muiXDatePickersCalendarPickerSkeletonDefault */),
   ],
   [
     '@mui/x-date-pickers/DesktopTimePicker',
-    esm(muiXDatePickersDesktopTimePickerDefault, muiXDatePickersDesktopTimePicker),
+    esm(muiXDatePickersDesktopTimePicker /* , muiXDatePickersDesktopTimePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/MonthPicker',
-    esm(muiXDatePickersMonthPickerDefault, muiXDatePickersMonthPicker),
+    esm(muiXDatePickersMonthPicker /* , muiXDatePickersMonthPickerDefault */),
   ],
   [
     '@mui/x-date-pickers/StaticTimePicker',
-    esm(muiXDatePickersStaticTimePickerDefault, muiXDatePickersStaticTimePicker),
+    esm(muiXDatePickersStaticTimePicker /* , muiXDatePickersStaticTimePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/AdapterDayjs',
-    esm(muiXDatePickersAdapterDayjsDefault, muiXDatePickersAdapterDayjs),
+    esm(muiXDatePickersAdapterDayjs /* , muiXDatePickersAdapterDayjsDefault */),
   ],
   [
     '@mui/x-date-pickers/ClockPicker',
-    esm(muiXDatePickersClockPickerDefault, muiXDatePickersClockPicker),
+    esm(muiXDatePickersClockPicker /* , muiXDatePickersClockPickerDefault */),
   ],
   [
     '@mui/x-date-pickers/PickersActionBar',
-    esm(muiXDatePickersPickersActionBarDefault, muiXDatePickersPickersActionBar),
+    esm(muiXDatePickersPickersActionBar /* , muiXDatePickersPickersActionBarDefault */),
   ],
   [
     '@mui/x-date-pickers/TimePicker',
-    esm(muiXDatePickersTimePickerDefault, muiXDatePickersTimePicker),
+    esm(muiXDatePickersTimePicker /* , muiXDatePickersTimePickerDefault */),
   ],
-  ['@mui/x-date-pickers/locales', esm(muiXDatePickerslocalesDefault, muiXDatePickerslocales)],
-  // ['@mui/x-date-pickers/AdapterLuxon', esm(muiXDatePickersAdapterLuxonDefault, muiXDatePickersAdapterLuxon)],
+  [
+    '@mui/x-date-pickers/locales',
+    esm(muiXDatePickerslocales /* , muiXDatePickerslocalesDefault */),
+  ],
+  // ['@mui/x-date-pickers/AdapterLuxon', esm(muiXDatePickersAdapterLuxon, muiXDatePickersAdapterLuxonDefault)],
   [
     '@mui/x-date-pickers/DatePicker',
-    esm(muiXDatePickersDatePickerDefault, muiXDatePickersDatePicker),
+    esm(muiXDatePickersDatePicker /* , muiXDatePickersDatePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/LocalizationProvider',
-    esm(muiXDatePickersLocalizationProviderDefault, muiXDatePickersLocalizationProvider),
+    esm(muiXDatePickersLocalizationProvider /* , muiXDatePickersLocalizationProviderDefault */),
   ],
   [
     '@mui/x-date-pickers/PickersDay',
-    esm(muiXDatePickersPickersDayDefault, muiXDatePickersPickersDay),
+    esm(muiXDatePickersPickersDay /* , muiXDatePickersPickersDayDefault */),
   ],
   [
     '@mui/x-date-pickers/YearPicker',
-    esm(muiXDatePickersYearPickerDefault, muiXDatePickersYearPicker),
+    esm(muiXDatePickersYearPicker /* , muiXDatePickersYearPickerDefault */),
   ],
-  // ['@mui/x-date-pickers/AdapterMoment', esm(muiXDatePickersAdapterMomentDefault, muiXDatePickersAdapterMoment)],
+  // ['@mui/x-date-pickers/AdapterMoment', esm(muiXDatePickersAdapterMoment, muiXDatePickersAdapterMomentDefault)],
   [
     '@mui/x-date-pickers/DateTimePicker',
-    esm(muiXDatePickersDateTimePickerDefault, muiXDatePickersDateTimePicker),
+    esm(muiXDatePickersDateTimePicker /* , muiXDatePickersDateTimePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/MobileDatePicker',
-    esm(muiXDatePickersMobileDatePickerDefault, muiXDatePickersMobileDatePicker),
+    esm(muiXDatePickersMobileDatePicker /* , muiXDatePickersMobileDatePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/DesktopDatePicker',
-    esm(muiXDatePickersDesktopDatePickerDefault, muiXDatePickersDesktopDatePicker),
+    esm(muiXDatePickersDesktopDatePicker /* , muiXDatePickersDesktopDatePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/MobileDateTimePicker',
-    esm(muiXDatePickersMobileDateTimePickerDefault, muiXDatePickersMobileDateTimePicker),
+    esm(muiXDatePickersMobileDateTimePicker /* , muiXDatePickersMobileDateTimePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/StaticDatePicker',
-    esm(muiXDatePickersStaticDatePickerDefault, muiXDatePickersStaticDatePicker),
+    esm(muiXDatePickersStaticDatePicker /* , muiXDatePickersStaticDatePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/CalendarPicker',
-    esm(muiXDatePickersCalendarPickerDefault, muiXDatePickersCalendarPicker),
+    esm(muiXDatePickersCalendarPicker /* , muiXDatePickersCalendarPickerDefault */),
   ],
   [
     '@mui/x-date-pickers/DesktopDateTimePicker',
-    esm(muiXDatePickersDesktopDateTimePickerDefault, muiXDatePickersDesktopDateTimePicker),
+    esm(muiXDatePickersDesktopDateTimePicker /* , muiXDatePickersDesktopDateTimePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/MobileTimePicker',
-    esm(muiXDatePickersMobileTimePickerDefault, muiXDatePickersMobileTimePicker),
+    esm(muiXDatePickersMobileTimePicker /* , muiXDatePickersMobileTimePickerDefault */),
   ],
   [
     '@mui/x-date-pickers/StaticDateTimePicker',
-    esm(muiXDatePickersStaticDateTimePickerDefault, muiXDatePickersStaticDateTimePicker),
+    esm(muiXDatePickersStaticDateTimePicker /* , muiXDatePickersStaticDateTimePickerDefault */),
   ],
 ]);
 
 const muiDatePickersProExports = new Map([
-  ['@mui/x-date-pickers-pro', esm(muiXDatePickersProDefault, muiXDatePickersPro)],
-  // ['@mui/x-date-pickers-pro/AdapterDateFns', esm(muiXDatePickersProAdapterDateFnsDefault, muiXDatePickersProAdapterDateFns)],
+  ['@mui/x-date-pickers-pro', esm(muiXDatePickersPro /* , muiXDatePickersProDefault */)],
+  // ['@mui/x-date-pickers-pro/AdapterDateFns', esm(muiXDatePickersProAdapterDateFns, muiXDatePickersProAdapterDateFnsDefault)],
   [
     '@mui/x-date-pickers-pro/DateRangePicker',
-    esm(muiXDatePickersProDateRangePickerDefault, muiXDatePickersProDateRangePicker),
+    esm(muiXDatePickersProDateRangePicker /* , muiXDatePickersProDateRangePickerDefault */),
   ],
   [
     '@mui/x-date-pickers-pro/MultiInputDateRangeField',
     esm(
-      muiXDatePickersProMultiInputDateRangeFieldDefault,
       muiXDatePickersProMultiInputDateRangeField,
+      /*   muiXDatePickersProMultiInputDateRangeFieldDefault, */
     ),
   ],
   [
     '@mui/x-date-pickers-pro/AdapterDayjs',
-    esm(muiXDatePickersProAdapterDayjsDefault, muiXDatePickersProAdapterDayjs),
+    esm(muiXDatePickersProAdapterDayjs /* , muiXDatePickersProAdapterDayjsDefault */),
   ],
   [
     '@mui/x-date-pickers-pro/DateRangePickerDay',
-    esm(muiXDatePickersProDateRangePickerDayDefault, muiXDatePickersProDateRangePickerDay),
+    esm(muiXDatePickersProDateRangePickerDay /* , muiXDatePickersProDateRangePickerDayDefault */),
   ],
-  // ['@mui/x-date-pickers-pro/AdapterLuxon', esm(muiXDatePickersProAdapterLuxonDefault, muiXDatePickersProAdapterLuxon)],
+  // ['@mui/x-date-pickers-pro/AdapterLuxon', esm(muiXDatePickersProAdapterLuxon, muiXDatePickersProAdapterLuxonDefault)],
   [
     '@mui/x-date-pickers-pro/DesktopDateRangePicker',
-    esm(muiXDatePickersProDesktopDateRangePickerDefault, muiXDatePickersProDesktopDateRangePicker),
+    esm(
+      muiXDatePickersProDesktopDateRangePicker /* , muiXDatePickersProDesktopDateRangePickerDefault */,
+    ),
   ],
   [
     '@mui/x-date-pickers-pro/SingleInputDateRangeField',
     esm(
-      muiXDatePickersProSingleInputDateRangeFieldDefault,
       muiXDatePickersProSingleInputDateRangeField,
+      /*   muiXDatePickersProSingleInputDateRangeFieldDefault, */
     ),
   ],
-  // ['@mui/x-date-pickers-pro/AdapterMoment', esm(muiXDatePickersProAdapterMomentDefault, muiXDatePickersProAdapterMoment)],
+  // ['@mui/x-date-pickers-pro/AdapterMoment', esm(muiXDatePickersProAdapterMoment, muiXDatePickersProAdapterMomentDefault)],
   [
     '@mui/x-date-pickers-pro/StaticDateRangePicker',
-    esm(muiXDatePickersProStaticDateRangePickerDefault, muiXDatePickersProStaticDateRangePicker),
+    esm(
+      muiXDatePickersProStaticDateRangePicker /* , muiXDatePickersProStaticDateRangePickerDefault */,
+    ),
   ],
   [
     '@mui/x-date-pickers-pro/MobileDateRangePicker',
-    esm(muiXDatePickersProMobileDateRangePickerDefault, muiXDatePickersProMobileDateRangePicker),
+    esm(
+      muiXDatePickersProMobileDateRangePicker /* , muiXDatePickersProMobileDateRangePickerDefault */,
+    ),
   ],
 ]);
 
 const muiDataGridExports = new Map([
-  ['@mui/x-data-grid', esm(muiXDataGridDefault, muiXDataGrid)],
-  ['@mui/x-data-grid/DataGrid', esm(muiXDataGridDataGridDefault, muiXDataGridDataGrid)],
+  ['@mui/x-data-grid', esm(muiXDataGrid /* , muiXDataGridDefault */)],
+  ['@mui/x-data-grid/DataGrid', esm(muiXDataGridDataGrid /* , muiXDataGridDataGridDefault */)],
 ]);
 
 const muiDataGridProExports = new Map([
-  ['@mui/x-data-grid-pro', esm(muiXDataGridProDefault, muiXDataGridPro)],
+  ['@mui/x-data-grid-pro', esm(muiXDataGridPro /* , muiXDataGridProDefault */)],
   [
     '@mui/x-data-grid-pro/DataGridPro',
-    esm(muiXDataGridProDataGridProDefault, muiXDataGridProDataGridPro),
+    esm(muiXDataGridProDataGridPro /* , muiXDataGridProDataGridProDefault */),
   ],
 ]);
 
 export default new Map([
-  ['dayjs', esm(DayJsDefault, DayJs)],
-  ['@mui/toolpad-core', esm(muiToolpadCoreDefault, muiToolpadCore)],
-  ['@mui/icons-material', esm(muiIconsMaterialDefault, muiIconsMaterial)],
+  ['dayjs', esm(DayJs, DayJsDefault)],
+  ['@mui/toolpad-core', esm(muiToolpadCore /* , muiToolpadCoreDefault */)],
+  ['@mui/icons-material', esm(muiIconsMaterial /* , muiIconsMaterialDefault */)],
 
   ...muiMaterialExports,
   ...muiDatePickersExports,
   ...muiDatePickersProExports,
   ...muiDataGridExports,
   ...muiDataGridProExports,
-  ['@mui/x-data-grid-generator', esm(muiXDataGridGeneratorDefault, muiXDataGridGenerator)],
+  ['@mui/x-data-grid-generator', esm(muiXDataGridGenerator /* , muiXDataGridGeneratorDefault */)],
 ]);

--- a/packages/toolpad-app/src/runtime/muiExports.tsx
+++ b/packages/toolpad-app/src/runtime/muiExports.tsx
@@ -3,7 +3,7 @@ import /* muiToolpadCoreDefault, */ * as muiToolpadCore from '@mui/toolpad-core'
 // eslint-disable-next-line no-restricted-imports
 import /* muiIconsMaterialDefault, */ * as muiIconsMaterial from '@mui/icons-material';
 
-import muiMaterialDefault, * as muiMaterial from '@mui/material';
+import /* muiMaterialDefault, */ * as muiMaterial from '@mui/material';
 import muiMaterialAccordionDefault, * as muiMaterialAccordion from '@mui/material/Accordion';
 import muiMaterialCssBaselineDefault, * as muiMaterialCssBaseline from '@mui/material/CssBaseline';
 import muiMaterialListDefault, * as muiMaterialList from '@mui/material/List';
@@ -135,7 +135,7 @@ import muiMaterialCircularProgressDefault, * as muiMaterialCircularProgress from
 import muiMaterialInputLabelDefault, * as muiMaterialInputLabel from '@mui/material/InputLabel';
 import muiMaterialSelectDefault, * as muiMaterialSelect from '@mui/material/Select';
 import muiMaterialTabsDefault, * as muiMaterialTabs from '@mui/material/Tabs';
-import muiMaterialutilsDefault, * as muiMaterialutils from '@mui/material/utils';
+import /* muiMaterialutilsDefault, */ * as muiMaterialutils from '@mui/material/utils';
 import muiMaterialClickAwayListenerDefault, * as muiMaterialClickAwayListener from '@mui/material/ClickAwayListener';
 import muiMaterialSkeletonDefault, * as muiMaterialSkeleton from '@mui/material/Skeleton';
 import muiMaterialTextFieldDefault, * as muiMaterialTextField from '@mui/material/TextField';
@@ -195,7 +195,7 @@ function esm(namedExports: any, defaultExport?: any) {
 }
 
 const muiMaterialExports = new Map([
-  ['@mui/material', esm(muiMaterial, muiMaterialDefault)],
+  ['@mui/material', esm(muiMaterial /* , muiMaterialDefault */)],
   ['@mui/material/Accordion', esm(muiMaterialAccordion, muiMaterialAccordionDefault)],
   ['@mui/material/CssBaseline', esm(muiMaterialCssBaseline, muiMaterialCssBaselineDefault)],
   ['@mui/material/List', esm(muiMaterialList, muiMaterialListDefault)],
@@ -420,7 +420,7 @@ const muiMaterialExports = new Map([
   ['@mui/material/InputLabel', esm(muiMaterialInputLabel, muiMaterialInputLabelDefault)],
   ['@mui/material/Select', esm(muiMaterialSelect, muiMaterialSelectDefault)],
   ['@mui/material/Tabs', esm(muiMaterialTabs, muiMaterialTabsDefault)],
-  ['@mui/material/utils', esm(muiMaterialutils, muiMaterialutilsDefault)],
+  ['@mui/material/utils', esm(muiMaterialutils /* , muiMaterialutilsDefault */)],
   [
     '@mui/material/ClickAwayListener',
     esm(muiMaterialClickAwayListener, muiMaterialClickAwayListenerDefault),


### PR DESCRIPTION
Running into this trying to build a new runtime with a build step for https://github.com/mui/mui-toolpad/pull/1521

There have been a bunch of missing exports warnings in webpack release build. This PR turns those warnings into errors, and removes the missing default imports. I'm leaving them as comments for documentation purposes. Even though in general we avoid committing commented out code. This file is intended to become obsolete anyway once a build step is introduced.
