### PR TITLE
Add in page settings option to sidebar to allow for easier access to page module settings

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -256,7 +256,10 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
       const node = appDom.getNode(dom, nodeId);
 
       if (appDom.isPage(node)) {
-        domApi.update(dom => dom, { view: { kind: 'page', nodeId: node.id }, selectedNodeId: null });
+        domApi.update((dom) => dom, {
+          view: { kind: 'page', nodeId: node.id },
+          selectedNodeId: null,
+        });
       }
     },
     [dom, domApi],

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -170,6 +170,7 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
     }
 
     if (appDom.isPage(node)) {
+      domApi.deselectNode();
       domApi.setView({ kind: 'page', nodeId: node.id });
     }
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -253,12 +253,10 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
 
   const handlePageSettingsNode = React.useCallback(
     (nodeId: NodeId) => {
-      if (nodeId) {
-        const node = appDom.getNode(dom, nodeId);
-        if (appDom.isPage(node)) {
-          domApi.setView({ kind: 'page', nodeId: node.id });
-          domApi.deselectNode();
-        }
+      const node = appDom.getNode(dom, nodeId);
+
+      if (appDom.isPage(node)) {
+        domApi.update(dom => dom, { view: { kind: 'page', nodeId: node.id }, selectedNodeId: null });
       }
     },
     [dom, domApi],

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -44,12 +44,14 @@ const StyledTreeItem = styled(TreeItem)({
 type StyledTreeItemProps = TreeItemProps & {
   onDeleteNode?: (nodeId: NodeId) => void;
   onDuplicateNode?: (nodeId: NodeId) => void;
+  onSettingsNode?: (nodeId: NodeId) => void;
   onCreate?: React.MouseEventHandler;
   labelIcon?: React.ReactNode;
   labelText: string;
   createLabelText?: string;
   deleteLabelText?: string;
   duplicateLabelText?: string;
+  settingsLabelText?: string;
   toolpadNodeId?: NodeId;
 };
 
@@ -60,9 +62,11 @@ function HierarchyTreeItem(props: StyledTreeItemProps) {
     onCreate,
     onDeleteNode,
     onDuplicateNode,
+    onSettingsNode,
     createLabelText,
     deleteLabelText = 'Delete',
     duplicateLabelText = 'Duplicate',
+    settingsLabelText = 'Settings',
     toolpadNodeId,
     ...other
   } = props;
@@ -98,6 +102,8 @@ function HierarchyTreeItem(props: StyledTreeItemProps) {
               duplicateLabelText={duplicateLabelText}
               onDeleteNode={onDeleteNode}
               onDuplicateNode={onDuplicateNode}
+              onSettingsNode={onSettingsNode}
+              settingsLabelText={settingsLabelText}
             />
           ) : null}
         </Box>
@@ -244,6 +250,19 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
     [dom, domApi],
   );
 
+  const handlePageSettingsNode = React.useCallback(
+    (nodeId: NodeId) => {
+      if (nodeId) {
+        const node = appDom.getNode(dom, nodeId);
+        if (appDom.isPage(node)) {
+          domApi.setView({ kind: 'page', nodeId: node.id });
+          domApi.deselectNode();
+        }
+      }
+    },
+    [dom, domApi],
+  );
+
   const hasConnectionsView = !config.localMode && !config.isDemo;
   const hasComponentsView = !config.localMode;
 
@@ -317,6 +336,7 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
               labelText={page.name}
               onDuplicateNode={handleDuplicateNode}
               onDeleteNode={handleDeleteNode}
+              onSettingsNode={handlePageSettingsNode}
             />
           ))}
         </HierarchyTreeItem>

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -256,7 +256,7 @@ export default function HierarchyExplorer({ appId, className }: HierarchyExplore
       const node = appDom.getNode(dom, nodeId);
 
       if (appDom.isPage(node)) {
-        domApi.update((dom) => dom, {
+        domApi.update((draft) => draft, {
           view: { kind: 'page', nodeId: node.id },
           selectedNodeId: null,
         });

--- a/packages/toolpad-app/src/toolpad/AppEditor/NodeMenu.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/NodeMenu.tsx
@@ -88,14 +88,14 @@ export default function NodeMenu({
           menuProps.onClick?.(event);
         }}
       >
-        {onSettingsNode && (
+        {onSettingsNode ? (
           <MenuItem onClick={handleSettingsClick}>
             <ListItemIcon>
               <SettingsIcon />
             </ListItemIcon>
             <ListItemText>{settingsLabelText}</ListItemText>
           </MenuItem>
-        )}
+        ) : null}
         <MenuItem onClick={handleDuplicateClick}>
           <ListItemIcon>
             <ContentCopyIcon />

--- a/packages/toolpad-app/src/toolpad/AppEditor/NodeMenu.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/NodeMenu.tsx
@@ -2,6 +2,7 @@ import { MenuItem, Menu, ListItemIcon, ListItemText, ButtonProps, MenuProps } fr
 import * as React from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import SettingsIcon from '@mui/icons-material/Settings';
 import { NodeId } from '@mui/toolpad-core';
 import * as appDom from '../../appDom';
 import { useDom } from '../DomLoader';
@@ -14,8 +15,10 @@ export interface NodeMenuProps {
   renderButton: (params: { buttonProps: ButtonProps; menuProps: MenuProps }) => React.ReactNode;
   deleteLabelText?: string;
   duplicateLabelText?: string;
+  settingsLabelText?: string;
   onDeleteNode?: (nodeId: NodeId) => void;
   onDuplicateNode?: (nodeId: NodeId) => void;
+  onSettingsNode?: (nodeId: NodeId) => void;
 }
 
 export default function NodeMenu({
@@ -23,8 +26,10 @@ export default function NodeMenu({
   renderButton,
   deleteLabelText,
   duplicateLabelText,
+  settingsLabelText,
   onDeleteNode,
   onDuplicateNode,
+  onSettingsNode,
 }: NodeMenuProps) {
   const { dom } = useDom();
 
@@ -62,6 +67,14 @@ export default function NodeMenu({
     [onDuplicateNode, nodeId, onMenuClose],
   );
 
+  const handleSettingsClick = React.useCallback(
+    (event: React.MouseEvent) => {
+      onMenuClose(event);
+      onSettingsNode?.(nodeId);
+    },
+    [onSettingsNode, nodeId, onMenuClose],
+  );
+
   return (
     <React.Fragment>
       {renderButton({
@@ -75,6 +88,14 @@ export default function NodeMenu({
           menuProps.onClick?.(event);
         }}
       >
+        {onSettingsNode && (
+          <MenuItem onClick={handleSettingsClick}>
+            <ListItemIcon>
+              <SettingsIcon />
+            </ListItemIcon>
+            <ListItemText>{settingsLabelText}</ListItemText>
+          </MenuItem>
+        )}
         <MenuItem onClick={handleDuplicateClick}>
           <ListItemIcon>
             <ContentCopyIcon />


### PR DESCRIPTION
One of the harder things to understand with the toolpad so far is how to access your page settings. Right now:

- Clicking on the page on the left side won't show the settings (if you are currently on that same page and have another node selected in the editor)
- Accessing the menu gives me the option to duplicate or delete, but I needed to realize to click "off" any components and it would finally show the page settings.

- Even clicking between pages doesn't seem to show Page Settings again (notice the right hand side still shows "Data Grid", even when I'm on a separate page):

![between-pages](https://user-images.githubusercontent.com/463175/218758680-2b1927e2-11a3-4c25-9700-c01110a61cdd.gif)

The only way to really access page settings is to know to click off any component on the page, which when a page is complex, might be hard to understand (you'll need to find some whitespace to click on, and that whitespace might be minimal).

This PR adds a small item to the `NavMenu` dropdown to support "Settings", which can help alleviate this.

## Visual demonstration
![page-settings-menu](https://user-images.githubusercontent.com/463175/218757077-028a4e39-d9f2-456b-a25e-5aa73d4690a2.gif)

<img width="1728" alt="Screenshot 2023-02-14 at 8 49 07 AM" src="https://user-images.githubusercontent.com/463175/218757282-21f0b578-7d8a-4381-90ed-d9c9e0edcf03.png">

