### PR TITLE
[fix] disable auto formatting `_redirects`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,9 @@
     "source.fixAll.eslint": true
   },
   "editor.formatOnSave": true,
+  "files.associations": {
+    "**/docs/public/_redirects": "plaintext"
+  },
   "typescript.tsdk": "node_modules/typescript/lib",
   "cSpell.words": ["Toolpad"]
 }


### PR DESCRIPTION
 This causes a build time issue on the documentation website on Netlify with the 

`/toolpad/_next/* /_next/:splat 301` rule being autoformatted to become:
`/toolpad/\_next/\* /\_next/:splat 301`

which results in 404s when the browser attempts to find the builds