### PR TITLE
Allow falsy MySQL variable values

### DIFF
--- a/packages/toolpad-app/src/toolpadDataSources/mysql/server.ts
+++ b/packages/toolpad-app/src/toolpadDataSources/mysql/server.ts
@@ -18,7 +18,7 @@ function prepareQuery(sql: string, params: Record<string, string>) {
       const trimmedMatch = match.trim().replaceAll(/[']+/g, '');
       if (trimmedMatch[0] === '$') {
         const varName = trimmedMatch.slice(1);
-        if (params[varName]) {
+        if (typeof params[varName] !== 'undefined') {
           substitutions.push(params[varName]);
         }
         return '?';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

When sending a falsy (`0`/`false`) variable to MySQL to be substituted, it will ignore the variable and you will get a prepared statement error since it can't find all the substitutions. This fixes that bug.

## Alternatives

We could also do a `params.hasOwnProperty(varName)` check or `varName in params`, which may catch even more cases. Let me know if I should update.
