### PR TITLE
Remove hideControls and button type

### DIFF
--- a/packages/toolpad-components/src/Button.tsx
+++ b/packages/toolpad-components/src/Button.tsx
@@ -56,12 +56,6 @@ export default createComponent(Button, {
       helperText: 'Whether the button is disabled.',
       type: 'boolean',
     },
-    type: {
-      helperText: 'Button HTML type',
-      type: 'string',
-      enum: ['button', 'submit', 'reset'],
-      default: 'button',
-    },
     sx: {
       helperText: SX_PROP_HELPER_TEXT,
       type: 'object',

--- a/packages/toolpad-components/src/Form.tsx
+++ b/packages/toolpad-components/src/Form.tsx
@@ -24,7 +24,6 @@ interface FormProps extends ContainerProps {
   hasResetButton?: boolean;
   mode?: keyof ValidationMode | undefined;
   hasChrome?: boolean;
-  hideControls?: boolean;
 }
 
 function Form({
@@ -38,7 +37,6 @@ function Form({
   submitButtonText = 'Submit',
   mode = 'onSubmit',
   hasChrome = true,
-  hideControls = false,
   sx,
   ...rest
 }: FormProps) {
@@ -83,42 +81,41 @@ function Form({
         <Container disableGutters sx={sx} {...rest}>
           <form onSubmit={form.handleSubmit(handleSubmit)} onReset={handleReset}>
             {children}
-            {!hideControls ? (
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  justifyContent: formControlsAlign,
-                  pt: 1,
-                }}
+
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: formControlsAlign,
+                pt: 1,
+              }}
+            >
+              <Stack
+                direction="row"
+                spacing={1}
+                sx={{ flex: formControlsFullWidth ? 1 : '0 1 auto' }}
               >
-                <Stack
-                  direction="row"
-                  spacing={1}
-                  sx={{ flex: formControlsFullWidth ? 1 : '0 1 auto' }}
-                >
-                  {hasResetButton ? (
-                    <LoadingButton
-                      type="reset"
-                      color="secondary"
-                      variant="contained"
-                      sx={{ flex: formControlsFullWidth ? 1 : '0 1 auto' }}
-                    >
-                      Reset
-                    </LoadingButton>
-                  ) : null}
+                {hasResetButton ? (
                   <LoadingButton
-                    type="submit"
-                    color="primary"
+                    type="reset"
+                    color="secondary"
                     variant="contained"
-                    loading={form.formState.isSubmitting}
                     sx={{ flex: formControlsFullWidth ? 1 : '0 1 auto' }}
                   >
-                    {submitButtonText}
+                    Reset
                   </LoadingButton>
-                </Stack>
-              </Box>
-            ) : null}
+                ) : null}
+                <LoadingButton
+                  type="submit"
+                  color="primary"
+                  variant="contained"
+                  loading={form.formState.isSubmitting}
+                  sx={{ flex: formControlsFullWidth ? 1 : '0 1 auto' }}
+                >
+                  {submitButtonText}
+                </LoadingButton>
+              </Stack>
+            </Box>
           </form>
         </Container>
       ) : (
@@ -274,11 +271,6 @@ export default createComponent(Form, {
     },
     hasResetButton: {
       helperText: 'Show button to reset form values.',
-      type: 'boolean',
-      default: false,
-    },
-    hideControls: {
-      helperText: 'Hide form controls.',
       type: 'boolean',
       default: false,
     },


### PR DESCRIPTION
If I understand correctly these properties allow the user to build their own reset/submit logic?

I think as an abstraction this is both too leaky and not powerful enough.

- For any button outside of a form, this property has no meaning
- The user requires knowing implementation details in order to understand how this property is to be used ("HTML type")
- The form can't be submitted from anywhere else, or on an event

I propose to remove this for the beta release and wait for user feedback