### PR TITLE
Disable property control for controlled properties

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
@@ -58,7 +58,7 @@ export default function NodeAttributeEditor<P extends object>({
 
   // NOTE: Doesn't make much sense to bind controlled props. In the future we might opt
   // to make them bindable to other controlled props only
-  const isDisabled = !!argType.onChangeHandler;
+  const isDisabled = !!argType.onChangeProp;
 
   const isBindable =
     !isDisabled &&

--- a/test/integration/propControls/index.spec.ts
+++ b/test/integration/propControls/index.spec.ts
@@ -44,6 +44,8 @@ test.describe('basic', () => {
     await firstInputLocator.fill(TEST_VALUE_1);
     expect(await valueControl.inputValue()).toBe(TEST_VALUE_1);
 
+    await expect(valueControl).toBeDisabled();
+
     // Change component prop values through controls
     const TEST_VALUE_2 = 'value2';
     const inputByLabel = editorModel.appCanvas.getByLabel(TEST_VALUE_2, { exact: true });


### PR DESCRIPTION
Bit of an inception title, but extracting this from https://github.com/mui/mui-toolpad/pull/1598 and adding a test

these properties can't be updated from the UI since their default value comes from another prop and their current value is controlled by the runtime.

