### PR TITLE
Fix DataGrid number formats for non-numerical values

### DIFF
--- a/packages/toolpad-app/pages/api/data/[appId]/[version]/[queryId].ts
+++ b/packages/toolpad-app/pages/api/data/[appId]/[version]/[queryId].ts
@@ -12,7 +12,7 @@ const apiHandler = (async (req, res) => {
   }
 
   const version = parseVersion(req.query.version);
-  if (!version) {
+  if (typeof version !== 'number' && version !== 'preview') {
     res.status(404).end();
     return;
   }

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -231,6 +231,12 @@ export function inferColumns(rows: GridRowsProp): SerializableGridColumns {
   });
 }
 
+function createNumericFormatter(
+  format: (value: number) => string,
+): (params: GridValueFormatterParams<unknown>) => string {
+  return ({ value }) => (typeof value === 'number' ? format(value) : String(value || ''));
+}
+
 export function parseColumns(columns: SerializableGridColumns): GridColumns {
   return columns.map((column) => {
     if (column.type === 'number' && column.numberFormat) {
@@ -238,11 +244,17 @@ export function parseColumns(columns: SerializableGridColumns): GridColumns {
         case 'preset': {
           const preset = NUMBER_FORMAT_PRESETS.get(column.numberFormat.preset);
           const { format } = new Intl.NumberFormat(undefined, preset?.options);
-          return { ...column, valueFormatter: ({ value }) => format(value) };
+          return {
+            ...column,
+            valueFormatter: createNumericFormatter((value) => format(value)),
+          };
         }
         case 'custom': {
           const { format } = new Intl.NumberFormat(undefined, column.numberFormat.custom);
-          return { ...column, valueFormatter: ({ value }) => format(value) };
+          return {
+            ...column,
+            valueFormatter: createNumericFormatter((value) => format(value)),
+          };
         }
         case 'currency': {
           const userInput = column.numberFormat.currency || 'USD';
@@ -251,10 +263,16 @@ export function parseColumns(columns: SerializableGridColumns): GridColumns {
               style: 'currency',
               currency: userInput,
             });
-            return { ...column, valueFormatter: ({ value }) => format(value) };
+            return {
+              ...column,
+              valueFormatter: createNumericFormatter((value) => format(value)),
+            };
           }
           const { format } = new Intl.NumberFormat(undefined, {});
-          return { ...column, valueFormatter: ({ value }) => `${userInput} ${format(value)}` };
+          return {
+            ...column,
+            valueFormatter: createNumericFormatter((value) => `${userInput} ${format(value)}`),
+          };
         }
         default: {
           return column;


### PR DESCRIPTION
Show empty when the value can't be formatted as a number

Found out in https://bundle-size.onrender.com/prod/pages/h71gdad?circleCIBuildNumber=478251&baseRef=master&baseCommit=467a3af67ee21b4a0949d0053b2113b89e1cd6ca&prNumber=36001