### PR TITLE
[docs] Pass productId to the pagecontext

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -15,6 +15,7 @@ import DocsStyledEngineProvider from 'docs/src/modules/utils/StyledEngineProvide
 import createEmotionCache from 'docs/src/createEmotionCache';
 import findActivePage from 'docs/src/modules/utils/findActivePage';
 import pages from '../data/pages';
+import toolpadPkgJson from '../../packages/toolpad/package.json';
 
 const clientSideEmotionCache = createEmotionCache();
 
@@ -144,12 +145,18 @@ function AppWrapper(props) {
     const { activePage, activePageParents } = findActivePage(pages, router.pathname);
 
     const productIdentifier = {
+      metadata: '',
       name: 'Toolpad',
-      metadata: 'MUI Toolpad',
-      versions: [],
+      versions: [{ text: `v${toolpadPkgJson.version}`, current: true }],
     };
 
-    return { activePage, activePageParents, pages, productIdentifier };
+    return {
+      activePage,
+      activePageParents,
+      pages,
+      productIdentifier,
+      productId: 'toolpad',
+    };
   }, [router.pathname]);
 
   return (


### PR DESCRIPTION
Make sure we pass the product id to the pag context so it can get picked up by https://github.com/mui/material-ui/pull/37600

Also add the current version in the header