### PR TITLE
Add needs triage action

### DIFF
--- a/.github/workflows/ensure-triage-label.yml
+++ b/.github/workflows/ensure-triage-label.yml
@@ -12,9 +12,17 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            github.rest.issues.addLabels({
+            const labels = await github.rest.issues.listLabelsOnIssue({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['status: needs triage']
-            })
+            });
+
+            if (labels.length <= 0) {
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['status: needs triage']
+              })
+            }

--- a/.github/workflows/ensure-triage-label.yml
+++ b/.github/workflows/ensure-triage-label.yml
@@ -1,0 +1,20 @@
+name: Label new issues with "needs triage"
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['status: needs triage']
+            })


### PR DESCRIPTION
From https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues

Ensure we add the needs-triage on opened issues
