### PR TITLE
Remove deprecated waitForNavigation playwright API

### DIFF
--- a/test/integration/appTemplates.spec.ts
+++ b/test/integration/appTemplates.spec.ts
@@ -7,8 +7,6 @@ test('can use default app template', async ({ page }) => {
   await homeModel.goto();
   const app = await homeModel.createApplication({ appTemplateId: 'default' });
 
-  page.waitForNavigation();
-
   const runtimeModel = new ToolpadRuntime(page);
   await runtimeModel.gotoPage(app.id, 'page1');
 
@@ -21,8 +19,6 @@ test('can use hr template', async ({ page }) => {
   await homeModel.goto();
   const app = await homeModel.createApplication({ appTemplateId: 'hr' });
 
-  page.waitForNavigation();
-
   const runtimeModel = new ToolpadRuntime(page);
   await runtimeModel.gotoPage(app.id, 'page1');
 
@@ -34,8 +30,6 @@ test('can use images app template', async ({ page }) => {
   const homeModel = new ToolpadHome(page);
   await homeModel.goto();
   const app = await homeModel.createApplication({ appTemplateId: 'images' });
-
-  page.waitForNavigation();
 
   const runtimeModel = new ToolpadRuntime(page);
   await runtimeModel.gotoPage(app.id, 'dogBreedsPage');

--- a/test/integration/duplication/index.spec.ts
+++ b/test/integration/duplication/index.spec.ts
@@ -17,7 +17,9 @@ test('duplication', async ({ page, api }) => {
   {
     await editorModel.openHierarchyMenu('connections', 'connection');
     const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate' });
-    await Promise.all([duplicateMenuItem.click(), page.waitForNavigation()]);
+    await duplicateMenuItem.click();
+
+    await page.waitForURL(/\/_toolpad\/app\/[^/]+\/connections\/[^/]+$/);
 
     const input = page.getByLabel('base url');
     await expect(input).toHaveValue('https://example.com/');
@@ -26,7 +28,7 @@ test('duplication', async ({ page, api }) => {
     const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete' });
     await deleteMenuItem.click();
     const deleteButton = editorModel.confirmationDialog.getByRole('button', { name: 'Delete' });
-    await Promise.all([deleteButton.click(), page.waitForNavigation()]);
+    await deleteButton.click();
 
     await expect(editorModel.hierarchyItem('connections', 'connection1')).toBeHidden();
   }
@@ -34,13 +36,15 @@ test('duplication', async ({ page, api }) => {
   {
     await editorModel.openHierarchyMenu('components', 'myComponent');
     const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate' });
-    await Promise.all([duplicateMenuItem.click(), page.waitForNavigation()]);
+    await duplicateMenuItem.click();
+
+    await page.waitForURL(/\/_toolpad\/app\/[^/]+\/codeComponents\/[^/]+$/);
 
     await editorModel.openHierarchyMenu('components', 'myComponent1');
     const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete' });
     await deleteMenuItem.click();
     const deleteButton = editorModel.confirmationDialog.getByRole('button', { name: 'Delete' });
-    await Promise.all([deleteButton.click(), page.waitForNavigation()]);
+    await deleteButton.click();
 
     await expect(editorModel.hierarchyItem('components', 'myComponent1')).toBeHidden();
   }
@@ -48,7 +52,9 @@ test('duplication', async ({ page, api }) => {
   {
     await editorModel.openHierarchyMenu('pages', 'page1');
     const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate' });
-    await Promise.all([duplicateMenuItem.click(), page.waitForNavigation()]);
+    await duplicateMenuItem.click();
+
+    await page.waitForURL(/\/_toolpad\/app\/[^/]+\/pages\/[^/]+$/);
 
     const button = editorModel.appCanvas.getByRole('button', { name: 'hello world' });
     await expect(button).toBeVisible();
@@ -57,7 +63,7 @@ test('duplication', async ({ page, api }) => {
     const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete' });
     await deleteMenuItem.click();
     const deleteButton = editorModel.confirmationDialog.getByRole('button', { name: 'Delete' });
-    await Promise.all([deleteButton.click(), page.waitForNavigation()]);
+    await deleteButton.click();
 
     await expect(editorModel.hierarchyItem('pages', 'page2')).toBeHidden();
   }

--- a/test/integration/editor/index.spec.ts
+++ b/test/integration/editor/index.spec.ts
@@ -1,24 +1,11 @@
 import * as path from 'path';
-import * as url from 'url';
 import { test, expect } from '../../playwright/test.js';
 import { ToolpadEditor } from '../../models/ToolpadEditor.js';
 import clickCenter from '../../utils/clickCenter.js';
 import generateId from '../../utils/generateId.js';
 import { readJsonFile } from '../../utils/fs.js';
 
-const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
-
-async function runApp() {
-  const { execa } = await import('execa');
-  const x = await execa('toolpad', ['start'], {
-    cwd: currentDirectory,
-  });
-  console.log(x.stdout);
-}
-
-test.only('can place new components from catalog', async ({ page, api }) => {
-  await runApp();
-
+test('can place new components from catalog', async ({ page, api }) => {
   const app = await api.mutation.createApp(`App ${generateId()}`);
 
   const editorModel = new ToolpadEditor(page);

--- a/test/integration/editor/index.spec.ts
+++ b/test/integration/editor/index.spec.ts
@@ -1,9 +1,9 @@
 import * as path from 'path';
-import { test, expect } from '../../playwright/test.js';
-import { ToolpadEditor } from '../../models/ToolpadEditor.js';
-import clickCenter from '../../utils/clickCenter.js';
-import generateId from '../../utils/generateId.js';
-import { readJsonFile } from '../../utils/fs.js';
+import { test, expect } from '../../playwright/test';
+import { ToolpadEditor } from '../../models/ToolpadEditor';
+import clickCenter from '../../utils/clickCenter';
+import generateId from '../../utils/generateId';
+import { readJsonFile } from '../../utils/fs';
 
 test('can place new components from catalog', async ({ page, api }) => {
   const app = await api.mutation.createApp(`App ${generateId()}`);

--- a/test/integration/editor/index.spec.ts
+++ b/test/integration/editor/index.spec.ts
@@ -1,11 +1,24 @@
 import * as path from 'path';
-import { test, expect } from '../../playwright/test';
-import { ToolpadEditor } from '../../models/ToolpadEditor';
-import clickCenter from '../../utils/clickCenter';
-import generateId from '../../utils/generateId';
-import { readJsonFile } from '../../utils/fs';
+import * as url from 'url';
+import { test, expect } from '../../playwright/test.js';
+import { ToolpadEditor } from '../../models/ToolpadEditor.js';
+import clickCenter from '../../utils/clickCenter.js';
+import generateId from '../../utils/generateId.js';
+import { readJsonFile } from '../../utils/fs.js';
 
-test('can place new components from catalog', async ({ page, api }) => {
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+
+async function runApp() {
+  const { execa } = await import('execa');
+  const x = await execa('toolpad', ['start'], {
+    cwd: currentDirectory,
+  });
+  console.log(x.stdout);
+}
+
+test.only('can place new components from catalog', async ({ page, api }) => {
+  await runApp();
+
   const app = await api.mutation.createApp(`App ${generateId()}`);
 
   const editorModel = new ToolpadEditor(page);


### PR DESCRIPTION
Noticed
```tsx
page.waitForNavigation();
```
in tests, without `await`, so it was not doing anything. It also seems to be deprecated by playwright for being racey, so I replaced it everywhere