### PR TITLE
Remove obsolete onDelete datagrid property

### DIFF
--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -393,10 +393,6 @@ interface Selection {
   id?: any;
 }
 
-interface OnDeleteEvent {
-  row: GridRowsProp[number];
-}
-
 interface ToolpadDataGridProps extends Omit<DataGridProProps, 'columns' | 'rows' | 'error'> {
   rows?: GridRowsProp;
   columns?: SerializableGridColumns;
@@ -405,7 +401,6 @@ interface ToolpadDataGridProps extends Omit<DataGridProProps, 'columns' | 'rows'
   error?: Error | string;
   selection?: Selection | null;
   onSelectionChange?: (newSelection?: Selection | null) => void;
-  onDelete?: (event: OnDeleteEvent) => void;
   hideToolbar?: boolean;
 }
 
@@ -613,17 +608,6 @@ export default createComponent(DataGridComponent, {
     sx: {
       helperText: SX_PROP_HELPER_TEXT,
       typeDef: { type: 'object' },
-    },
-    onDelete: {
-      typeDef: {
-        type: 'event',
-        arguments: [
-          {
-            name: 'event',
-            tsType: `{ row: ThisComponent['rows'][number] }`,
-          },
-        ],
-      },
     },
   },
 });


### PR DESCRIPTION
This seems to be a leftover of an earlier experiment. Removing.

For now we recommend binding a manual query parameter to the `dataGrid.selection` and triggering it on button click.

For the future we're looking into abstracting tabular data better on the backend and providing a complete interface to interact with them as a whole on the frontend https://github.com/mui/mui-toolpad/issues/385