### PR TITLE
Fix: Local installation needs new resolution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,8 @@ _If you're looking into contributing to the docs, follow the [instructions](#bui
      "resolutions": {
        "@mui/toolpad-app": "portal:<your-local-toolpad-monorepo>/packages/toolpad-app",
        "@mui/toolpad-core": "portal:<your-local-toolpad-monorepo>/packages/toolpad-core",
-       "@mui/toolpad-components": "portal:<your-local-toolpad-monorepo>/packages/toolpad-components"
+       "@mui/toolpad-components": "portal:<your-local-toolpad-monorepo>/packages/toolpad-components",
+       "@mui/toolpad-utils": "portal:<your-local-toolpad-monorepo>/packages/toolpad-utils"
      }
    }
    ```


### PR DESCRIPTION
Adds `@mui/toolpad-utils` to the `resolutions` required if running Toolpad as a developer