### PR TITLE
Support loading raw text for .txt files and .sql files

### DIFF
--- a/packages/toolpad-app/src/server/FunctionsManager.ts
+++ b/packages/toolpad-app/src/server/FunctionsManager.ts
@@ -22,28 +22,6 @@ import {
 import { Awaitable } from '../utils/types';
 import { format } from '../utils/prettier';
 
-const ESBUILD_RAW_LOADER: esbuild.Plugin = {
-  name: 'raw-loader',
-  setup(build) {
-    build.onResolve({ filter: /\?raw$/ }, async ({ path: importedPath, ...args }) => {
-      const pathWithoutQuery = importedPath.replace(/\?raw$/, '');
-      const resolved = await build.resolve(pathWithoutQuery, args);
-      return {
-        ...resolved,
-        suffix: '?raw',
-        namespace: 'raw-files',
-      };
-    });
-
-    build.onLoad({ filter: /.*/, namespace: 'raw-files' }, async ({ path: loadedPath }) => {
-      return {
-        contents: await fs.readFile(loadedPath, 'utf-8'),
-        loader: 'text',
-      };
-    });
-  },
-};
-
 function createDefaultFunction(): string {
   return format(`
     /**
@@ -212,7 +190,7 @@ export default class FunctionsManager {
     return esbuild.context({
       absWorkingDir: root,
       entryPoints,
-      plugins: [toolpadPlugin, ESBUILD_RAW_LOADER],
+      plugins: [toolpadPlugin],
       write: true,
       bundle: true,
       metafile: true,
@@ -221,6 +199,10 @@ export default class FunctionsManager {
       packages: 'external',
       target: 'es2022',
       tsconfigRaw: JSON.stringify(tsConfig),
+      loader: {
+        '.txt': 'text',
+        '.sql': 'text',
+      },
     });
   }
 

--- a/packages/toolpad-app/src/server/FunctionsManager.ts
+++ b/packages/toolpad-app/src/server/FunctionsManager.ts
@@ -22,6 +22,28 @@ import {
 import { Awaitable } from '../utils/types';
 import { format } from '../utils/prettier';
 
+const ESBUILD_RAW_LOADER: esbuild.Plugin = {
+  name: 'raw-loader',
+  setup(build) {
+    build.onResolve({ filter: /\?raw$/ }, async ({ path: importedPath, ...args }) => {
+      const pathWithoutQuery = importedPath.replace(/\?raw$/, '');
+      const resolved = await build.resolve(pathWithoutQuery, args);
+      return {
+        ...resolved,
+        suffix: '?raw',
+        namespace: 'raw-files',
+      };
+    });
+
+    build.onLoad({ filter: /.*/, namespace: 'raw-files' }, async ({ path: loadedPath }) => {
+      return {
+        contents: await fs.readFile(loadedPath, 'utf-8'),
+        loader: 'text',
+      };
+    });
+  },
+};
+
 function createDefaultFunction(): string {
   return format(`
     /**
@@ -190,7 +212,7 @@ export default class FunctionsManager {
     return esbuild.context({
       absWorkingDir: root,
       entryPoints,
-      plugins: [toolpadPlugin],
+      plugins: [toolpadPlugin, ESBUILD_RAW_LOADER],
       write: true,
       bundle: true,
       metafile: true,

--- a/packages/toolpad-core/src/server.ts
+++ b/packages/toolpad-core/src/server.ts
@@ -1,3 +1,5 @@
+/// <reference path="./serverModules.d.ts" />
+
 import { TOOLPAD_FUNCTION } from './constants.js';
 import { InferParameterType, PrimitiveValueType, PropValueType } from './types.js';
 

--- a/packages/toolpad-core/src/serverModules.d.ts
+++ b/packages/toolpad-core/src/serverModules.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const value: string;
+  export default value;
+}

--- a/packages/toolpad-core/src/serverModules.d.ts
+++ b/packages/toolpad-core/src/serverModules.d.ts
@@ -1,4 +1,9 @@
-declare module '*?raw' {
+declare module '*.txt' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.sql' {
   const value: string;
   export default value;
 }

--- a/test/integration/backend-basic/fixture/toolpad/pages/basic/page.yml
+++ b/test/integration/backend-basic/fixture/toolpad/pages/basic/page.yml
@@ -138,6 +138,15 @@ spec:
               $$jsExpression: >
                 `Loading: ${alwaysLoading.isLoading}; Propagated loading:
                 ${propagatedLoading.isLoading}`
+    - component: PageRow
+      name: pageRow13
+      children:
+        - component: Text
+          name: text6
+          props:
+            value:
+              $$jsExpression: |
+                `Raw text: ${getRawText.data}`
   queries:
     - name: hello
       query:
@@ -214,3 +223,7 @@ spec:
       parameters:
         - name: msg
           value: threw error 1
+    - name: getRawText
+      query:
+        function: functions.ts#getRawText
+        kind: local

--- a/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
+++ b/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
@@ -1,4 +1,5 @@
 import { createFunction } from '@mui/toolpad/server';
+import rawText from './raw.txt?raw';
 
 export async function hello() {
   return { message: 'hello world' };
@@ -121,4 +122,8 @@ export async function bareWithParams(
 
 export function neverResolving() {
   return new Promise(() => {});
+}
+
+export async function getRawText() {
+  return rawText;
 }

--- a/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
+++ b/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
@@ -1,5 +1,6 @@
 import { createFunction } from '@mui/toolpad/server';
-import rawText from './raw.txt?raw';
+import rawText from './raw.txt';
+import rawSql from './raw.sql';
 
 export async function hello() {
   return { message: 'hello world' };
@@ -125,5 +126,5 @@ export function neverResolving() {
 }
 
 export async function getRawText() {
-  return rawText;
+  return [rawText, rawSql].join(' | ');
 }

--- a/test/integration/backend-basic/fixture/toolpad/resources/raw.sql
+++ b/test/integration/backend-basic/fixture/toolpad/resources/raw.sql
@@ -1,0 +1,1 @@
+SELECT NOW()

--- a/test/integration/backend-basic/fixture/toolpad/resources/raw.txt
+++ b/test/integration/backend-basic/fixture/toolpad/resources/raw.txt
@@ -1,0 +1,1 @@
+Hello, I'm raw text!

--- a/test/integration/backend-basic/shared.ts
+++ b/test/integration/backend-basic/shared.ts
@@ -16,5 +16,7 @@ export async function expectBasicPageContent(page: Page) {
   await expect(
     page.getByText('Loading: true; Propagated loading: true', { exact: true }),
   ).toBeVisible();
-  await expect(page.getByText("Raw text: Hello, I'm raw text!", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Raw text: Hello, I'm raw text! | SELECT NOW()", { exact: true }),
+  ).toBeVisible();
 }

--- a/test/integration/backend-basic/shared.ts
+++ b/test/integration/backend-basic/shared.ts
@@ -16,4 +16,5 @@ export async function expectBasicPageContent(page: Page) {
   await expect(
     page.getByText('Loading: true; Propagated loading: true', { exact: true }),
   ).toBeVisible();
+  await expect(page.getByText("Raw text: Hello, I'm raw text!", { exact: true })).toBeVisible();
 }


### PR DESCRIPTION
This allows for importing sql files:

```tsx
import sql from './getOrders.sql'

// ...

await connection.execute(sql)
```

See also https://github.com/mui/mui-private/pull/281