### PR TITLE
Disable a query as long as its input is still loading

### DIFF
--- a/test/integration/backend-basic/fixture/toolpad/pages/basic/page.yml
+++ b/test/integration/backend-basic/fixture/toolpad/pages/basic/page.yml
@@ -21,7 +21,7 @@ spec:
           props:
             value:
               $$jsExpression: |
-                `throws, error.message: ${throws.error.message}`
+                `throws, error.message: ${throws.error}`
     - component: PageRow
       name: pageRow2
       children:
@@ -110,6 +110,25 @@ spec:
             value:
               $$jsExpression: |
                 `global value: ${getGlobal.data}`
+    - component: PageRow
+      name: pageRow11
+      children:
+        - component: Text
+          name: text3
+          props:
+            value:
+              $$jsExpression: |
+                `Propagated error: ${errorInput.error}`
+    - component: PageRow
+      name: pageRow10
+      children:
+        - component: Text
+          name: text2
+          props:
+            value:
+              $$jsExpression: >
+                `Loading: ${alwaysLoading.isLoading}; Propagated loading:
+                ${propagatedLoading.isLoading}`
   queries:
     - name: hello
       query:
@@ -155,3 +174,27 @@ spec:
       query:
         function: getGlobal
         kind: local
+    - name: errorInput
+      query:
+        function: echo
+        kind: local
+      parameters:
+        - name: foo
+          value:
+            $$jsExpression: |
+              (() => {
+                throw new Error("KABOOM!")
+              })()
+    - name: alwaysLoading
+      query:
+        function: neverResolving
+        kind: local
+    - name: propagatedLoading
+      query:
+        function: echo
+        kind: local
+      parameters:
+        - name: foo
+          value:
+            $$jsExpression: |
+              alwaysLoading.data

--- a/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
+++ b/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
@@ -87,3 +87,7 @@ export async function invalidError() {
   // Yes, I'm throwing a function here
   throw function Hello() {};
 }
+
+export function neverResolving() {
+  return new Promise(() => {});
+}

--- a/test/integration/backend-basic/index.spec.ts
+++ b/test/integration/backend-basic/index.spec.ts
@@ -47,6 +47,10 @@ test('functions basics', async ({ page }) => {
   await expect(page.locator('text="echo, parameter: bound foo parameter"')).toBeVisible();
   await expect(page.locator('text="echo, secret: Some bar secret"')).toBeVisible();
   await expect(page.locator('text="echo, secret not in .env: Some baz secret"')).toBeVisible();
+  await expect(page.getByText('Propagated error: KABOOM!', { exact: true })).toBeVisible();
+  await expect(
+    page.getByText('Loading: true; Propagated loading: true', { exact: true }),
+  ).toBeVisible();
 });
 
 test('function editor reload', async ({ page, localApp }) => {


### PR DESCRIPTION
Noticed in tools-public that a query that depended on another query results in erratic loading behavior. The developer of that page solved it by hiding the chart as long as there is no data, but in the runtime fetches with bogus parameters were still happening. The query downstream really shouldn't do anything until its input is done resolving, we can propagate the loading (and error) state downstream. Which is what this PR implements.
