### PR TITLE
Lay foundation for new and improved theme editor

### DIFF
--- a/docs/schemas/v1/definitions.json
+++ b/docs/schemas/v1/definitions.json
@@ -390,28 +390,10 @@
                       ]
                     },
                     "primary": {
-                      "type": "object",
-                      "properties": {
-                        "main": {
-                          "type": "string"
-                        },
-                        "light": {
-                          "type": "string"
-                        },
-                        "dark": {
-                          "type": "string"
-                        },
-                        "contrastText": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "main"
-                      ],
-                      "additionalProperties": false
+                      "$ref": "#/definitions/SimplePaletteColorOptions"
                     },
                     "secondary": {
-                      "$ref": "#/properties/Theme/properties/spec/properties/options/properties/palette/properties/primary"
+                      "$ref": "#/definitions/SimplePaletteColorOptions"
                     }
                   },
                   "required": [
@@ -686,6 +668,27 @@
       ],
       "additionalProperties": false,
       "description": "A name/value pair where the value is dynamically bindable to strings."
+    },
+    "SimplePaletteColorOptions": {
+      "type": "object",
+      "properties": {
+        "main": {
+          "type": "string"
+        },
+        "light": {
+          "type": "string"
+        },
+        "dark": {
+          "type": "string"
+        },
+        "contrastText": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "main"
+      ],
+      "additionalProperties": false
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"

--- a/docs/schemas/v1/definitions.json
+++ b/docs/schemas/v1/definitions.json
@@ -400,13 +400,13 @@
                     "primary",
                     "secondary"
                   ],
-                  "additionalProperties": false
+                  "additionalProperties": true
                 }
               },
               "required": [
                 "palette"
               ],
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "The ThemeOptions object that gets fed into MUI's createTheme function."
             }
           },

--- a/docs/schemas/v1/definitions.json
+++ b/docs/schemas/v1/definitions.json
@@ -376,22 +376,7 @@
         "spec": {
           "type": "object",
           "properties": {
-            "palette.mode": {
-              "type": "string",
-              "enum": [
-                "light",
-                "dark"
-              ],
-              "description": "The MUI theme palette mode."
-            },
-            "palette.primary.main": {
-              "type": "string",
-              "description": "The primary theme color."
-            },
-            "palette.secondary.main": {
-              "type": "string",
-              "description": "The secondary theme color."
-            }
+            "options": {}
           },
           "additionalProperties": false,
           "description": "Defines the shape of this \"theme\" object"

--- a/docs/schemas/v1/definitions.json
+++ b/docs/schemas/v1/definitions.json
@@ -424,12 +424,10 @@
               "required": [
                 "palette"
               ],
-              "additionalProperties": false
+              "additionalProperties": false,
+              "description": "The ThemeOptions object that gets fed into MUI's createTheme function."
             }
           },
-          "required": [
-            "options"
-          ],
           "additionalProperties": false,
           "description": "Defines the shape of this \"theme\" object"
         }

--- a/docs/schemas/v1/definitions.json
+++ b/docs/schemas/v1/definitions.json
@@ -376,8 +376,60 @@
         "spec": {
           "type": "object",
           "properties": {
-            "options": {}
+            "options": {
+              "type": "object",
+              "properties": {
+                "palette": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "light",
+                        "dark"
+                      ]
+                    },
+                    "primary": {
+                      "type": "object",
+                      "properties": {
+                        "main": {
+                          "type": "string"
+                        },
+                        "light": {
+                          "type": "string"
+                        },
+                        "dark": {
+                          "type": "string"
+                        },
+                        "contrastText": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "main"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "secondary": {
+                      "$ref": "#/properties/Theme/properties/spec/properties/options/properties/palette/properties/primary"
+                    }
+                  },
+                  "required": [
+                    "primary",
+                    "secondary"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "palette"
+              ],
+              "additionalProperties": false
+            }
           },
+          "required": [
+            "options"
+          ],
           "additionalProperties": false,
           "description": "Defines the shape of this \"theme\" object"
         }

