### PR TITLE
[docs] Add product identifier to page context

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -143,7 +143,12 @@ function AppWrapper(props) {
   const pageContextValue = React.useMemo(() => {
     const { activePage, activePageParents } = findActivePage(pages, router.pathname);
 
-    return { activePage, activePageParents, pages };
+    const productIdentifier = {
+      name: 'Toolpad',
+      metadata: 'MUI Toolpad',
+    };
+
+    return { activePage, activePageParents, pages, productIdentifier };
   }, [router.pathname]);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,8 +1403,8 @@
     react-transition-group "^4.4.5"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git":
-  version "5.13.0"
-  resolved "https://github.com/mui/material-ui.git#ea7201aa8f2cc6295d9c51b866b595757ad992c4"
+  version "5.13.1"
+  resolved "https://github.com/mui/material-ui.git#0667edf8955caa654a6b18874844ce8acb8f3c3a"
 
 "@mui/private-theming@^5.13.1":
   version "5.13.1"


### PR DESCRIPTION
Preview: https://deploy-preview-2043--mui-toolpad-docs.netlify.app/toolpad/getting-started/overview/

In https://github.com/mui/material-ui/pull/35078 I changed from where we get the information for the product identifier. Previously, the main repo had the logic for all products. This required us to open a PR in the main repo every time a new version or component (in the case of MUI X) is released. Now each repo manages this information.

![image](https://github.com/mui/mui-toolpad/assets/42154031/b41c379f-2d64-478f-828a-4c92a84d67de)

I also upgraded the monorepo to fetch the commit with the changed I did.