### PR TITLE
Fix orphaned node delete order

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -203,6 +203,32 @@ function deleteOrphanedLayoutNodes(
           moveTargetNodeId !== parentParent.id &&
           moveTargetNodeId !== lastContainerChild.id
         ) {
+          if (
+            moveTargetNodeId !== parent.id &&
+            moveTargetNodeId !== lastContainerChild.id &&
+            isPageLayoutComponent(parentParent)
+          ) {
+            draftDom = appDom.moveNode(
+              draftDom,
+              lastContainerChild,
+              parentParent,
+              lastContainerChild.parentProp,
+              parent.parentIndex,
+            );
+
+            if (isPageColumn(parent)) {
+              draftDom = appDom.setNodeNamespacedProp(
+                draftDom,
+                lastContainerChild,
+                'layout',
+                'columnSize',
+                parent.layout?.columnSize || appDom.createConst(1),
+              );
+            }
+
+            orphanedLayoutNodeIds = [...orphanedLayoutNodeIds, parent.id];
+          }
+
           draftDom = appDom.moveNode(
             draftDom,
             lastContainerChild,
@@ -222,32 +248,6 @@ function deleteOrphanedLayoutNodes(
           }
 
           orphanedLayoutNodeIds = [...orphanedLayoutNodeIds, parentParent.id];
-        }
-
-        if (
-          moveTargetNodeId !== parent.id &&
-          moveTargetNodeId !== lastContainerChild.id &&
-          isPageLayoutComponent(parentParent)
-        ) {
-          draftDom = appDom.moveNode(
-            draftDom,
-            lastContainerChild,
-            parentParent,
-            lastContainerChild.parentProp,
-            parent.parentIndex,
-          );
-
-          if (isPageColumn(parent)) {
-            draftDom = appDom.setNodeNamespacedProp(
-              draftDom,
-              lastContainerChild,
-              'layout',
-              'columnSize',
-              parent.layout?.columnSize || appDom.createConst(1),
-            );
-          }
-
-          orphanedLayoutNodeIds = [...orphanedLayoutNodeIds, parent.id];
         }
       }
     }


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/2033

When some nested elements were moved out of a parent or deleted, the parent 2 levels above was being adjusted before the parent 1 level above, which could result in moving the non-deleted elements to a parent that ended up being deleted. Not easy to explain.