### PR TITLE
Add extra note about aspect ratio of screenshots

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,9 +23,11 @@ on how to get started contributing to MUI.
 
 Some ground rules to ensure and maintain consistency in our documentation screenshots:
 
-- screenshots of the full browser viewport will always be at 1440x796 DPR:2
+- Screenshots of the full browser viewport will always be at 1440x796 DPR:2
   You can check your size with https://whatismyviewport.com/. If all is well it should look like:
 
   ![whatismyviewport](./public/static/toolpad/docs/whatismyviewport.png)
+
+  _Note: This rule is not just about a consistent aspect ratio, it's also about maintaining consistent size between UI elements across screenshots. e.g. we want to aim at text always having the same size relative to the screenshot dimensions, or have the sidebar width relative to the screenshot width be the same everywhere._
 
 - In order to maintain consistency across all screenshots we will use the same theme for editor and canvas when taking screenshots. As the default dark theme doesn't look that great in combination with the editor theme, we will use the light theme for all screenshots.


### PR DESCRIPTION
Maybe we should just mandate viewport width instead of width/height?