### PR TITLE
Fix toolpad process output disappearing

### DIFF
--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -16,6 +16,7 @@ async function waitForMatch(input: Readable, regex: RegExp): Promise<RegExpExecA
       const match = regex.exec(line);
       if (match) {
         rl.close();
+        input.resume();
         resolve(match);
       }
     });
@@ -24,7 +25,7 @@ async function waitForMatch(input: Readable, regex: RegExp): Promise<RegExpExecA
   });
 }
 
-function* getNextPort(port: number = DEFAULT_PORT) {
+function* getPreferredPorts(port: number = DEFAULT_PORT): Iterable<number> {
   while (true) {
     yield port;
     port += 1;
@@ -45,7 +46,7 @@ async function runApp(cmd: 'dev' | 'start', { devMode = false, port }: RunComman
   const nextCommand = devMode ? 'dev' : 'start';
 
   if (!port) {
-    port = cmd === 'dev' ? await getPort({ port: getNextPort(DEFAULT_PORT) }) : DEFAULT_PORT;
+    port = cmd === 'dev' ? await getPort({ port: getPreferredPorts(DEFAULT_PORT) }) : DEFAULT_PORT;
   } else {
     // if port is specified but is not available, exit
     const availablePort = await getPort({ port });
@@ -71,7 +72,7 @@ async function runApp(cmd: 'dev' | 'start', { devMode = false, port }: RunComman
 
   process.stdin.pipe(cp.stdin!);
   cp.stdout?.pipe(process.stdout);
-  cp.stderr?.pipe(process.stdout);
+  cp.stderr?.pipe(process.stderr);
 
   if (cmd === 'dev') {
     // Poll stdout for "http://localhost:3000" first


### PR DESCRIPTION
The toolpad process stopped writing to stdout since we added the monitor that checks readiness

* for some reason the readline interface pauses the input stream after calling `.close()`.
* pipe childprocess stderr to stderr instead of stdout
* Rename getNextPort and type to make the intent clearer