### PR TITLE
Isolate marked in renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -73,8 +73,7 @@
     },
     {
       "groupName": "marked",
-      "matchPackageNames": ["marked"],
-      "allowedVersions": "< 5.0.0"
+      "matchPackageNames": ["marked"]
     },
     {
       "matchDepTypes": ["action"],

--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,11 @@
       "allowedVersions": "< 2.0.0"
     },
     {
+      "groupName": "marked",
+      "matchPackageNames": ["marked"],
+      "allowedVersions": "< 5.0.0"
+    },
+    {
       "matchDepTypes": ["action"],
       "pinDigests": true
     },


### PR DESCRIPTION
It forces us to move to node.js 18 in https://github.com/mui/mui-toolpad/pull/2219, but we want to be able to test under 16 and we can't install the workspace under 16