--- a/docs/src/modules/components/SchemaReference.tsx
+++ b/docs/src/modules/components/SchemaReference.tsx
@@ -277,7 +277,10 @@ function JsonSchemaPropertiesDisplay({ schema, idPrefix, open }: JsonSchemaPrope
   }
 
   if (schema.additionalProperties) {
-    properties.push(['*', schema.additionalProperties]);
+    properties.push([
+      '*',
+      typeof schema.additionalProperties === 'boolean' ? {} : schema.additionalProperties,
+    ]);
   }
 
   return properties.length > 0 ? (
@@ -396,7 +399,10 @@ function JsonSchemaNameValueDisplay({
   schema,
   idPrefix = '',
 }: JsonSchemaNameValueDisplayProps) {
-  invariant(typeof schema === 'object', `Expected an object but got ${typeof schema}`);
+  invariant(
+    typeof schema === 'object',
+    `Expected an object at "${name}" but got "${typeof schema}"`,
+  );
 
   const properties: [string, JSONSchema7Definition][] = [];
 
@@ -405,7 +411,10 @@ function JsonSchemaNameValueDisplay({
   }
 
   if (schema.additionalProperties) {
-    properties.push(['*', schema.additionalProperties]);
+    properties.push([
+      '*',
+      typeof schema.additionalProperties === 'boolean' ? {} : schema.additionalProperties,
+    ]);
   }
 
   const tooltipContext = React.useContext(TooltipContext);

--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -11,10 +11,10 @@ import {
   EnvAttrValue,
 } from '@mui/toolpad-core';
 import invariant from 'invariant';
-import { BoxProps } from '@mui/material';
+import { BoxProps, ThemeOptions as MuiThemeOptions } from '@mui/material';
 import { pascalCase, removeDiacritics, uncapitalize } from '@mui/toolpad-utils/strings';
 import { mapProperties, mapValues } from '@mui/toolpad-utils/collections';
-import { ConnectionStatus, AppTheme } from '../types';
+import { ConnectionStatus } from '../types';
 import { omit, update, updateOrCreate } from '../utils/immutability';
 import { ExactEntriesOf, Maybe } from '../utils/types';
 import { envBindingSchema } from '../server/schema';
@@ -69,7 +69,7 @@ export interface AppNode extends AppDomNodeBase {
 
 export interface ThemeNode extends AppDomNodeBase {
   readonly type: 'theme';
-  readonly theme?: BindableAttrValues<AppTheme>;
+  readonly theme?: MuiThemeOptions;
 }
 
 export interface ConnectionNode<P = unknown> extends AppDomNodeBase {

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -106,7 +106,7 @@ export default function AppCanvas({
     );
 
     const unsetUpdate = setCommandHandler(bridge.canvasCommands, 'update', (newState) => {
-      React.startTransition(() => setState(newState));
+      React.startTransition(() => setState(structuredClone(newState)));
     });
 
     const unsetInvalidateQueries = setCommandHandler(

--- a/packages/toolpad-app/src/components/ColorTool.tsx
+++ b/packages/toolpad-app/src/components/ColorTool.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { SxProps, rgbToHex, useTheme } from '@mui/material/styles';
 import * as colors from '@mui/material/colors';
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
 import Input from '@mui/material/Input';
 import Radio, { RadioProps } from '@mui/material/Radio';
 import Tooltip from '@mui/material/Tooltip';

--- a/packages/toolpad-app/src/components/ColorTool.tsx
+++ b/packages/toolpad-app/src/components/ColorTool.tsx
@@ -176,7 +176,7 @@ function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
   const id = React.useId();
 
   return (
-    <Grid item xs={12} sm={6} md={4} sx={sx}>
+    <Box sx={sx}>
       <Typography component="label" gutterBottom htmlFor={id} variant="h6">
         {label}
       </Typography>
@@ -261,7 +261,7 @@ function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
           </Box>
         ))}
       </Grid>
-    </Grid>
+    </Box>
   );
 }
 

--- a/packages/toolpad-app/src/components/ColorTool.tsx
+++ b/packages/toolpad-app/src/components/ColorTool.tsx
@@ -10,6 +10,7 @@ import Typography from '@mui/material/Typography';
 import CheckIcon from '@mui/icons-material/Check';
 import Slider from '@mui/material/Slider';
 import invariant from 'invariant';
+import { Stack } from '@mui/material';
 
 const isRgb = (string: string) =>
   /rgb\([0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\)/i.test(string);
@@ -200,13 +201,13 @@ function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
         />
         <Typography>{shades[intentShade]}</Typography>
       </Box>
-      <Box sx={{ width: 192 }}>
+      <Box sx={{ width: 192, margin: 'auto' }}>
         {hues.map((hue) => {
           const shade = shades[state.shade];
           const backgroundColor = colors[hue][shade];
 
           return (
-            <Tooltip placement="right" title={hue} key={hue}>
+            <Tooltip placement="right" title={hue} key={hue} disableInteractive>
               <TooltipRadio
                 sx={{ p: 0 }}
                 color="default"
@@ -237,7 +238,7 @@ function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
           );
         })}
       </Box>
-      <Grid container sx={{ mt: 2 }}>
+      <Stack direction="row" sx={{ mt: 2, justifyContent: 'center' }}>
         {(['dark', 'main', 'light'] as const).map((key) => (
           <Box
             sx={{
@@ -260,7 +261,7 @@ function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
             </Typography>
           </Box>
         ))}
-      </Grid>
+      </Stack>
     </Box>
   );
 }

--- a/packages/toolpad-app/src/components/ColorTool.tsx
+++ b/packages/toolpad-app/src/components/ColorTool.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { rgbToHex, useTheme } from '@mui/material/styles';
+import { SxProps, rgbToHex, useTheme } from '@mui/material/styles';
 import * as colors from '@mui/material/colors';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
@@ -88,9 +88,10 @@ export interface ColorToolProps {
   label: string;
   value: string;
   onChange: (value: string) => void;
+  sx?: SxProps;
 }
 
-function ColorTool({ label, value, onChange }: ColorToolProps) {
+function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
   const theme = useTheme();
 
   const [state, setState] = React.useState<{
@@ -172,7 +173,7 @@ function ColorTool({ label, value, onChange }: ColorToolProps) {
   const id = React.useId();
 
   return (
-    <Grid item xs={12} sm={6} md={4}>
+    <Grid item xs={12} sm={6} md={4} sx={sx}>
       <Typography component="label" gutterBottom htmlFor={id} variant="h6">
         {label}
       </Typography>

--- a/packages/toolpad-app/src/components/ColorTool.tsx
+++ b/packages/toolpad-app/src/components/ColorTool.tsx
@@ -98,10 +98,12 @@ function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
     input: string;
     hue: keyof typeof colors;
     shade: number;
+    isValidColor: boolean;
   }>({
     input: value,
     hue: 'blue',
     shade: 4,
+    isValidColor: true,
   });
 
   const handleChangeColor = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -109,21 +111,22 @@ function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
       target: { value: color },
     } = event;
 
-    setState((oldState) => ({
-      ...oldState,
-      input: color,
-    }));
-
     let isValidColor = false;
 
     if (isRgb(color)) {
       isValidColor = true;
     } else if (isHex(color)) {
       isValidColor = true;
-      if (color.indexOf('#') === -1) {
+      if (!color.startsWith('#')) {
         color = `#${color}`;
       }
     }
+
+    setState((oldState) => ({
+      ...oldState,
+      input: color,
+      isValidColor,
+    }));
 
     if (isValidColor) {
       onChange(color);
@@ -177,7 +180,13 @@ function ColorTool({ sx, label, value, onChange }: ColorToolProps) {
       <Typography component="label" gutterBottom htmlFor={id} variant="h6">
         {label}
       </Typography>
-      <Input id={id} value={intentInput} onChange={handleChangeColor} fullWidth />
+      <Input
+        id={id}
+        value={intentInput}
+        onChange={handleChangeColor}
+        fullWidth
+        error={!state.isValidColor}
+      />
       <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, mb: 2 }}>
         <Typography id={`${id}ShadeSliderLabel`}>Shade:</Typography>
         <Slider

--- a/packages/toolpad-app/src/components/ColorTool.tsx
+++ b/packages/toolpad-app/src/components/ColorTool.tsx
@@ -1,0 +1,258 @@
+import * as React from 'react';
+import { rgbToHex, useTheme } from '@mui/material/styles';
+import * as colors from '@mui/material/colors';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Input from '@mui/material/Input';
+import Radio, { RadioProps } from '@mui/material/Radio';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import CheckIcon from '@mui/icons-material/Check';
+import Slider from '@mui/material/Slider';
+import invariant from 'invariant';
+
+const isRgb = (string: string) =>
+  /rgb\([0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\)/i.test(string);
+
+const isHex = (string: string) => /^#?([0-9a-f]{3})$|^#?([0-9a-f]){6}$/i.test(string);
+
+const hues = [
+  'red',
+  'pink',
+  'purple',
+  'deepPurple',
+  'indigo',
+  'blue',
+  'lightBlue',
+  'cyan',
+  'teal',
+  'green',
+  'lightGreen',
+  'lime',
+  'yellow',
+  'amber',
+  'orange',
+  'deepOrange',
+] as const;
+
+const shades = [
+  900,
+  800,
+  700,
+  600,
+  500,
+  400,
+  300,
+  200,
+  100,
+  50,
+  'A700',
+  'A400',
+  'A200',
+  'A100',
+] as const;
+
+type Shade = (typeof shades)[number];
+
+interface TooltipRadioProps extends RadioProps {
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  inputProps?: RadioProps['inputProps'];
+}
+
+const TooltipRadio = React.forwardRef<HTMLButtonElement, TooltipRadioProps>(function TooltipRadio(
+  props,
+  ref,
+) {
+  const {
+    'aria-labelledby': ariaLabelledBy,
+    'aria-label': ariaLabel,
+    inputProps,
+    ...other
+  } = props;
+
+  return (
+    <Radio
+      ref={ref}
+      {...other}
+      inputProps={{
+        ...inputProps,
+        'aria-labelledby': ariaLabelledBy,
+        'aria-label': ariaLabel,
+      }}
+    />
+  );
+});
+
+export interface ColorToolProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function ColorTool({ label, value, onChange }: ColorToolProps) {
+  const theme = useTheme();
+
+  const [state, setState] = React.useState<{
+    input: string;
+    hue: keyof typeof colors;
+    shade: number;
+  }>({
+    input: value,
+    hue: 'blue',
+    shade: 4,
+  });
+
+  const handleChangeColor = (event: React.ChangeEvent<HTMLInputElement>) => {
+    let {
+      target: { value: color },
+    } = event;
+
+    setState((oldState) => ({
+      ...oldState,
+      input: color,
+    }));
+
+    let isValidColor = false;
+
+    if (isRgb(color)) {
+      isValidColor = true;
+    } else if (isHex(color)) {
+      isValidColor = true;
+      if (color.indexOf('#') === -1) {
+        color = `#${color}`;
+      }
+    }
+
+    if (isValidColor) {
+      onChange(color);
+    }
+  };
+
+  const handleChangeHue = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const hue = event.target.value as keyof typeof colors;
+    const color = (colors[hue] as Record<Shade, string | undefined>)[shades[state.shade]];
+
+    if (color) {
+      setState({
+        ...state,
+        hue,
+        input: color,
+      });
+      onChange(color);
+    }
+  };
+
+  const handleChangeShade = (event: Event, shade: number | number[]) => {
+    invariant(!Array.isArray(shade), 'Material-UI: `shade` must not be an array.');
+
+    const color = (colors[state.hue] as Record<Shade, string | undefined>)[shades[shade]];
+
+    if (color) {
+      setState({
+        ...state,
+        shade,
+
+        input: color,
+      });
+      onChange(color);
+    }
+  };
+
+  const intentInput = state.input;
+  const intentShade = state.shade;
+  const color = value;
+
+  const background = theme.palette.augmentColor({
+    color: {
+      main: color,
+    },
+  });
+
+  const id = React.useId();
+
+  return (
+    <Grid item xs={12} sm={6} md={4}>
+      <Typography component="label" gutterBottom htmlFor={id} variant="h6">
+        {label}
+      </Typography>
+      <Input id={id} value={intentInput} onChange={handleChangeColor} fullWidth />
+      <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, mb: 2 }}>
+        <Typography id={`${id}ShadeSliderLabel`}>Shade:</Typography>
+        <Slider
+          sx={{ width: 'calc(100% - 80px)', ml: 3, mr: 3 }}
+          value={intentShade}
+          min={0}
+          max={13}
+          step={1}
+          onChange={handleChangeShade}
+          aria-labelledby={`${id}ShadeSliderLabel`}
+        />
+        <Typography>{shades[intentShade]}</Typography>
+      </Box>
+      <Box sx={{ width: 192 }}>
+        {hues.map((hue) => {
+          const shade = shades[state.shade];
+          const backgroundColor = colors[hue][shade];
+
+          return (
+            <Tooltip placement="right" title={hue} key={hue}>
+              <TooltipRadio
+                sx={{ p: 0 }}
+                color="default"
+                checked={color === backgroundColor}
+                onChange={handleChangeHue}
+                value={hue}
+                name={label}
+                icon={<Box sx={{ width: 48, height: 48 }} style={{ backgroundColor }} />}
+                checkedIcon={
+                  <Box
+                    sx={{
+                      width: 48,
+                      height: 48,
+                      border: 1,
+                      borderColor: 'white',
+                      color: 'common.white',
+                      display: 'flex',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                    }}
+                    style={{ backgroundColor }}
+                  >
+                    <CheckIcon style={{ fontSize: 30 }} />
+                  </Box>
+                }
+              />
+            </Tooltip>
+          );
+        })}
+      </Box>
+      <Grid container sx={{ mt: 2 }}>
+        {(['dark', 'main', 'light'] as const).map((key) => (
+          <Box
+            sx={{
+              width: 64,
+              height: 64,
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+            style={{ backgroundColor: background[key] }}
+            key={key}
+          >
+            <Typography
+              variant="caption"
+              style={{
+                color: theme.palette.getContrastText(background[key]),
+              }}
+            >
+              {rgbToHex(background[key])}
+            </Typography>
+          </Box>
+        ))}
+      </Grid>
+    </Grid>
+  );
+}
+
+export default ColorTool;

--- a/packages/toolpad-app/src/components/MuiThemeEditor.tsx
+++ b/packages/toolpad-app/src/components/MuiThemeEditor.tsx
@@ -90,14 +90,16 @@ export default function MuiThemeEditor({ value, onChange }: MuiThemeEditorProps)
       <ToggleButtonGroup
         exclusive
         value={value?.palette?.mode}
-        onChange={(event, newMode: PaletteMode) => {
-          onChange({
-            ...value,
-            palette: {
-              ...value?.palette,
-              mode: newMode,
-            },
-          });
+        onChange={(event, newMode: PaletteMode | null) => {
+          if (newMode) {
+            onChange({
+              ...value,
+              palette: {
+                ...value?.palette,
+                mode: newMode,
+              },
+            });
+          }
         }}
         aria-label="Mode"
       >

--- a/packages/toolpad-app/src/components/MuiThemeEditor.tsx
+++ b/packages/toolpad-app/src/components/MuiThemeEditor.tsx
@@ -83,7 +83,7 @@ export default function MuiThemeEditor({ value, onChange }: MuiThemeEditorProps)
 
       <PaletteColorPicker
         label="Secondary"
-        value={(value?.palette?.primary as PaletteColor)?.main || '#f50057'}
+        value={(value?.palette?.secondary as PaletteColor)?.main || '#f50057'}
         onChange={(newMain) => {
           onChange({
             ...value,

--- a/packages/toolpad-app/src/components/MuiThemeEditor.tsx
+++ b/packages/toolpad-app/src/components/MuiThemeEditor.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Box,
   Button,
+  capitalize,
   PaletteColor,
   PaletteMode,
   Popover,
@@ -85,6 +86,26 @@ export interface MuiThemeEditorProps {
 
 export default function MuiThemeEditor({ value, onChange }: MuiThemeEditorProps) {
   const theme = useTheme();
+
+  const colorPicker = (intent: 'primary' | 'secondary') => (
+    <PaletteColorPicker
+      label={capitalize(intent)}
+      value={(value?.palette?.[intent] as PaletteColor)?.main || '#f50057'}
+      onChange={(newMain) => {
+        onChange({
+          ...value,
+          palette: {
+            ...value?.palette,
+            [intent]: {
+              main: newMain,
+              contrastText: theme.palette.getContrastText(newMain),
+            },
+          },
+        });
+      }}
+    />
+  );
+
   return (
     <Stack direction="column" spacing={2}>
       <ToggleButtonGroup
@@ -113,39 +134,9 @@ export default function MuiThemeEditor({ value, onChange }: MuiThemeEditorProps)
         </IconToggleButton>
       </ToggleButtonGroup>
 
-      <PaletteColorPicker
-        label="Primary"
-        value={(value?.palette?.primary as PaletteColor)?.main || '#2196f3'}
-        onChange={(newMain) => {
-          onChange({
-            ...value,
-            palette: {
-              ...value?.palette,
-              primary: {
-                main: newMain,
-                contrastText: theme.palette.getContrastText(newMain),
-              },
-            },
-          });
-        }}
-      />
+      {colorPicker('primary')}
 
-      <PaletteColorPicker
-        label="Secondary"
-        value={(value?.palette?.secondary as PaletteColor)?.main || '#f50057'}
-        onChange={(newMain) => {
-          onChange({
-            ...value,
-            palette: {
-              ...value?.palette,
-              secondary: {
-                main: newMain,
-                contrastText: theme.palette.getContrastText(newMain),
-              },
-            },
-          });
-        }}
-      />
+      {colorPicker('secondary')}
     </Stack>
   );
 }

--- a/packages/toolpad-app/src/components/MuiThemeEditor.tsx
+++ b/packages/toolpad-app/src/components/MuiThemeEditor.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import {
+  Box,
+  Button,
   PaletteColor,
   PaletteMode,
+  Popover,
   Stack,
   styled,
   ThemeOptions,
@@ -13,6 +16,7 @@ import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import { WithControlledProp } from '../utils/types';
 import ColorTool from './ColorTool';
+import FlexFill from './FlexFill';
 
 const IconToggleButton = styled(ToggleButton)({
   display: 'flex',
@@ -28,7 +32,50 @@ interface PaletteColorPickerProps extends WithControlledProp<string> {
 }
 
 function PaletteColorPicker({ label, value, onChange }: PaletteColorPickerProps) {
-  return <ColorTool label={label} value={value} onChange={onChange} />;
+  const theme = useTheme();
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = React.useId();
+  return (
+    <React.Fragment>
+      <Button aria-describedby={id} variant="outlined" onClick={handleClick}>
+        {label}
+        <FlexFill />
+        <Box
+          sx={{
+            ml: 2,
+            p: '2px 8px',
+            background: value,
+            color: theme.palette.getContrastText(value),
+            borderRadius: 1,
+          }}
+        >
+          {value}
+        </Box>
+      </Button>
+      <Popover
+        id={open ? id : undefined}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <ColorTool sx={{ m: 2 }} label={label} value={value} onChange={onChange} />
+      </Popover>
+    </React.Fragment>
+  );
 }
 
 export interface MuiThemeEditorProps {

--- a/packages/toolpad-app/src/components/MuiThemeEditor.tsx
+++ b/packages/toolpad-app/src/components/MuiThemeEditor.tsx
@@ -3,9 +3,9 @@ import {
   Box,
   Button,
   capitalize,
-  PaletteColor,
   PaletteMode,
   Popover,
+  SimplePaletteColorOptions,
   Stack,
   styled,
   ThemeOptions,
@@ -90,7 +90,7 @@ export default function MuiThemeEditor({ value, onChange }: MuiThemeEditorProps)
   const colorPicker = (intent: 'primary' | 'secondary') => (
     <PaletteColorPicker
       label={capitalize(intent)}
-      value={(value?.palette?.[intent] as PaletteColor)?.main || '#f50057'}
+      value={(value?.palette?.[intent] as SimplePaletteColorOptions)?.main || '#f50057'}
       onChange={(newMain) => {
         onChange({
           ...value,

--- a/packages/toolpad-app/src/components/MuiThemeEditor.tsx
+++ b/packages/toolpad-app/src/components/MuiThemeEditor.tsx
@@ -87,10 +87,10 @@ export interface MuiThemeEditorProps {
 export default function MuiThemeEditor({ value, onChange }: MuiThemeEditorProps) {
   const theme = useTheme();
 
-  const colorPicker = (intent: 'primary' | 'secondary') => (
+  const colorPicker = (intent: 'primary' | 'secondary', defaultValue: string) => (
     <PaletteColorPicker
       label={capitalize(intent)}
-      value={(value?.palette?.[intent] as SimplePaletteColorOptions)?.main || '#f50057'}
+      value={(value?.palette?.[intent] as SimplePaletteColorOptions)?.main || defaultValue}
       onChange={(newMain) => {
         onChange({
           ...value,
@@ -134,9 +134,9 @@ export default function MuiThemeEditor({ value, onChange }: MuiThemeEditorProps)
         </IconToggleButton>
       </ToggleButtonGroup>
 
-      {colorPicker('primary')}
+      {colorPicker('primary', '#2196f3')}
 
-      {colorPicker('secondary')}
+      {colorPicker('secondary', '#f50057')}
     </Stack>
   );
 }

--- a/packages/toolpad-app/src/components/MuiThemeEditor.tsx
+++ b/packages/toolpad-app/src/components/MuiThemeEditor.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import {
+  PaletteColor,
+  PaletteMode,
+  Stack,
+  styled,
+  ThemeOptions,
+  ToggleButton,
+  ToggleButtonGroup,
+  useTheme,
+} from '@mui/material';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import { WithControlledProp } from '../utils/types';
+import ColorTool from './ColorTool';
+
+const IconToggleButton = styled(ToggleButton)({
+  display: 'flex',
+  justifyContent: 'center',
+  width: '100%',
+  '& > *': {
+    marginRight: '8px',
+  },
+});
+
+interface PaletteColorPickerProps extends WithControlledProp<string> {
+  label: string;
+}
+
+function PaletteColorPicker({ label, value, onChange }: PaletteColorPickerProps) {
+  return <ColorTool label={label} value={value} onChange={onChange} />;
+}
+
+export interface MuiThemeEditorProps {
+  value: ThemeOptions | null;
+  onChange: (value: ThemeOptions) => void;
+}
+
+export default function MuiThemeEditor({ value, onChange }: MuiThemeEditorProps) {
+  const theme = useTheme();
+  return (
+    <Stack direction="column" spacing={2}>
+      <ToggleButtonGroup
+        exclusive
+        value={value?.palette?.mode}
+        onChange={(event, newMode: PaletteMode) => {
+          onChange({
+            ...value,
+            palette: {
+              ...value?.palette,
+              mode: newMode,
+            },
+          });
+        }}
+        aria-label="Mode"
+      >
+        <IconToggleButton value="light" aria-label="light">
+          <LightModeIcon />
+          Light
+        </IconToggleButton>
+        <IconToggleButton value="dark" aria-label="dark">
+          <DarkModeIcon />
+          Dark
+        </IconToggleButton>
+      </ToggleButtonGroup>
+
+      <PaletteColorPicker
+        label="Primary"
+        value={(value?.palette?.primary as PaletteColor)?.main || '#2196f3'}
+        onChange={(newMain) => {
+          onChange({
+            ...value,
+            palette: {
+              ...value?.palette,
+              primary: {
+                main: newMain,
+                contrastText: theme.palette.getContrastText(newMain),
+              },
+            },
+          });
+        }}
+      />
+
+      <PaletteColorPicker
+        label="Secondary"
+        value={(value?.palette?.primary as PaletteColor)?.main || '#f50057'}
+        onChange={(newMain) => {
+          onChange({
+            ...value,
+            palette: {
+              ...value?.palette,
+              secondary: {
+                main: newMain,
+                contrastText: theme.palette.getContrastText(newMain),
+              },
+            },
+          });
+        }}
+      />
+    </Stack>
+  );
+}

--- a/packages/toolpad-app/src/runtime/AppThemeProvider.tsx
+++ b/packages/toolpad-app/src/runtime/AppThemeProvider.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { createTheme, Theme, PaletteOptions, ThemeProvider } from '@mui/material';
-import * as colors from '@mui/material/colors';
+import { createTheme, Theme, ThemeProvider, ThemeOptions } from '@mui/material';
 import * as appDom from '../appDom';
-import { AppTheme } from '../types';
 
 declare module '@mui/material/styles' {
   interface Theme {
@@ -14,25 +12,8 @@ declare module '@mui/material/styles' {
   }
 }
 
-function createMuiThemeFromToolpadTheme(toolpadTheme: AppTheme = {}): Theme {
-  const palette: PaletteOptions = {};
-  const primary = toolpadTheme['palette.primary.main'];
-  if (primary) {
-    palette.primary = (colors as any)[primary];
-  }
-
-  const secondary = toolpadTheme['palette.secondary.main'];
-  if (secondary) {
-    palette.secondary = (colors as any)[secondary];
-  }
-
-  const mode = toolpadTheme['palette.mode'];
-  if (mode) {
-    palette.mode = mode;
-  }
-
-  return createTheme({
-    palette,
+function createMuiThemeFromToolpadTheme(toolpadTheme: ThemeOptions = {}): Theme {
+  return createTheme(toolpadTheme, {
     typography: {
       h1: {
         fontSize: `3.25rem`,
@@ -72,9 +53,7 @@ export function createToolpadAppTheme(dom: appDom.AppDom): Theme {
   const root = appDom.getApp(dom);
   const { themes = [] } = appDom.getChildNodes(dom, root);
   const themeNode = themes.length > 0 ? themes[0] : null;
-  const toolpadTheme: AppTheme = themeNode?.theme
-    ? appDom.fromConstPropValues(themeNode.theme)
-    : {};
+  const toolpadTheme = themeNode?.theme;
   return createMuiThemeFromToolpadTheme(toolpadTheme);
 }
 

--- a/packages/toolpad-app/src/runtime/AppThemeProvider.tsx
+++ b/packages/toolpad-app/src/runtime/AppThemeProvider.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { createTheme, Theme, ThemeProvider, ThemeOptions } from '@mui/material';
+import { deepmerge } from '@mui/utils';
 import * as appDom from '../appDom';
 
 declare module '@mui/material/styles' {
@@ -13,40 +14,45 @@ declare module '@mui/material/styles' {
 }
 
 function createMuiThemeFromToolpadTheme(toolpadTheme: ThemeOptions = {}): Theme {
-  return createTheme(toolpadTheme, {
-    typography: {
-      h1: {
-        fontSize: `3.25rem`,
-        fontWeight: 800,
-      },
+  return createTheme(
+    deepmerge(
+      {
+        typography: {
+          h1: {
+            fontSize: `3.25rem`,
+            fontWeight: 800,
+          },
 
-      h2: {
-        fontSize: `2.25rem`,
-        fontWeight: 700,
-      },
+          h2: {
+            fontSize: `2.25rem`,
+            fontWeight: 700,
+          },
 
-      h3: {
-        fontSize: `1.75rem`,
-        fontWeight: 700,
-      },
+          h3: {
+            fontSize: `1.75rem`,
+            fontWeight: 700,
+          },
 
-      h4: {
-        fontSize: `1.5rem`,
-        fontWeight: 700,
-      },
+          h4: {
+            fontSize: `1.5rem`,
+            fontWeight: 700,
+          },
 
-      h5: {
-        fontSize: `1.25rem`,
-        fontWeight: 700,
-      },
+          h5: {
+            fontSize: `1.25rem`,
+            fontWeight: 700,
+          },
 
-      h6: {
-        fontSize: `1.15rem`,
-        fontWeight: 700,
+          h6: {
+            fontSize: `1.15rem`,
+            fontWeight: 700,
+          },
+        },
+        fontFamilyMonospaced: 'Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace',
       },
-    },
-    fontFamilyMonospaced: 'Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace',
-  });
+      toolpadTheme,
+    ),
+  );
 }
 
 export function createToolpadAppTheme(dom: appDom.AppDom): Theme {

--- a/packages/toolpad-app/src/server/schema.ts
+++ b/packages/toolpad-app/src/server/schema.ts
@@ -294,14 +294,18 @@ const simplePaletteColorOptionsSchema: z.ZodType<SimplePaletteColorOptions> = z.
   contrastText: z.string().optional(),
 });
 
-const themeOptionsSchema: z.ZodType<ThemeOptions> = z.object({
-  // TODO: expand to full MUI theme object
-  palette: z.object({
-    mode: z.union([z.literal('light'), z.literal('dark')]).optional(),
-    primary: simplePaletteColorOptionsSchema,
-    secondary: simplePaletteColorOptionsSchema,
-  }),
-});
+const themeOptionsSchema: z.ZodType<ThemeOptions> = z
+  .object({
+    // TODO: expand to full MUI theme object
+    palette: z
+      .object({
+        mode: z.union([z.literal('light'), z.literal('dark')]).optional(),
+        primary: simplePaletteColorOptionsSchema,
+        secondary: simplePaletteColorOptionsSchema,
+      })
+      .passthrough(),
+  })
+  .passthrough();
 
 export type Page = z.infer<typeof pageSchema>;
 

--- a/packages/toolpad-app/src/server/schema.ts
+++ b/packages/toolpad-app/src/server/schema.ts
@@ -290,14 +290,8 @@ export type Page = z.infer<typeof pageSchema>;
 
 export const themeSchema = toolpadObjectSchema(
   'theme',
-  z.object({
-    'palette.mode': z
-      .union([z.literal('light'), z.literal('dark')])
-      .optional()
-      .describe('The MUI theme palette mode.'),
-    'palette.primary.main': z.string().optional().describe('The primary theme color.'),
-    'palette.secondary.main': z.string().optional().describe('The secondary theme color.'),
-  }),
+  // TODO: Validate MUI theme object
+  z.any(),
 );
 
 export type Theme = z.infer<typeof themeSchema>;

--- a/packages/toolpad-app/src/server/schema.ts
+++ b/packages/toolpad-app/src/server/schema.ts
@@ -290,8 +290,10 @@ export type Page = z.infer<typeof pageSchema>;
 
 export const themeSchema = toolpadObjectSchema(
   'theme',
-  // TODO: Validate MUI theme object
-  z.any(),
+  z.object({
+    // TODO: Validate MUI theme object
+    options: z.any(),
+  }),
 );
 
 export type Theme = z.infer<typeof themeSchema>;

--- a/packages/toolpad-app/src/server/schema.ts
+++ b/packages/toolpad-app/src/server/schema.ts
@@ -1,3 +1,5 @@
+import { SimplePaletteColorOptions, ThemeOptions } from '@mui/material';
+import { satisfies } from 'semver';
 import { z } from 'zod';
 
 export const API_VERSION = 'v1';
@@ -286,13 +288,28 @@ export const pageSchema = toolpadObjectSchema(
   }),
 );
 
+const colorSchema: z.ZodType<SimplePaletteColorOptions> = z.object({
+  main: z.string(),
+  light: z.string().optional(),
+  dark: z.string().optional(),
+  contrastText: z.string().optional(),
+});
+
+const themeOptionsSchema: z.ZodType<ThemeOptions> = z.object({
+  // TODO: expand to full MUI theme object
+  palette: z.object({
+    mode: z.union([z.literal('light'), z.literal('dark')]).optional(),
+    primary: colorSchema,
+    secondary: colorSchema,
+  }),
+});
+
 export type Page = z.infer<typeof pageSchema>;
 
 export const themeSchema = toolpadObjectSchema(
   'theme',
   z.object({
-    // TODO: Validate MUI theme object
-    options: z.any(),
+    options: themeOptionsSchema,
   }),
 );
 

--- a/packages/toolpad-app/src/server/schema.ts
+++ b/packages/toolpad-app/src/server/schema.ts
@@ -1,5 +1,4 @@
 import { SimplePaletteColorOptions, ThemeOptions } from '@mui/material';
-import { satisfies } from 'semver';
 import { z } from 'zod';
 
 export const API_VERSION = 'v1';

--- a/packages/toolpad-app/src/server/schema.ts
+++ b/packages/toolpad-app/src/server/schema.ts
@@ -308,7 +308,9 @@ export type Page = z.infer<typeof pageSchema>;
 export const themeSchema = toolpadObjectSchema(
   'theme',
   z.object({
-    options: themeOptionsSchema,
+    options: themeOptionsSchema
+      .optional()
+      .describe("The ThemeOptions object that gets fed into MUI's createTheme function."),
   }),
 );
 

--- a/packages/toolpad-app/src/server/schema.ts
+++ b/packages/toolpad-app/src/server/schema.ts
@@ -287,7 +287,7 @@ export const pageSchema = toolpadObjectSchema(
   }),
 );
 
-const colorSchema: z.ZodType<SimplePaletteColorOptions> = z.object({
+const simplePaletteColorOptionsSchema: z.ZodType<SimplePaletteColorOptions> = z.object({
   main: z.string(),
   light: z.string().optional(),
   dark: z.string().optional(),
@@ -298,8 +298,8 @@ const themeOptionsSchema: z.ZodType<ThemeOptions> = z.object({
   // TODO: expand to full MUI theme object
   palette: z.object({
     mode: z.union([z.literal('light'), z.literal('dark')]).optional(),
-    primary: colorSchema,
-    secondary: colorSchema,
+    primary: simplePaletteColorOptionsSchema,
+    secondary: simplePaletteColorOptionsSchema,
   }),
 });
 
@@ -331,5 +331,6 @@ export const META = {
     Template: templateSchema,
     NameStringValuePair: nameStringValuePairSchema,
     BindableNameStringValue: bindableNameStringValueSchema,
+    SimplePaletteColorOptions: simplePaletteColorOptionsSchema,
   },
 };

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ThemeEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ThemeEditor.tsx
@@ -1,68 +1,8 @@
 import * as React from 'react';
-import {
-  MenuItem,
-  Stack,
-  Button,
-  ToggleButtonGroup,
-  ToggleButton,
-  styled,
-  TextField,
-} from '@mui/material';
-import LightModeIcon from '@mui/icons-material/LightMode';
-import DarkModeIcon from '@mui/icons-material/DarkMode';
+import { Button } from '@mui/material';
 import * as appDom from '../../../appDom';
-import { WithControlledProp } from '../../../utils/types';
 import { useDom, useDomApi } from '../../AppState';
-
-const IconToggleButton = styled(ToggleButton)({
-  display: 'flex',
-  justifyContent: 'center',
-  width: '100%',
-  '& > *': {
-    marginRight: '8px',
-  },
-});
-
-const THEME_COLORS = [
-  'red',
-  'pink',
-  'purple',
-  'deepPurple',
-  'indigo',
-  'blue',
-  'lightBlue',
-  'cyan',
-  'teal',
-  'green',
-  'lightGreen',
-  'lime',
-  'yellow',
-  'amber',
-  'orange',
-  'deepOrange',
-];
-
-interface PaletteColorPickerProps extends WithControlledProp<string> {
-  name: string;
-}
-
-function PaletteColorPicker({ name, value, onChange }: PaletteColorPickerProps) {
-  return (
-    <TextField
-      select
-      fullWidth
-      value={value}
-      label={name}
-      onChange={(event) => onChange(event.target.value)}
-    >
-      {THEME_COLORS.map((color) => (
-        <MenuItem key={color} value={color}>
-          {color}
-        </MenuItem>
-      ))}
-    </TextField>
-  );
-}
+import MuiThemeEditor from '../../../components/MuiThemeEditor';
 
 export interface ComponentEditorProps {
   className?: string;
@@ -88,57 +28,15 @@ export default function ComponentEditor({ className }: ComponentEditorProps) {
   return (
     <div className={className} data-testid="theme-editor">
       {theme ? (
-        <Stack spacing={2}>
-          <ToggleButtonGroup
-            exclusive
-            value={appDom.fromConstPropValue(theme.theme?.['palette.mode']) || 'light'}
-            onChange={(event, newValue) => {
-              domApi.update((draft) =>
-                appDom.setNodeNamespacedProp(draft, theme, 'theme', 'palette.mode', newValue),
-              );
-            }}
-            aria-label="Mode"
-          >
-            <IconToggleButton value="light" aria-label="light">
-              <LightModeIcon />
-              Light
-            </IconToggleButton>
-            <IconToggleButton value="dark" aria-label="dark">
-              <DarkModeIcon />
-              Dark
-            </IconToggleButton>
-          </ToggleButtonGroup>
-          <PaletteColorPicker
-            name="primary"
-            value={appDom.fromConstPropValue(theme.theme?.['palette.primary.main']) || ''}
-            onChange={(newValue) => {
-              domApi.update((draft) =>
-                appDom.setNodeNamespacedProp(
-                  draft,
-                  theme,
-                  'theme',
-                  'palette.primary.main',
-                  newValue,
-                ),
-              );
-            }}
-          />
-          <PaletteColorPicker
-            name="secondary"
-            value={appDom.fromConstPropValue(theme.theme?.['palette.secondary.main']) || ''}
-            onChange={(newValue) => {
-              domApi.update((draft) =>
-                appDom.setNodeNamespacedProp(
-                  draft,
-                  theme,
-                  'theme',
-                  'palette.secondary.main',
-                  newValue,
-                ),
-              );
-            }}
-          />
-        </Stack>
+        <MuiThemeEditor
+          value={theme.theme || {}}
+          onChange={(newTheme) => {
+            domApi.update((draft) => {
+              draft = appDom.setNodeProp(draft, theme, 'theme', newTheme);
+              return draft;
+            });
+          }}
+        />
       ) : (
         <Button onClick={handleAddThemeClick}>Add theme</Button>
       )}


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/1446
Closes https://github.com/mui/mui-toolpad/issues/1995

Lay the basis for an improved theme editor. This one works as a controlled component for `ThemeOptions`, I ~stole~ [borrowed](https://mui.com/material-ui/customization/color/#playground) some code from the core docs.

Relying on the MUI core theme options shape makes it easier to build this editor as we won't have to come up with new file schema definitions. All we have to do is expand this generic component that controls the standard `ThemeOptions` object



https://github.com/mui/mui-toolpad/assets/2109932/e1fe3989-30b2-420e-9c8b-e0bd3285e24d


It now also allows setting arbitrary colors and correctly stores the theme in the project folder
