### PR TITLE
version examples instead of using latest

### DIFF
--- a/examples/custom-datagrid-column/package.json
+++ b/examples/custom-datagrid-column/package.json
@@ -8,6 +8,6 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "latest"
+    "@mui/toolpad": "^0.1.11"
   }
 }


### PR DESCRIPTION
This should bust the cache on codesandbox.

If this works we'll probably have to add a script to update examples package.json when we release since we won't make them part of the yarn workspace.
