### PR TITLE
Fix websocket connection in codesandbox

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppState.tsx
+++ b/packages/toolpad-app/src/toolpad/AppState.tsx
@@ -19,7 +19,8 @@ import { DomView, getViewFromPathname, PageViewTab } from '../utils/domView';
 let ws: WebSocket | null = null;
 
 if (typeof window !== 'undefined') {
-  ws = new WebSocket(`ws://${window.location.host}/toolpad-ws`);
+  const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  ws = new WebSocket(`${wsProtocol}//${window.location.host}/toolpad-ws`);
 
   ws.addEventListener('error', (err) => console.error(err));
 


### PR DESCRIPTION
codesandbox serves the editor over https. Getting errors like:

```
preview-protocol.js:13 DOMException: Failed to construct 'WebSocket': An insecure WebSocket connection may not be initiated from a page loaded over HTTPS.
```

We can just connect to `wss:` instead of `ws:` when served over https.
