### PR TITLE
Pages folder [WIP]

### DIFF
--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -106,7 +106,9 @@
     "superjson": "^1.12.2",
     "ts-node": "^10.9.1",
     "whatwg-url": "^12.0.1",
-    "yaml": "^2.2.1"
+    "yaml": "^2.2.1",
+    "zod": "^3.21.4",
+    "zod-validation-error": "^1.1.0"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.3",

--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -17,7 +17,7 @@ import { pascalCase, removeDiacritics, uncapitalize } from '../utils/strings';
 import { ExactEntriesOf, Maybe } from '../utils/types';
 import { mapProperties, mapValues } from '../utils/collections';
 
-export const CURRENT_APPDOM_VERSION = 6;
+export const CURRENT_APPDOM_VERSION = 7;
 
 export const RESERVED_NODE_PROPERTIES = [
   'id',
@@ -85,6 +85,7 @@ export interface PageNode extends AppDomNodeBase {
     readonly title: ConstantAttrValue<string>;
     readonly parameters?: ConstantAttrValue<[string, string][]>;
     readonly module?: ConstantAttrValue<string>;
+    readonly isNew?: ConstantAttrValue<boolean>;
   };
 }
 

--- a/packages/toolpad-app/src/appDom/migrations/index.ts
+++ b/packages/toolpad-app/src/appDom/migrations/index.ts
@@ -5,9 +5,10 @@ import v3 from './v3';
 import v4 from './v4';
 import v5 from './v5';
 import v6 from './v6';
+import v7 from './v7';
 import * as appDom from '..';
 
-const versions = [v1, v2, v3, v4, v5, v6];
+const versions = [v1, v2, v3, v4, v5, v6, v7];
 
 invariant(versions.length === appDom.CURRENT_APPDOM_VERSION, 'Unable to find the latest version');
 

