### PR TITLE
Fix broken preview in vite runtime

### DIFF
--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -220,6 +220,15 @@ export function createViteConfig({
         },
       },
     },
+    resolve: {
+      alias: [
+        {
+          // FIXME(https://github.com/mui/material-ui/issues/35233)
+          find: /^@mui\/icons-material\/([^/]*)/,
+          replacement: '@mui/icons-material/esm/$1',
+        },
+      ],
+    },
     server: {
       fs: {
         allow: [root, path.resolve(__dirname, '../../../../')],

--- a/packages/toolpad-app/tsup.config.ts
+++ b/packages/toolpad-app/tsup.config.ts
@@ -53,6 +53,9 @@ export default defineConfig([
     silent: true,
     outDir: 'dist/runtime',
     tsconfig: './tsconfig.esbuild.json',
+    // FIXME(https://github.com/mui/material-ui/issues/35233)
+    noExternal: ['@mui/icons-material'],
+    clean: true,
     async onSuccess() {
       // eslint-disable-next-line no-console
       console.log('runtime: build successful');

--- a/packages/toolpad-app/tsup.config.ts
+++ b/packages/toolpad-app/tsup.config.ts
@@ -53,8 +53,6 @@ export default defineConfig([
     silent: true,
     outDir: 'dist/runtime',
     tsconfig: './tsconfig.esbuild.json',
-    // FIXME(https://github.com/mui/material-ui/issues/35233)
-    noExternal: ['@mui/icons-material'],
     clean: true,
     async onSuccess() {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Quite hard to replicate as it only happens in installed context, but we're getting into trouble with  https://github.com/mui/material-ui/issues/35233

This should fix https://github.com/mui/mui-toolpad/issues/1983