### PR TITLE
Provide all exports of @mui/toolpad on @mui/toolpad-app

### DIFF
--- a/packages/toolpad-app/browser/package.json
+++ b/packages/toolpad-app/browser/package.json
@@ -1,0 +1,5 @@
+{
+  "type": "commonjs",
+  "main": "../dist/exports/browser.js",
+  "types": "../dist/exports/browser.d.ts"
+}

--- a/packages/toolpad-app/canvas/package.json
+++ b/packages/toolpad-app/canvas/package.json
@@ -1,5 +1,5 @@
 {
   "type": "commonjs",
-  "main": "../dist/runtime/canvas.js",
-  "types": "../dist/runtime/canvas.d.ts"
+  "main": "../dist/exports/canvas.js",
+  "types": "../dist/exports/canvas.d.ts"
 }

--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -31,15 +31,10 @@
     "./cli": {
       "require": "./dist/cli/index.js"
     },
-    "./runtime": {
-      "types": "./dist/runtime/index.d.ts",
-      "import": "./dist/runtime/index.mjs",
-      "require": "./dist/runtime/index.js"
-    },
-    "./canvas": {
-      "types": "./dist/runtime/canvas.d.ts",
-      "import": "./dist/runtime/canvas.mjs",
-      "require": "./dist/runtime/canvas.js"
+    "./*": {
+      "types": "./dist/exports/*.d.ts",
+      "import": "./dist/exports/*.mjs",
+      "require": "./dist/exports/*.js"
     }
   },
   "dependencies": {

--- a/packages/toolpad-app/runtime/package.json
+++ b/packages/toolpad-app/runtime/package.json
@@ -1,5 +1,5 @@
 {
   "type": "commonjs",
-  "main": "../dist/runtime/index.js",
-  "types": "../dist/runtime/index.d.ts"
+  "main": "../dist/exports/runtime.js",
+  "types": "../dist/exports/runtime.d.ts"
 }

--- a/packages/toolpad-app/server/package.json
+++ b/packages/toolpad-app/server/package.json
@@ -1,5 +1,5 @@
 {
   "type": "commonjs",
-  "main": "../dist/server.cjs",
-  "types": "../dist/server.d.ts"
+  "main": "../dist/exports/server.cjs",
+  "types": "../dist/exports/server.d.ts"
 }

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import invariant from 'invariant';
 import { throttle } from 'lodash-es';
 import { CanvasEventsContext } from '@mui/toolpad-core/runtime';
-import ToolpadApp, { LoadComponents, queryClient } from '../runtime';
+import ToolpadApp, { LoadComponents, queryClient } from '../runtime/ToolpadApp';
 import { AppCanvasState } from '../types';
 import getPageViewState from './getPageViewState';
 import { rectContainsPoint } from '../utils/geometry';

--- a/packages/toolpad-app/src/exports/browser.ts
+++ b/packages/toolpad-app/src/exports/browser.ts
@@ -1,0 +1,1 @@
+export * from '@mui/toolpad-core/browser';

--- a/packages/toolpad-app/src/exports/canvas.ts
+++ b/packages/toolpad-app/src/exports/canvas.ts
@@ -1,0 +1,2 @@
+export * from '../canvas';
+export { default } from '../canvas';

--- a/packages/toolpad-app/src/exports/runtime.ts
+++ b/packages/toolpad-app/src/exports/runtime.ts
@@ -1,0 +1,1 @@
+export * from '../runtime';

--- a/packages/toolpad-app/src/exports/server.ts
+++ b/packages/toolpad-app/src/exports/server.ts
@@ -1,0 +1,1 @@
+export * from '@mui/toolpad-core/server';

--- a/packages/toolpad-app/src/runtime/index.ts
+++ b/packages/toolpad-app/src/runtime/index.ts
@@ -1,2 +1,0 @@
-export { default } from './ToolpadApp';
-export * from './ToolpadApp';

--- a/packages/toolpad-app/src/runtime/index.tsx
+++ b/packages/toolpad-app/src/runtime/index.tsx
@@ -5,7 +5,7 @@ import { ToolpadComponents } from '@mui/toolpad-core';
 import { Emitter } from '@mui/toolpad-utils/events';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
-import RuntimeToolpadApp, { ToolpadAppProps } from './index';
+import RuntimeToolpadApp, { ToolpadAppProps } from './ToolpadApp';
 import { RuntimeState } from '../types';
 
 let componentsStore: ToolpadComponents = {};

--- a/packages/toolpad-app/tsup.config.ts
+++ b/packages/toolpad-app/tsup.config.ts
@@ -62,14 +62,11 @@ export default defineConfig([
     },
   },
   {
-    entry: {
-      index: './src/runtime/entrypoint.tsx',
-      canvas: './src/canvas/index.tsx',
-    },
+    entry: ['src/exports/*.ts', 'src/exports/*.tsx'],
     format: ['esm', 'cjs'],
     dts: true,
     silent: true,
-    outDir: 'dist/runtime',
+    outDir: 'dist/exports',
     tsconfig: './tsconfig.runtime.json',
     sourcemap: true,
     esbuildPlugins: [cleanFolderOnFailure(path.resolve(__dirname, 'dist/runtime'))],


### PR DESCRIPTION
In preparation of removing `@mui/toolpad` and renaming `@mui/toolpad-app` to `@mui/toolpad`.
At the moment `@mui/toolpad` app is nothing more than a wrapper for exports of other packages, we don't need it around anymore
