### PR TITLE
Fix overlay grid spacing

### DIFF
--- a/packages/toolpad-app/src/runtime/AppThemeProvider.tsx
+++ b/packages/toolpad-app/src/runtime/AppThemeProvider.tsx
@@ -4,6 +4,8 @@ import * as colors from '@mui/material/colors';
 import * as appDom from '../appDom';
 import { AppTheme } from '../types';
 
+import { getDesignTokens } from '../theme';
+
 export function createToolpadTheme(toolpadTheme: AppTheme = {}): ThemeOptions {
   const palette: PaletteOptions = {};
   const primary = toolpadTheme['palette.primary.main'];
@@ -21,8 +23,11 @@ export function createToolpadTheme(toolpadTheme: AppTheme = {}): ThemeOptions {
     palette.mode = mode;
   }
 
+  const designTokens = getDesignTokens(mode || 'light');
+
   return createTheme({
     palette,
+    spacing: designTokens.spacing,
     typography: {
       h1: {
         fontSize: `3.25rem`,

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/OverlayGrid.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/OverlayGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Grid, styled } from '@mui/material';
+import { Grid, Container, styled } from '@mui/material';
 import invariant from 'invariant';
 
 export interface OverlayGridHandle {
@@ -12,12 +12,15 @@ export interface OverlayGridHandle {
 export const GRID_NUMBER_OF_COLUMNS = 12;
 export const GRID_COLUMN_GAP = 1;
 
-const StyledGrid = styled(Grid)({
-  height: '100vh',
+const GridContainer = styled(Container)({
+  height: '100%',
   pointerEvents: 'none',
   position: 'absolute',
   zIndex: 1,
-  border: '4px solid transparent',
+});
+
+const StyledGrid = styled(Grid)({
+  height: '100%',
 });
 
 const StyledGridColumn = styled('div')(({ theme }) => ({
@@ -65,12 +68,14 @@ export const OverlayGrid = React.forwardRef<OverlayGridHandle>(function OverlayG
   );
 
   return (
-    <StyledGrid ref={gridRef} container columnSpacing={GRID_COLUMN_GAP} px={2}>
-      {[...Array(GRID_NUMBER_OF_COLUMNS)].map((column, index) => (
-        <Grid key={index} item xs={1}>
-          <StyledGridColumn />
-        </Grid>
-      ))}
-    </StyledGrid>
+    <GridContainer>
+      <StyledGrid ref={gridRef} container columnSpacing={GRID_COLUMN_GAP}>
+        {[...Array(GRID_NUMBER_OF_COLUMNS)].map((column, index) => (
+          <Grid key={index} item xs={1}>
+            <StyledGridColumn />
+          </Grid>
+        ))}
+      </StyledGrid>
+    </GridContainer>
   );
 });


### PR DESCRIPTION
The spacing in the themes used in the runtime VS the editor was not the same, so for example when resizing elements using the grid there was always a slight misalignment:

https://user-images.githubusercontent.com/10789765/235211223-0d13896d-38c4-4cf1-b93f-b91c6029fc5a.mov

This PR fixes the issue by using the same spacing in the runtime and editor themes:

https://user-images.githubusercontent.com/10789765/235211380-61353bdf-345d-4937-8392-b7552d2e2406.mov



