### PR TITLE
Use correct command for opening vscode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,8 @@ _If you're looking into contributing to the docs, follow the [instructions](#bui
      "resolutions": {
        "@mui/toolpad-app": "portal:<your-local-toolpad-monorepo>/packages/toolpad-app",
        "@mui/toolpad-core": "portal:<your-local-toolpad-monorepo>/packages/toolpad-core",
-       "@mui/toolpad-components": "portal:<your-local-toolpad-monorepo>/packages/toolpad-components"
+       "@mui/toolpad-components": "portal:<your-local-toolpad-monorepo>/packages/toolpad-components",
+       "@mui/toolpad-utils": "portal:<your-local-toolpad-monorepo>/packages/toolpad-utils"
      }
    }
    ```

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/CreateCodeComponentNodeDialog.tsx
@@ -114,7 +114,12 @@ export default function CreateCodeComponentDialog({
                 <Button
                   size="small"
                   onClick={() => {
-                    client.mutation.openCodeComponentEditor(name);
+                    client.mutation.openCodeComponentEditor(name).catch((err) => {
+                      // TODO: Write docs with instructions on how to install editor
+                      // Add a good looking alert box and inline some instructions and link to docs
+                      // eslint-disable-next-line no-alert
+                      alert(err.message);
+                    });
                   }}
                 >
                   Open

--- a/packages/toolpad-app/src/toolpadDataSources/local/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/local/client.tsx
@@ -71,7 +71,12 @@ function QueryEditor({
   );
 
   const openEditor = React.useCallback(() => {
-    fetchPrivate({ kind: 'openEditor' });
+    fetchPrivate({ kind: 'openEditor' }).catch((err) => {
+      // TODO: Write docs with instructions on how to install editor
+      // Add a good looking alert box and inline some instructions and link to docs
+      // eslint-disable-next-line no-alert
+      alert(err.message);
+    });
   }, [fetchPrivate]);
 
   const {

--- a/packages/toolpad-utils/src/strings.ts
+++ b/packages/toolpad-utils/src/strings.ts
@@ -89,7 +89,7 @@ export function removePrefix(input: string, prefix: string): string {
  * Removes a suffix from a string if it ends with it.
  */
 export function removeSuffix(input: string, suffix: string): string {
-  return input.endsWith(suffix) ? input.slice(0, input.length - suffix.length) : input;
+  return input.endsWith(suffix) ? input.slice(0, -suffix.length) : input;
 }
 
 /**


### PR DESCRIPTION
We were falling back to `code` instead of `vscode`. Took the liberty to add a quick check on existence of the command. We should expand and add some docs on how to fix