### PR TITLE
New create component flow

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -4,10 +4,14 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  IconButton,
+  Portal,
+  Snackbar,
   TextField,
 } from '@mui/material';
 import * as React from 'react';
 import invariant from 'invariant';
+import CloseIcon from '@mui/icons-material/Close';
 import * as appDom from '../../../appDom';
 import { useAppStateApi, useDom } from '../../AppState';
 import { format } from '../../../utils/prettier';
@@ -16,6 +20,7 @@ import useEvent from '../../../utils/useEvent';
 import { useNodeNameValidation } from './validation';
 import client from '../../../api';
 import config from '../../../config';
+import useLatest from '../../../utils/useLatest';
 
 const DEFAULT_NAME = 'MyComponent';
 
@@ -86,66 +91,104 @@ export default function CreateCodeComponentDialog({
   const isNameValid = !inputErrorMsg;
   const isFormValid = isNameValid;
 
+  const [snackbarState, setSnackbarState] = React.useState<{ name: string } | null>(null);
+  const lastSnackbarState = useLatest(snackbarState);
+  const handleSnackbarClose = React.useCallback(() => {
+    setSnackbarState(null);
+  }, []);
+
   return (
-    <Dialog open={open} onClose={onClose} {...props}>
-      <DialogForm
-        autoComplete="off"
-        onSubmit={(event) => {
-          invariant(isFormValid, 'Invalid form should not be submitted when submit is disabled');
+    <React.Fragment>
+      <Dialog open={open} onClose={onClose} {...props}>
+        <DialogForm
+          autoComplete="off"
+          onSubmit={(event) => {
+            invariant(isFormValid, 'Invalid form should not be submitted when submit is disabled');
 
-          event.preventDefault();
-          const newNode = appDom.createNode(dom, 'codeComponent', {
-            name,
-            attributes: {
-              code: appDom.createConst(createDefaultCodeComponent(name)),
-              isNew: appDom.createConst(true),
-            },
-          });
-          const appNode = appDom.getApp(dom);
-
-          if (config.localMode) {
-            appStateApi.update((draft) =>
-              appDom.addNode(draft, newNode, appNode, 'codeComponents'),
-            );
-
-            client.mutation.openCodeComponentEditor(name);
-          } else {
-            appStateApi.update(
-              (draft) => appDom.addNode(draft, newNode, appNode, 'codeComponents'),
-              {
-                kind: 'codeComponent',
-                nodeId: newNode.id,
+            event.preventDefault();
+            const newNode = appDom.createNode(dom, 'codeComponent', {
+              name,
+              attributes: {
+                code: appDom.createConst(createDefaultCodeComponent(name)),
+                isNew: appDom.createConst(true),
               },
-            );
-          }
+            });
+            const appNode = appDom.getApp(dom);
 
-          onClose();
-        }}
-      >
-        <DialogTitle>Create a new Code Component</DialogTitle>
-        <DialogContent>
-          <TextField
-            sx={{ my: 1 }}
-            required
-            onFocus={handleInputFocus}
-            autoFocus
-            fullWidth
-            label="name"
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            error={!isNameValid}
-            helperText={inputErrorMsg}
+            if (config.localMode) {
+              appStateApi.update((draft) =>
+                appDom.addNode(draft, newNode, appNode, 'codeComponents'),
+              );
+
+              setSnackbarState({ name });
+            } else {
+              appStateApi.update(
+                (draft) => appDom.addNode(draft, newNode, appNode, 'codeComponents'),
+                {
+                  kind: 'codeComponent',
+                  nodeId: newNode.id,
+                },
+              );
+            }
+
+            onClose();
+          }}
+        >
+          <DialogTitle>Create a new Code Component</DialogTitle>
+          <DialogContent>
+            <TextField
+              sx={{ my: 1 }}
+              required
+              onFocus={handleInputFocus}
+              autoFocus
+              fullWidth
+              label="name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              error={open && !isNameValid}
+              helperText={inputErrorMsg}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button color="inherit" variant="text" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isFormValid}>
+              Create
+            </Button>
+          </DialogActions>
+        </DialogForm>
+      </Dialog>
+      {lastSnackbarState ? (
+        <Portal>
+          <Snackbar
+            open={!!snackbarState}
+            onClose={handleSnackbarClose}
+            message={`Component "${lastSnackbarState.name}" created`}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            action={
+              <React.Fragment>
+                <Button
+                  size="small"
+                  onClick={() => {
+                    client.mutation.openCodeComponentEditor(name);
+                  }}
+                >
+                  Open
+                </Button>
+                <IconButton
+                  size="small"
+                  aria-label="close"
+                  color="inherit"
+                  onClick={handleSnackbarClose}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </React.Fragment>
+            }
           />
-        </DialogContent>
-        <DialogActions>
-          <Button color="inherit" variant="text" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button type="submit" disabled={!isFormValid}>
-            Create
-          </Button>
-        </DialogActions>
-      </DialogForm>
-    </Dialog>
+        </Portal>
+      ) : null}
+    </React.Fragment>
   );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
@@ -59,15 +59,6 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
     'catalog-future-expanded',
     true,
   );
-  const [createCodeComponentDialogOpen, setCreateCodeComponentDialogOpen] = React.useState(0);
-
-  const handleCreateCodeComponentDialogOpen = React.useCallback(() => {
-    setCreateCodeComponentDialogOpen(Math.random());
-  }, []);
-  const handleCreateCodeComponentDialogClose = React.useCallback(
-    () => setCreateCodeComponentDialogOpen(0),
-    [],
-  );
 
   const closeTimeoutRef = React.useRef<NodeJS.Timeout>();
   const openDrawer = React.useCallback(() => {
@@ -97,6 +88,17 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
 
   const handleMouseEnter = React.useCallback(() => openDrawer(), [openDrawer]);
   const handleMouseLeave = React.useCallback(() => closeDrawer(), [closeDrawer]);
+
+  const [createCodeComponentDialogOpen, setCreateCodeComponentDialogOpen] = React.useState(false);
+
+  const handleCreateCodeComponentDialogOpen = React.useCallback(() => {
+    setCreateCodeComponentDialogOpen(true);
+    closeDrawer(0);
+  }, [closeDrawer]);
+  const handleCreateCodeComponentDialogClose = React.useCallback(
+    () => setCreateCodeComponentDialogOpen(false),
+    [],
+  );
 
   return (
     <ComponentCatalogRoot
@@ -283,7 +285,6 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
         </Box>
       </Box>
       <CreateCodeComponentNodeDialog
-        key={createCodeComponentDialogOpen || undefined}
         appId={pageState.appId}
         open={!!createCodeComponentDialogOpen}
         onClose={handleCreateCodeComponentDialogClose}


### PR DESCRIPTION
Too many issues in the tests with vscode automatically opening. Adding a snackbar instead to bring the user back in control and only open vscode on explicit user interaction


https://user-images.githubusercontent.com/2109932/220999536-378de086-3b39-4a29-bc8d-df1689d5abed.mov

