### PR TITLE
Fix config file being deleted

### DIFF
--- a/packages/toolpad-app/pages/api/runtime/[[...path]].ts
+++ b/packages/toolpad-app/pages/api/runtime/[[...path]].ts
@@ -28,7 +28,7 @@ async function getBuilder() {
       }
 
       const builder = await createBuilder({
-        filePath: getConfigFilePath(),
+        filePath: await getConfigFilePath(),
         dev: true,
       });
 


### PR DESCRIPTION
* Do not migrate the config file by extension, just read/write from which one is available: .yml or .yaml
* Pipe childprocess output before waiting on output, to see immediate feedback of the app starting
* Make sure the healthcheck works on node.js <= 16 that don't have global fetch
     > note: in dev mode it needs to wait unnecessarily long until the `/healthcheck` path has been built. I propose we don't healthcheck and just rely on the child process output to tell when it's ready

Fixes https://github.com/mui/mui-toolpad/issues/1724 ?