### PR TITLE
Disable bindings for properties that can be controlled in canvas

### DIFF
--- a/packages/toolpad-app/src/constants.ts
+++ b/packages/toolpad-app/src/constants.ts
@@ -28,3 +28,5 @@ export const PRODUCTION_DATASOURCES = new Set([
 export const APP_ID_LOCAL_MARKER = '__LOCAL_MODE_APP_';
 
 export const TOOLPAD_BRIDGE_GLOBAL = '__TOOLPAD_BRIDGE__';
+
+export const NON_BINDABLE_CONTROL_TYPES = ['GridColumns'];

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
@@ -17,8 +17,7 @@ import { usePageEditorState } from './PageEditorProvider';
 import { getDefaultControl } from '../../propertyControls';
 import MarkdownTooltip from '../../../components/MarkdownTooltip';
 import { isTemplateDescendant } from '../../../toolpadComponents/template';
-
-const NON_BINDABLE_CONTROL_TYPES = ['GridColumns'];
+import { NON_BINDABLE_CONTROL_TYPES } from '../../../constants';
 
 export interface NodeAttributeEditorProps<P extends object> {
   node: appDom.AppDomNode;


### PR DESCRIPTION
Finishes fixing https://github.com/mui/mui-toolpad/issues/1614.

Disable bindings for properties controllable in the canvas:
- resizable height properties such as "height" in DataGrid
- "columns" property in DataGrid

It was still possible to bind to these properties in the binding editor, but not after this PR.