### PR TITLE
Fix binding editor confirm on unsaved changes

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/BindingEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/BindingEditor.tsx
@@ -315,7 +315,7 @@ export function BindingEditorDialog<V>({
     }
   }, [open, value]);
 
-  const committedInput = React.useRef<BindableAttrValue<V> | null>(null);
+  const committedInput = React.useRef<BindableAttrValue<V> | null>(input);
 
   const handleSave = React.useCallback(() => {
     let newValue = input;
@@ -331,7 +331,9 @@ export function BindingEditorDialog<V>({
     onChange(newValue);
   }, [onChange, input]);
 
-  const hasUnsavedChanges = input ? input !== committedInput.current : false;
+  const hasUnsavedChanges = input
+    ? input.type !== committedInput.current?.type || input.value !== committedInput.current?.value
+    : false;
 
   const { handleCloseWithUnsavedChanges } = useUnsavedChangesConfirm({
     hasUnsavedChanges,


### PR DESCRIPTION
Fix issue reported by @oliviertassinari in https://github.com/mui/mui-toolpad/pull/1618#issuecomment-1438885548:

Do not show confirmation popup if there have been no changes in the binding editor since it was opened, or if there were changes but the value on leaving is the same as the initial value

https://user-images.githubusercontent.com/10789765/220441075-c3887a36-6870-4f58-9530-26ddaf0c0bde.mov

