### PR TITLE
Fix React function ref warning for the row id selector component

### DIFF
--- a/packages/toolpad-app/src/toolpad/propertyControls/RowIdFieldSelect.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/RowIdFieldSelect.tsx
@@ -4,23 +4,19 @@ import * as React from 'react';
 import { EditorProps } from '../../types';
 import { usePageEditorState } from '../AppEditor/PageEditor/PageEditorProvider';
 import SelectControl from './select';
-import PropertyControl from '../../components/PropertyControl';
 
 function ColumnSelect({ propType, nodeId, ...props }: EditorProps<string>) {
   const { bindings } = usePageEditorState();
+  const { helperText } = propType;
   const columnsValue = nodeId && bindings[`${nodeId}.props.columns`];
   const definedColumns: GridColDef[] = columnsValue?.value as any;
 
   const newPropType: PropValueType = React.useMemo(() => {
     const columnNames = definedColumns?.map((column) => column.field);
-    return { type: 'string', enum: columnNames };
-  }, [definedColumns]);
+    return { type: 'string', enum: columnNames, helperText };
+  }, [helperText, definedColumns]);
 
-  return (
-    <PropertyControl propType={propType}>
-      <SelectControl nodeId={nodeId} {...props} propType={newPropType} />
-    </PropertyControl>
-  );
+  return <SelectControl nodeId={nodeId} {...props} propType={newPropType} />;
 }
 
 export default ColumnSelect;


### PR DESCRIPTION
Noticed a warning while working on https://github.com/mui/mui-toolpad/pull/2080#issuecomment-1567385772

The `SelectControl` already wraps with a `PropertyControl`, we just need to pass the `helperText`