### PR TITLE
Fix broken query editor when env vars are defined

### DIFF
--- a/packages/toolpad-app/src/server/data.ts
+++ b/packages/toolpad-app/src/server/data.ts
@@ -57,7 +57,7 @@ export async function execQuery<P, Q>(
     const transformEnabled = dataNode.attributes.transformEnabled;
     const transform = dataNode.attributes.transform;
     if (transformEnabled && transform) {
-      const jsServerRuntime = await createServerJsRuntime();
+      const jsServerRuntime = await createServerJsRuntime(process.env);
       result = {
         data: await applyTransform(jsServerRuntime, transform, result.data),
       };

--- a/packages/toolpad-core/src/jsServerRuntime.tsx
+++ b/packages/toolpad-core/src/jsServerRuntime.tsx
@@ -28,5 +28,9 @@ export function createServerJsRuntime(env?: Record<string, string | undefined>):
 }
 
 export function useServerJsRuntime(): JsRuntime {
-  return React.useMemo(() => createServerJsRuntime(), []);
+  return React.useMemo(() => {
+    // process.env is not available in the browser
+    const processEnv = {};
+    return createServerJsRuntime(processEnv);
+  }, []);
 }


### PR DESCRIPTION
This regressed in https://github.com/mui/mui-toolpad/pull/2214

Also splitting the test into an editor and runtime part, and adding a test for this issue