### PR TITLE
Fixes on the dev pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier:all": "prettier --write . --ignore-path .eslintignore",
     "deduplicate": "node scripts/deduplicate.mjs",
     "start": "dotenv cross-env FORCE_COLOR=1 yarn workspace @mui/toolpad-app start",
-    "dev": "dotenv cross-env FORCE_COLOR=1 lerna -- run dev --stream --parallel",
+    "dev": "dotenv cross-env FORCE_COLOR=1 lerna -- run dev --stream --parallel --ignore docs",
     "docs:dev": "yarn workspace docs dev",
     "docs:build": "yarn workspace docs build",
     "docs:export": "yarn workspace docs export",

--- a/packages/create-toolpad-app/package.json
+++ b/packages/create-toolpad-app/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "prebuild": "rimraf ./dist",
     "build": "tsc -p ./tsconfig.json -outDir ./dist/",
-    "dev": "tsc -w -p ./tsconfig.json --outDir ./dist/"
+    "dev": "tsc -w --preserveWatchOutput -p ./tsconfig.json --outDir ./dist/"
   },
   "engines": {
     "node": ">=14.6.0"

--- a/packages/create-toolpad-app/package.json
+++ b/packages/create-toolpad-app/package.json
@@ -22,8 +22,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./dist",
-    "build": "tsc -p ./tsconfig.json -outDir ./dist/",
-    "dev": "tsc -w --preserveWatchOutput -p ./tsconfig.json --outDir ./dist/"
+    "build": "tsc -p ./tsconfig.json",
+    "dev": "tsc -p ./tsconfig.json --watch"
   },
   "engines": {
     "node": ">=14.6.0"

--- a/packages/create-toolpad-app/tsconfig.json
+++ b/packages/create-toolpad-app/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": false,
+    "rootDir": "src",
     "outDir": "./dist",
     "pretty": true,
     "preserveWatchOutput": true

--- a/packages/create-toolpad-app/tsconfig.json
+++ b/packages/create-toolpad-app/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmit": false,
     "outDir": "./dist"
   },
-  "exclude": ["templates", "dist"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/create-toolpad-app/tsconfig.json
+++ b/packages/create-toolpad-app/tsconfig.json
@@ -9,7 +9,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": false,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "pretty": true,
+    "preserveWatchOutput": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -13,7 +13,7 @@
     "build:next": "NODE_OPTIONS=--max-old-space-size=8192 next build",
     "build:react-devtools": "rimraf ./public/reactDevtools && esbuild ./reactDevtools/bootstrap.ts --target=es6 --bundle --format=iife --outdir=./public/reactDevtools",
     "build:typings": "ts-node --esm ./scripts/typings.mts",
-    "dev:cli": "yarn build:cli --watch --preserveWatchOutput",
+    "dev:cli": "yarn build:cli --watch",
     "dev:react-devtools": "yarn build:react-devtools --watch",
     "dev:typings": "yarn build:typings",
     "waitForApp": "ts-node --esm ./scripts/waitForApp.mts",

--- a/packages/toolpad-app/tsconfig.json
+++ b/packages/toolpad-app/tsconfig.json
@@ -26,7 +26,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "pretty": true,
+    "preserveWatchOutput": true
   },
   "include": [
     "next.config.mjs",

--- a/packages/toolpad-components/package.json
+++ b/packages/toolpad-components/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",
-    "dev": "tsc --pretty --watch --preserveWatchOutput",
+    "dev": "tsc --watch",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "check-types": "tsc"
   },

--- a/packages/toolpad-components/tsconfig.json
+++ b/packages/toolpad-components/tsconfig.json
@@ -8,7 +8,9 @@
     "outDir": "dist",
     "declaration": true,
     "target": "ES2020",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "pretty": true,
+    "preserveWatchOutput": true
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/toolpad-components/tsconfig.json
+++ b/packages/toolpad-components/tsconfig.json
@@ -12,5 +12,5 @@
     "pretty": true,
     "preserveWatchOutput": true
   },
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/toolpad-core/package.json
+++ b/packages/toolpad-core/package.json
@@ -76,8 +76,8 @@
     "build:esm": "tsc --outDir dist/esm --module esnext",
     "build:cjs": "tsc --outDir dist/cjs --module commonjs",
     "dev": "concurrently \"yarn:dev:*\" yarn:cjsify",
-    "dev:esm": "yarn build:esm --pretty --watch --preserveWatchOutput",
-    "dev:cjs": "yarn build:cjs --pretty --watch --preserveWatchOutput",
+    "dev:esm": "yarn build:esm --watch",
+    "dev:cjs": "yarn build:cjs --watch",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "check-types": "yarn build"
   },

--- a/packages/toolpad-core/tsconfig.json
+++ b/packages/toolpad-core/tsconfig.json
@@ -8,7 +8,9 @@
     "outDir": "dist",
     "declaration": true,
     "target": "ES2020",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "pretty": true,
+    "preserveWatchOutput": true
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/toolpad/package.json
+++ b/packages/toolpad/package.json
@@ -8,8 +8,8 @@
     "build:esm": "tsc",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "dev": "concurrently \"yarn:dev:*\" yarn:cjsify",
-    "dev:esm": "yarn build:esm --pretty --watch --preserveWatchOutput",
-    "dev:cjs": "yarn build:cjs --pretty --watch --preserveWatchOutput"
+    "dev:esm": "yarn build:esm --watch",
+    "dev:cjs": "yarn build:cjs --watch"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/packages/toolpad/tsconfig.json
+++ b/packages/toolpad/tsconfig.json
@@ -12,7 +12,9 @@
     "outDir": "dist/esm",
     "declaration": true,
     "target": "ES2020",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "pretty": true,
+    "preserveWatchOutput": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
* Avoid starting the up docs (use `yarn docs:dev` for this)
* Make sure `create-toolpad-app` doesn't trash the console output
* Make sure `create-toolpad-app` only builds on `src` files changes
* align `pretty` and `preserveWatchOutput` across workspaces in `tsconfig.json`