### PR TITLE
Make Toolpad work offline

### DIFF
--- a/packages/toolpad-app/src/api.ts
+++ b/packages/toolpad-app/src/api.ts
@@ -11,7 +11,16 @@ import {
 import type { Definition, MethodsGroup, MethodsOf, ServerDefinition } from '../pages/api/rpc';
 import { createRpcClient } from './rpcClient';
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      networkMode: 'always',
+    },
+    mutations: {
+      networkMode: 'always',
+    },
+  },
+});
 
 export interface UseQueryFnOptions<F extends (...args: any[]) => any>
   extends Omit<

--- a/test/playwright/test.ts
+++ b/test/playwright/test.ts
@@ -19,6 +19,7 @@ interface ConsoleEntry {
 const IGNORED_ERRORS = [
   /JavaScript Error: "downloadable font: download failed \(font-family: "Roboto" style:normal/,
   /JavaScript Error: "Image corrupt or truncated./,
+  /net::ERR_INTERNET_DISCONNECTED/,
 ];
 
 export type Options = { ignoreConsoleErrors: RegExp[] };


### PR DESCRIPTION
Discovered while on the plane this afternoon. `react-query` by default [doesn't fetch](https://tanstack.com/query/v4/docs/react/guides/network-mode) when it detects being offline