### PR TITLE
remove renovate docs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,10 +21,6 @@
       "matchDepTypes": ["devDependencies"]
     },
     {
-      "groupName": "docs",
-      "matchFiles": ["docs/package.json"]
-    },
-    {
       "groupName": "MUI Core",
       "matchPackagePatterns": ["^@mui/"],
       "schedule": ["at any time"]


### PR DESCRIPTION
Grouping dependencies by workspace potentially results in multiple versions of the same dependency. The improper use of the monorepo github dependency makes dependency resolution unpredictable. This resulted in issues with `@emotion/react`. Removing the group of docs to avoid this issue in the future. We'll restrict to grouping only by dependency for now.