### PR TITLE
Run type checker without generating files

### DIFF
--- a/packages/toolpad-components/package.json
+++ b/packages/toolpad-components/package.json
@@ -24,7 +24,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "echo \"Error: run tests from root\" && exit 1",
-    "check-types": "tsc"
+    "check-types": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/mui/mui-toolpad/issues"

--- a/packages/toolpad-core/package.json
+++ b/packages/toolpad-core/package.json
@@ -46,7 +46,7 @@
     "dev:esm": "yarn build:esm --watch",
     "dev:cjs": "yarn build:cjs --watch",
     "test": "echo \"Error: run tests from root\" && exit 1",
-    "check-types": "yarn build"
+    "check-types": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/mui/mui-toolpad/issues"


### PR DESCRIPTION
This allows us to run the type checker, even when `yarn dev` is still running in the background