### PR TITLE
Make sure global variables are retained in between invocations

### DIFF
--- a/test/integration/backend-basic/fixture/toolpad/pages/page1/page.yml
+++ b/test/integration/backend-basic/fixture/toolpad/pages/page1/page.yml
@@ -93,6 +93,23 @@ spec:
             value:
               $$jsExpression: |
                 `destination: ${manualQuery.data?.parameters?.foo}`
+    - component: PageRow
+      name: pageRow7
+      children:
+        - component: Button
+          name: button1
+          props:
+            content: increment
+            onClick:
+              $$jsExpressionAction: |-
+                await increment.call()
+                getGlobal.refetch()
+        - component: Text
+          name: text
+          props:
+            value:
+              $$jsExpression: |
+                `global value: ${getGlobal.data}`
   queries:
     - name: hello
       query:
@@ -129,3 +146,12 @@ spec:
           value:
             $$jsExpression: |
               "checksum"
+    - name: increment
+      mode: mutation
+      query:
+        function: increment
+        kind: local
+    - name: getGlobal
+      query:
+        function: getGlobal
+        kind: local

--- a/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
+++ b/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
@@ -53,3 +53,13 @@ export const manualQueryWithParams = createFunction(
     },
   },
 );
+
+let x = 1;
+
+export async function increment() {
+  x += 1;
+}
+
+export async function getGlobal() {
+  return x;
+}

--- a/test/integration/backend-basic/index.spec.ts
+++ b/test/integration/backend-basic/index.spec.ts
@@ -91,3 +91,15 @@ test('bound parameters are preserved on manual call', async ({ page }) => {
 
   await expect(page.getByText('destination: checksum', { exact: true })).toBeVisible();
 });
+
+test('global variables are retained in function runtime', async ({ page }) => {
+  const runtimeModel = new ToolpadRuntime(page);
+  await runtimeModel.gotoPage('page1');
+
+  await expect(page.getByText('global value: 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('global value: 2', { exact: true })).not.toBeVisible();
+
+  await page.getByRole('button', { name: 'increment' }).click();
+
+  await expect(page.getByText('global value: 2', { exact: true })).toBeVisible();
+});


### PR DESCRIPTION
Found this broken in my last iteration of https://github.com/mui/mui-toolpad/pull/2096
The function source was executed on every invocation, this breaks global variables as in https://github.com/mui/mui-toolpad/pull/2096
This PR caches the instantiated module as long as the source doesn't change.
