### PR TITLE
Make canvas column spacing the same as in the runtime

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/OverlayGrid.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/OverlayGrid.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Grid, Container, styled } from '@mui/material';
 import invariant from 'invariant';
+import { createToolpadAppTheme } from '../../../../runtime/AppThemeProvider';
+import { useDom } from '../../../AppState';
 
 export interface OverlayGridHandle {
   gridElement: HTMLDivElement | null;
@@ -34,6 +36,9 @@ export const OverlayGrid = React.forwardRef<OverlayGridHandle>(function OverlayG
   forwardedRef,
 ) {
   const gridRef = React.useRef<HTMLDivElement | null>(null);
+
+  const { dom } = useDom();
+  const appTheme = React.useMemo(() => createToolpadAppTheme(dom), [dom]);
 
   React.useImperativeHandle(
     forwardedRef,
@@ -69,7 +74,7 @@ export const OverlayGrid = React.forwardRef<OverlayGridHandle>(function OverlayG
 
   return (
     <GridContainer>
-      <StyledGrid ref={gridRef} container columnSpacing={GRID_COLUMN_GAP}>
+      <StyledGrid ref={gridRef} container columnSpacing={appTheme.spacing(GRID_COLUMN_GAP)}>
         {[...Array(GRID_NUMBER_OF_COLUMNS)].map((column, index) => (
           <Grid key={index} item xs={1}>
             <StyledGridColumn />


### PR DESCRIPTION
Isolate app theme from editor theme and use the spacing of the runtime theme for the columns overlay instead of the other way around (See point 1 of https://github.com/mui/mui-toolpad/pull/1947/files#r1193477233
