### PR TITLE
Pull fixes

### DIFF
--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -114,13 +114,13 @@ async function buildCommand({ dir }: BuildOptions) {
   const projectDir = path.resolve(process.cwd(), dir);
   const { default: chalk } = await import('chalk');
   // eslint-disable-next-line no-console
-  console.log(`${chalk.blue('info')}  - building Toolpad application...`);
+  console.log(
+    `${chalk.blue('info')}  - building Toolpad application at ${chalk.cyan(projectDir)}...`,
+  );
 
-  process.env.TOOLPAD_PROJECT_DIR = projectDir;
-
-  const { buildApp } = await import('../src/server/toolpadAppBuilder');
-
-  await buildApp({ root: projectDir, base: '/prod' });
+  await new Promise((resolve) => {
+    setTimeout(resolve, 1000);
+  });
   // eslint-disable-next-line no-console
   console.log(`${chalk.green('success')} - build done.`);
 }

--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -33,13 +33,13 @@ function* getPreferredPorts(port: number = DEFAULT_PORT): Iterable<number> {
 }
 
 type Command = 'dev' | 'start' | 'build';
-interface Options {
+interface RunOptions {
+  dir: string;
   port?: number;
   dev?: boolean;
-  dir?: string;
 }
 
-async function runApp(cmd: Command, { port, dev = false, dir = '.' }: Options) {
+async function runApp(cmd: Command, { port, dev = false, dir }: RunOptions) {
   const projectDir = path.resolve(process.cwd(), dir);
   const { execaNode } = await import('execa');
   const { default: chalk } = await import('chalk');
@@ -98,7 +98,7 @@ async function runApp(cmd: Command, { port, dev = false, dir = '.' }: Options) {
   });
 }
 
-async function devCommand(args: yargs.ArgumentsCamelCase<Options>) {
+async function devCommand(args: RunOptions) {
   const { default: chalk } = await import('chalk');
 
   // eslint-disable-next-line no-console
@@ -106,18 +106,26 @@ async function devCommand(args: yargs.ArgumentsCamelCase<Options>) {
   await runApp('dev', args);
 }
 
-async function buildCommand() {
+interface BuildOptions {
+  dir: string;
+}
+
+async function buildCommand({ dir }: BuildOptions) {
+  const projectDir = path.resolve(process.cwd(), dir);
   const { default: chalk } = await import('chalk');
   // eslint-disable-next-line no-console
   console.log(`${chalk.blue('info')}  - building Toolpad application...`);
-  await new Promise((resolve) => {
-    setTimeout(resolve, 1000);
-  });
+
+  process.env.TOOLPAD_PROJECT_DIR = projectDir;
+
+  const { buildApp } = await import('../src/server/toolpadAppBuilder');
+
+  await buildApp({ root: projectDir, base: '/prod' });
   // eslint-disable-next-line no-console
   console.log(`${chalk.green('success')} - build done.`);
 }
 
-async function startCommand(args: yargs.ArgumentsCamelCase<Options>) {
+async function startCommand(args: RunOptions) {
   const { default: chalk } = await import('chalk');
   // eslint-disable-next-line no-console
   console.log(`${chalk.blue('info')}  - Starting Toolpad application...`);
@@ -125,59 +133,60 @@ async function startCommand(args: yargs.ArgumentsCamelCase<Options>) {
 }
 
 export default async function cli(argv: string[]) {
+  const sharedOptions = {
+    dir: {
+      type: 'string',
+      describe: 'Directory of the Toolpad application',
+      default: '.',
+    },
+  } as const;
+
+  const sharedRunOptions = {
+    ...sharedOptions,
+    port: {
+      type: 'number',
+      describe: 'Port to run the Toolpad application on',
+      demandOption: false,
+    },
+    dev: {
+      type: 'boolean',
+      describe: 'Run the Toolpad editor Next.js app in development mode',
+      demandOption: false,
+      default: false,
+      hidden: true,
+    },
+  } as const;
+
   await yargs(argv)
     // See https://github.com/yargs/yargs/issues/538
     .scriptName('toolpad')
-    .command({
-      command: 'dev [dir]',
-      describe: 'Run Toolpad in development mode',
-      builder: {
-        port: {
-          type: 'number',
-          describe: 'Port to run the application on',
-          demandOption: false,
-        },
-        dev: {
-          type: 'boolean',
-          describe: 'Run the Toolpad editor Next.js app in production mode',
-          demandOption: false,
-          default: false,
-          hidden: true,
-        },
+    .command(
+      ['$0 [dir]', 'dev [dir]'],
+      'Run Toolpad in development mode',
+      {
+        ...sharedRunOptions,
       },
-      handler: (args) => devCommand(args),
-    })
-    .command({
-      command: 'start [dir]',
-      describe: 'Run built Toolpad application in production mode',
-      builder: {
-        port: {
-          type: 'number',
-          describe: 'Port to run the application on',
-          demandOption: false,
-        },
-        dev: {
-          type: 'boolean',
-          describe: 'Run the Toolpad editor Next.js app in production mode',
-          demandOption: false,
-          default: false,
-          hidden: true,
-        },
+      (args) => devCommand(args),
+    )
+    .command(
+      'start [dir]',
+      'Run built Toolpad application in production mode',
+      {
+        ...sharedRunOptions,
       },
-      handler: (args) => startCommand(args),
-    })
-    .command({
-      command: 'build',
-      describe: 'Build Toolpad app for production',
-      handler: () => buildCommand(),
-    })
-    .command({
-      command: 'help',
-      describe: 'Show help',
-      handler: async () => {
-        // eslint-disable-next-line no-console
-        console.log(await yargs.getHelp());
+      (args) => startCommand(args),
+    )
+    .command(
+      'build [dir]',
+      'Build Toolpad app for production',
+      {
+        ...sharedOptions,
       },
+      (args) => buildCommand(args),
+    )
+    .command('help', 'Show help', {}, async () => {
+      // eslint-disable-next-line no-console
+      console.log(await yargs.getHelp());
     })
     .help().argv;
 }

--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -28,7 +28,7 @@
     "./package.json": "./package.json",
     "./cli": {
       "require": "./dist/cli/index.js"
-    },
+    }
   },
   "dependencies": {
     "@babel/code-frame": "^7.21.4",

--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -24,6 +24,12 @@
     "cli.js",
     ".next"
   ],
+  "exports": {
+    "./package.json": "./package.json",
+    "./cli": {
+      "require": "./dist/cli/index.js"
+    },
+  },
   "dependencies": {
     "@babel/code-frame": "^7.21.4",
     "@emotion/cache": "^11.10.7",

--- a/packages/toolpad-app/tsup.config.ts
+++ b/packages/toolpad-app/tsup.config.ts
@@ -1,14 +1,17 @@
+import { spawnSync } from 'child_process';
 import { defineConfig } from 'tsup';
 
 export default defineConfig([
   {
     entry: {
-      'cli/index': './cli/index.ts',
-      'cli/server': './cli/server.ts',
+      index: './cli/index.ts',
+      server: './cli/server.ts',
     },
+    outDir: 'dist/cli',
     silent: true,
-    noExternal: ['open-editor', 'execa', 'fractional-indexing'],
+    noExternal: ['open-editor', 'execa', 'fractional-indexing', 'lodash-es'],
     clean: true,
+    sourcemap: true,
     async onSuccess() {
       // eslint-disable-next-line no-console
       console.log('cli: build successful');

--- a/packages/toolpad/index.cjs
+++ b/packages/toolpad/index.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable */
 
-const { default: cli } = require('@mui/toolpad-app/dist/cli');
+const { default: cli } = require('@mui/toolpad-app/cli');
 
 cli(process.argv.slice(2));

--- a/packages/toolpad/src/browser.ts
+++ b/packages/toolpad/src/browser.ts
@@ -1,2 +1,1 @@
-export { default } from '@mui/toolpad-core/browser';
 export * from '@mui/toolpad-core/browser';

--- a/packages/toolpad/src/server.ts
+++ b/packages/toolpad/src/server.ts
@@ -1,2 +1,1 @@
-export { default } from '@mui/toolpad-core/server';
 export * from '@mui/toolpad-core/server';


### PR DESCRIPTION
* Make sure types of `args` in `yargs` handlers are strongly typed
* Add a default command when the CLI is run with `dev`/`build`/`start`
* Remove references to non-existing exports