### PR TITLE
Fix: Remove `default` from cli --port option

### DIFF
--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -146,7 +146,6 @@ export default async function cli(argv: string[]) {
     port: {
       type: 'number',
       describe: 'Port to run the Toolpad application on',
-      default: DEFAULT_PORT,
       demandOption: false,
     },
     dev: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Closes #1903 

- Visual demonstration

https://user-images.githubusercontent.com/19550456/233094822-9156647b-e8a5-4c44-84d8-3cb9e78f6150.mov


