### PR TITLE
Send dom diffs to the server to avoid overly large payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier:all": "prettier --write . --ignore-path .eslintignore",
     "deduplicate": "node scripts/deduplicate.mjs",
     "start": "dotenv cross-env FORCE_COLOR=1 yarn workspace @mui/toolpad-app start",
-    "dev": "dotenv cross-env FORCE_COLOR=1 lerna -- run dev --stream --parallel --ignore docs",
+    "dev": "dotenv cross-env NODE_OPTIONS=--enable-source-maps FORCE_COLOR=1 lerna -- run dev --stream --parallel --ignore docs --ignore hacker-news-client",
     "docs:dev": "yarn workspace docs dev",
     "docs:build": "yarn workspace docs build",
     "docs:build:api": "tsx ./scripts/docs/buildApi.ts",

--- a/packages/toolpad-app/src/server/liveProject.ts
+++ b/packages/toolpad-app/src/server/liveProject.ts
@@ -27,3 +27,8 @@ export async function loadDom(): Promise<appDom.AppDom> {
   const project = await getProject();
   return project.loadDom();
 }
+
+export async function applyDomDiff(diff: appDom.DomDiff): Promise<{ fingerprint: number }> {
+  const project = await getProject();
+  return project.applyDomDiff(diff);
+}

--- a/packages/toolpad-app/src/server/localMode.ts
+++ b/packages/toolpad-app/src/server/localMode.ts
@@ -1220,17 +1220,29 @@ class ToolpadProject {
     return dom;
   }
 
-  async saveDom(newDom: appDom.AppDom) {
+  async writeDomToDisk(newDom: appDom.AppDom) {
     if (config.cmd !== 'dev') {
       throw new Error(`Writing to disk is only possible in toolpad dev mode.`);
     }
 
+    await writeDomToDisk(newDom);
+    const newFingerprint = await calculateDomFingerprint(this.root);
+    this.domAndFingerprint = [newDom, newFingerprint];
+    this.events.emit('change', { fingerprint: newFingerprint });
+    return { fingerprint: newFingerprint };
+  }
+
+  async saveDom(newDom: appDom.AppDom) {
     return this.domAndFingerprintLock.use(async () => {
-      await writeDomToDisk(newDom);
-      const newFingerprint = await calculateDomFingerprint(this.root);
-      this.domAndFingerprint = [newDom, newFingerprint];
-      this.events.emit('change', { fingerprint: newFingerprint });
-      return { fingerprint: newFingerprint };
+      return this.writeDomToDisk(newDom);
+    });
+  }
+
+  async applyDomDiff(domDiff: appDom.DomDiff) {
+    return this.domAndFingerprintLock.use(async () => {
+      const dom = await this.loadDom();
+      const newDom = appDom.applyDiff(dom, domDiff);
+      return this.writeDomToDisk(newDom);
     });
   }
 

--- a/packages/toolpad-app/src/server/rpc.ts
+++ b/packages/toolpad-app/src/server/rpc.ts
@@ -9,7 +9,7 @@ import { execQuery, dataSourceFetchPrivate } from './data';
 import { getVersionInfo } from './versionInfo';
 import logger from './logs/logger';
 import { createComponent, deletePage, openCodeComponentEditor } from './localMode';
-import { loadDom, saveDom } from './liveProject';
+import { loadDom, saveDom, applyDomDiff } from './liveProject';
 import { asyncHandler } from '../utils/http';
 
 export interface Method<P extends any[] = any[], R = any> {
@@ -136,6 +136,9 @@ export const rpcServer = {
   mutation: {
     saveDom: createMethod<typeof saveDom>(({ params }) => {
       return saveDom(...params);
+    }),
+    applyDomDiff: createMethod<typeof applyDomDiff>(({ params }) => {
+      return applyDomDiff(...params);
     }),
     openCodeComponentEditor: createMethod<typeof openCodeComponentEditor>(({ params }) => {
       return openCodeComponentEditor(...params);

--- a/packages/toolpad-app/src/toolpad/AppState.tsx
+++ b/packages/toolpad-app/src/toolpad/AppState.tsx
@@ -543,8 +543,9 @@ export default function AppProvider({ children }: DomContextProps) {
 
     const domToSave = state.dom;
     dispatch({ type: 'DOM_SAVING' });
+    const domDiff = appDom.createDiff(state.savedDom, domToSave);
     client.mutation
-      .saveDom(domToSave)
+      .applyDomDiff(domDiff)
       .then(({ fingerprint: newFingerPrint }) => {
         fingerprint.current = newFingerPrint;
         dispatch({ type: 'DOM_SAVED', savedDom: domToSave });

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -7,6 +7,9 @@ const config: PlaywrightTestConfig<{ toolpadDev: boolean }> = {
   retries: process.env.TOOLPAD_TEST_RETRIES ? Number(process.env.TOOLPAD_TEST_RETRIES) : 0,
   testMatch: /.*.spec.[jt]sx?$/,
   workers: 2,
+  expect: {
+    timeout: 10000,
+  },
   use: {
     trace: { mode: 'on-first-retry', screenshots: true },
     screenshot: 'only-on-failure',


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/2072

Avoid sending the whole dom back to the server during saving. Instead construct a diff by comparing old dom with new one and only send updated/added/deleted nodes.

We could also have chosen to increase the upload limit as a quick solution.