--- a/packages/toolpad-app/src/appDom/migrations/v6.ts
+++ b/packages/toolpad-app/src/appDom/migrations/v6.ts
@@ -5,7 +5,7 @@ import { mapValues } from '../../utils/collections';
 
 export default {
   up(dom: appDom.AppDom): appDom.AppDom {
-    invariant(dom.version === 5, 'Can only migrate dom of version 4');
+    invariant(dom.version === 5, 'Can only migrate dom of version 5');
 
     const prefix = 'codeComponent.';
     return {

--- a/packages/toolpad-app/src/appDom/migrations/v7.ts
+++ b/packages/toolpad-app/src/appDom/migrations/v7.ts
@@ -1,0 +1,30 @@
+import invariant from 'invariant';
+import * as appDom from '..';
+import { mapValues } from '../../utils/collections';
+
+export default {
+  up(dom: appDom.AppDom): appDom.AppDom {
+    invariant(dom.version === 6, 'Can only migrate dom of version 6');
+
+    return {
+      ...dom,
+      nodes: mapValues(dom.nodes, (node) => {
+        if (node.type === 'page') {
+          return {
+            ...node,
+            attributes: {
+              ...node.attributes,
+              isNew: {
+                type: 'const' as const,
+                value: true,
+              },
+            },
+          };
+        }
+
+        return node;
+      }),
+      version: 6,
+    };
+  },
+};

--- a/packages/toolpad-app/src/server/schema.ts
+++ b/packages/toolpad-app/src/server/schema.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+function nameValuePair<V extends z.ZodTypeAny>(valueType: V) {
+  return z.object({ name: z.string(), value: valueType });
+}
+
+const JsExpressionBinding = z.object({
+  $$jsExpression: z.string(),
+});
+
+function bindable<V extends z.ZodTypeAny>(valueType: V) {
+  return z.union([JsExpressionBinding, valueType]);
+}
+
+const JsExpressionAction = z.object({
+  $$jsExpressionAction: z.string(),
+});
+
+const NavigationAction = z.object({
+  $$navigationAction: z.object({
+    page: z.string(),
+    parameters: z.record(bindable(z.any())),
+  }),
+});
+
+export type NavigationActionType = z.infer<typeof NavigationAction>;
+
+const BindableAction = z.union([JsExpressionAction, NavigationAction]);
+
+const FetchMode = z.union([z.literal('query'), z.literal('mutation')]);
+
+const NameValuePair = nameValuePair(z.string());
+
+const Query = z.object({
+  name: z.string().describe('A name for the query'),
+  enabled: bindable(z.boolean()).optional(),
+  parameters: z.array(nameValuePair(bindable(z.any()))).optional(),
+  mode: FetchMode.optional(),
+  dataSource: z.string().optional(),
+  query: z.any(),
+  transform: z.string().optional(),
+  transformEnabled: z.boolean().optional(),
+  refetchInterval: z.number().optional(),
+  cacheTime: z.number().optional(),
+});
+
+export type QueryType = z.infer<typeof Query>;
+
+const BaseElement = z.object({
+  component: z.string(),
+  name: z.string(),
+  props: z.record(z.union([bindable(z.any()), BindableAction])).optional(),
+  layout: z
+    .object({
+      horizontalAlign: z.string().optional(),
+      verticalAlign: z.string().optional(),
+      columnSize: z.number().optional(),
+    })
+    .optional(),
+});
+
+type BaseElementType = z.infer<typeof BaseElement>;
+
+export type ElementType = BaseElementType & {
+  children?: ElementType[];
+};
+
+const Element: z.ZodType<ElementType> = BaseElement.extend({
+  children: z.lazy(() => z.array(Element).optional()),
+});
+
+export const Page = z.object({
+  id: z.string(),
+  title: z.string().optional(),
+  parameters: z.array(NameValuePair).optional(),
+  queries: z.array(Query).optional(),
+  children: z.array(Element).optional(),
+});
+
+export type PageType = z.infer<typeof Page>;

--- a/packages/toolpad-app/src/utils/fs.ts
+++ b/packages/toolpad-app/src/utils/fs.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { Dirent } from 'fs';
 import { errorFrom } from './errors';
 
 /**
@@ -16,6 +17,18 @@ export async function readMaybeFile(filePath: string): Promise<string | null> {
   } catch (rawError) {
     const error = errorFrom(rawError);
     if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function readMaybeDir(dirPath: string): Promise<Dirent[] | null> {
+  try {
+    return await fs.readdir(dirPath, { withFileTypes: true });
+  } catch (rawError: unknown) {
+    const error = errorFrom(rawError);
+    if (errorFrom(error).code === 'ENOENT') {
       return null;
     }
     throw error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13036,3 +13036,13 @@ zip-stream@^4.1.0:
     archiver-utils "^2.1.0"
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
+
+zod-validation-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-1.1.0.tgz#d6dff11b596feb05f24a0ef22adc194ca6817edf"
+  integrity sha512-CI0zGWQjyDN0sLcmFiD+wnvkkJaLo6hNB4JBUDltkl6+CeHfnnQKU4Ff6ktMc+VmO/j2+vtLlx4S5xaw8YQN6A==
+
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
* Use `./pages/<name>/page.yml` to store page configuration
* Simplify the datastructure
  * Make most properties optional, to have it as light as possible
  * Expand the nodes to have a hierarchical structure instead of the flat list of nodes linked by ids
  * Simplify bindings. const values will just be the javascript primitive. Bindings will be an object with `{ $$jsExpression : '...' }`. Example file:

    ```yml
    # ./pages/example/page.yml
    id: rc03qfi
    title: page
    children:
      - component: PageRow
        name: pageRow
        children:
          - component: PageColumn
            name: pageColumn
            layout:
              columnSize: 1
            children:
              - component: TextField
                name: textField
              - component: Button
                name: button
                props:
                  content: "Button "
              - component: Button
                name: helloButton
                props:
                  onClick:
                    $$jsExpressionAction: text.value = 'hello!'
      - component: PageRow
        name: pageRow1
        children:
          - component: Text
            name: output
            layout:
              columnSize: 1
            props:
              value: hellooooo
    queries:
      - name: query
        dataSource: rest
        query:
          method: GET
          headers: []
          browser: false
          url:
            type: jsExpression
            value: |
              `http://localhost:3000/static/movies.json`
    ```

## To Do

- [ ] Nest `./queries.ts` in these folders
- [ ] Initialization is brittle and has lots of corner cases. Migrations start to become more and more complex and I'm thinking of making this more explicit. e.g.:
    * If toolpad config version < installed toolpad version: Show message "Please run `npx toolpad migrate` to upgrade the project"
    * If toolpad config version > installed toolpad version: Show message "Please upgrade toolpad"
    * Add explicit CLI command `npx toolpad migrate` that migrates the project to the currently installed version
