### PR TITLE
[website] use `theme.applyDarkStyles` on marketing website

### DIFF
--- a/docs/src/components/landing/CardGrid.js
+++ b/docs/src/components/landing/CardGrid.js
@@ -40,15 +40,19 @@ export default function CardGrid(props) {
     <Box
       sx={
         darker
-          ? {
-              background: (theme) =>
-                theme.palette.mode === 'dark'
-                  ? `radial-gradient(200% 150% at 50% 20%, transparent 30%, ${theme.palette.primaryDark[300]} 100%, ${theme.palette.primaryDark[100]} 0)`
-                  : `linear-gradient(180deg, ${theme.palette.grey[50]} 0%, ${alpha(
-                      theme.palette.grey[100],
-                      0.4,
-                    )} 100%)`,
-            }
+          ? [
+              {
+                background: (theme) =>
+                  `linear-gradient(180deg, ${theme.palette.grey[50]} 0%, ${alpha(
+                    theme.palette.grey[100],
+                    0.4,
+                  )} 100%)`,
+              },
+              (theme) =>
+                theme.applyDarkStyles({
+                  background: `radial-gradient(200% 150% at 50% 20%, transparent 30%, ${theme.palette.primaryDark[300]} 100%, ${theme.palette.primaryDark[100]} 0)`,
+                }),
+            ]
           : null
       }
     >

--- a/docs/src/components/landing/DemoVideo.js
+++ b/docs/src/components/landing/DemoVideo.js
@@ -3,52 +3,52 @@ import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import { styled, alpha } from '@mui/material/styles';
 
-const Video = styled('video')(({ theme }) => ({
-  overflow: 'hidden',
-  objectFit: 'cover',
-  width: '100%',
-  height: '100%',
-  borderRadius: '5px',
-  border: '1px solid',
-  borderColor:
-    theme.palette.mode === 'dark'
-      ? `${theme.palette.primaryDark[700]}`
-      : `${theme.palette.primary[100]}`,
-}));
+const Video = styled('video')(({ theme }) => [
+  {
+    overflow: 'hidden',
+    objectFit: 'cover',
+    width: '100%',
+    height: '100%',
+    borderRadius: '5px',
+    border: '1px solid',
+    borderColor: theme.palette.primary[100],
+  },
+  theme.applyDarkStyles({
+    borderColor: theme.palette.primaryDark[700],
+  }),
+]);
 
 const VIDEO_BREAKPOINT_GAP = 100;
 
-const VideoContainer = styled(Box)(({ theme }) => ({
-  maxWidth: 1100,
-  height: '100%',
-  width: {
-    xs: 360,
-    sm: theme.breakpoints.values.sm - VIDEO_BREAKPOINT_GAP,
-    md: theme.breakpoints.values.md + VIDEO_BREAKPOINT_GAP,
-    lg: theme.breakpoints.values.lg + VIDEO_BREAKPOINT_GAP,
+const VideoContainer = styled(Box)(({ theme }) => [
+  {
+    maxWidth: 1100,
+    height: '100%',
+    width: {
+      xs: 360,
+      sm: theme.breakpoints.values.sm - VIDEO_BREAKPOINT_GAP,
+      md: theme.breakpoints.values.md + VIDEO_BREAKPOINT_GAP,
+      lg: theme.breakpoints.values.lg + VIDEO_BREAKPOINT_GAP,
+    },
+    borderRadius: theme.shape.borderRadius,
+    padding: 16,
+    background: `linear-gradient(230deg, ${theme.palette.primary[50]} 0%, ${alpha(
+      theme.palette.primary[100],
+      0.4,
+    )} 150%)`,
+    border: '1px solid',
+    borderColor: `${alpha(theme.palette.primary[200], 0.5)}`,
+    boxShadow: `4px 0 60px ${alpha(theme.palette.primary[100], 0.8)}`,
   },
-  borderRadius: theme.shape.borderRadius,
-  padding: 16,
-  background:
-    theme.palette.mode === 'dark'
-      ? `linear-gradient(230deg, ${theme.palette.primaryDark[600]} 0%, ${alpha(
-          theme.palette.primaryDark[700],
-          0.4,
-        )} 150%)`
-      : `linear-gradient(230deg, ${theme.palette.primary[50]} 0%, ${alpha(
-          theme.palette.primary[100],
-          0.4,
-        )} 150%)`,
-  border: '1px solid',
-  borderColor:
-    theme.palette.mode === 'dark'
-      ? `${alpha(theme.palette.primaryDark[300], 0.5)}`
-      : `${alpha(theme.palette.primary[200], 0.5)}`,
-  boxShadow:
-    theme.palette.mode === 'dark'
-      ? `4px 0 60px ${alpha(theme.palette.primary[300], 0.5)}`
-      : `4px 0 60px ${alpha(theme.palette.primary[100], 0.8)}`,
-}));
+  theme.applyDarkStyles({
+    background: `linear-gradient(230deg, ${theme.palette.primaryDark[600]} 0%, ${alpha(
+      theme.palette.primaryDark[700],
+      0.4,
+    )} 150%)`,
+    borderColor: `${alpha(theme.palette.primaryDark[300], 0.5)}`,
+    boxShadow: `4px 0 60px ${alpha(theme.palette.primaryDark[300], 0.5)}`,
+  }),
+]);
 
 export default function DemoVideo() {
   return (

--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -22,12 +22,15 @@ export default function Hero() {
         <Typography
           fontWeight="bold"
           variant="body2"
-          color={(theme) => (theme.palette.mode === 'dark' ? 'primary.400' : 'primary.600')}
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: { xs: 'center', md: 'center' },
-          }}
+          sx={[
+            {
+              display: 'flex',
+              alignItems: 'center',
+              color: 'primary.600',
+              justifyContent: { xs: 'center', md: 'center' },
+            },
+            (theme) => theme.applyDarkStyles({ color: 'primary.400' }),
+          ]}
         >
           <IconImage name="product-toolpad" width="28" height="28" sx={{ mr: 1 }} />
           <Box component="span" sx={{ mr: 1 }}>

--- a/docs/src/components/landing/Marquee.js
+++ b/docs/src/components/landing/Marquee.js
@@ -16,7 +16,6 @@ function Marquee({ content }) {
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          // background: `linear-gradient(180deg, ${theme.palette.primaryDark[900]} 0%, ${theme.palette.primaryDark[800]})`,
           background: `radial-gradient(140% 150% at 50% 10%, transparent 20%,  ${theme.palette.primary[100]} 90%,  transparent 100%)`,
           borderBottom: '1px solid',
           borderColor: 'grey.200',
@@ -40,13 +39,16 @@ function Marquee({ content }) {
         {content.title}
       </Typography>
       <Typography
-        color="grey.500"
         textAlign="center"
-        sx={{
-          mt: 1,
-          mb: 4,
-          mx: 'auto',
-        }}
+        sx={[
+          {
+            mt: 1,
+            mb: 4,
+            mx: 'auto',
+            color: 'grey.600',
+          },
+          (theme) => theme.applyDarkStyles({ color: 'grey.500' }),
+        ]}
       >
         {content.subtitle}
       </Typography>

--- a/docs/src/components/landing/Marquee.js
+++ b/docs/src/components/landing/Marquee.js
@@ -7,26 +7,34 @@ import SignUp from './SignUp';
 function Marquee({ content }) {
   return (
     <Container
-      sx={(theme) => ({
-        mt: 8,
-        mx: 0,
-        minWidth: '100%',
-        py: { xs: 4, sm: 6, md: 12 },
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        background: `linear-gradient(180deg, ${theme.palette.primaryDark[900]} 0%, ${theme.palette.primaryDark[800]})`,
-        borderBottom: '1px solid',
-        borderColor: theme.palette.mode === 'dark' ? 'primaryDark.600' : 'grey.200',
-      })}
+      sx={[
+        (theme) => ({
+          mt: 4,
+          mx: 0,
+          minWidth: '100%',
+          py: { xs: 4, sm: 6, md: 12 },
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          // background: `linear-gradient(180deg, ${theme.palette.primaryDark[900]} 0%, ${theme.palette.primaryDark[800]})`,
+          background: `radial-gradient(140% 150% at 50% 10%, transparent 20%,  ${theme.palette.primary[100]} 90%,  transparent 100%)`,
+          borderBottom: '1px solid',
+          borderColor: 'grey.200',
+        }),
+        (theme) =>
+          theme.applyDarkStyles({
+            borderColor: 'primaryDark.600',
+            background: `linear-gradient(180deg, ${theme.palette.primaryDark[900]} 0%, ${theme.palette.primaryDark[800]})`,
+          }),
+      ]}
     >
       <Typography
-        color="white"
         textAlign="center"
         variant="h2"
         sx={{
           mt: 4,
           mx: 'auto',
+          color: (theme) => theme.palette.primary[800],
         }}
       >
         {content.title}
@@ -45,8 +53,10 @@ function Marquee({ content }) {
       <Typography
         component="label"
         variant="body2"
-        color={(theme) => (theme.palette.mode === 'dark' ? '#fff' : `text.secondary`)}
-        sx={{ fontWeight: 'medium', display: 'block', mb: 1, mx: 'auto' }}
+        sx={[
+          { fontWeight: 'medium', display: 'block', mb: 1, mx: 'auto', color: `text.secondary` },
+          (theme) => theme.applyDarkStyles({ color: '#fff' }),
+        ]}
         htmlFor="email-landing"
       >
         {content.action.label}

--- a/docs/src/components/landing/PricingTable.js
+++ b/docs/src/components/landing/PricingTable.js
@@ -58,30 +58,36 @@ PlanName.propTypes = {
   }),
 };
 
-function Cell({ highlighted = false, ...props }) {
+function Cell({ highlighted = false, sx, ...props }) {
   return (
     <Box
       {...props}
-      sx={{
-        py: 2,
-        px: 2,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        ...(highlighted && {
-          // Remove borders since there are only two plans
-          // https://github.com/mui/mui-toolpad/pull/809#issuecomment-1221026428
-          borderWidth: '0 1px 0 1px',
-          borderStyle: 'solid',
-          borderColor: (theme) => (theme.palette.mode === 'dark' ? 'primaryDark.700' : 'grey.100'),
-          bgcolor: (theme) =>
-            theme.palette.mode === 'dark'
-              ? alpha(theme.palette.primaryDark[900], 0.5)
-              : alpha(theme.palette.grey[50], 0.5),
+      sx={[
+        (theme) => ({
+          py: 2,
+          px: 2,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          ...(highlighted && {
+            // Remove borders since there are only two plans
+            // https://github.com/mui/mui-toolpad/pull/809#issuecomment-1221026428
+            borderWidth: '0 1px 0 1px',
+            borderStyle: 'solid',
+            borderColor: 'grey.100',
+            bgcolor: alpha(theme.palette.grey[50], 0.5),
+          }),
         }),
-        ...props.sx,
-      }}
+        (theme) =>
+          theme.applyDarkStyles({
+            ...(highlighted && {
+              borderColor: 'primaryDark.700',
+              bgcolor: alpha(theme.palette.primaryDark[900], 0.5),
+            }),
+          }),
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
     />
   );
 }
@@ -95,20 +101,27 @@ function RowHead({ children, startIcon, ...props }) {
   return (
     <Box
       {...props}
-      sx={{
-        justifyContent: 'flex-start',
-        borderRadius: '8px 0 0 8px',
-        bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'primaryDark.900' : 'grey.50'),
-        border: '1px solid',
-        borderColor: (theme) => (theme.palette.mode === 'dark' ? 'primaryDark.700' : 'grey.100'),
-        p: 1,
-        transition: 'none',
-        typography: 'body2',
-        fontWeight: 700,
-        display: 'flex',
-        alignItems: 'center',
-        ...props.sx,
-      }}
+      sx={[
+        {
+          justifyContent: 'flex-start',
+          borderRadius: '8px 0 0 8px',
+          bgcolor: 'grey.50',
+          border: '1px solid',
+          borderColor: 'grey.100',
+          p: 1,
+          transition: 'none',
+          typography: 'body2',
+          fontWeight: 700,
+          display: 'flex',
+          alignItems: 'center',
+          ...props.sx,
+        },
+        (theme) =>
+          theme.applyDarkStyles({
+            bgcolor: 'primaryDark.900',
+            borderColor: 'primaryDark.700',
+          }),
+      ]}
     >
       {startIcon ? <Box sx={{ lineHeight: 0, mr: 1 }}>{startIcon}</Box> : null}
       {children}
@@ -126,18 +139,25 @@ function RowCategory(props) {
   return (
     <Box
       {...props}
-      sx={{
-        typography: 'caption',
-        display: 'block',
-        fontWeight: 500,
-        bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'primaryDark.900' : 'grey.50'),
-        py: 1,
-        ml: 1,
-        pl: 1.5,
-        borderBottom: '1px solid',
-        borderColor: (theme) => (theme.palette.mode === 'dark' ? 'primaryDark.600' : 'grey.200'),
+      sx={[
+        {
+          typography: 'caption',
+          display: 'block',
+          fontWeight: 500,
+          bgcolor: 'grey.50',
+          py: 1,
+          ml: 1,
+          pl: 1.5,
+          borderBottom: '1px solid',
+          borderColor: 'grey.200',
+        },
+        (theme) =>
+          theme.applyDarkStyles({
+            bgcolor: 'primaryDark.900',
+            borderColor: 'primaryDark.600',
+          }),
         ...props.sx,
-      }}
+      ]}
     />
   );
 }
@@ -175,29 +195,30 @@ function StickyHead({ plans, planInfo, container, disableCalculation = false }) 
   }, [container, disableCalculation]);
   return (
     <Box
-      sx={{
-        position: 'fixed',
-        zIndex: 1,
-        top: 56,
-        left: 0,
-        right: 0,
-        transition: '0.3s',
-        ...(hidden && {
-          opacity: 0,
-          top: 0,
-        }),
-        py: 1,
-        display: { xs: 'none', md: 'block' },
-        backdropFilter: 'blur(20px)',
-        boxShadow: (theme) =>
-          `inset 0px -1px 1px ${
-            theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.grey[100]
-          }`,
-        backgroundColor: (theme) =>
-          theme.palette.mode === 'dark'
-            ? alpha(theme.palette.primaryDark[900], 0.72)
-            : 'rgba(255,255,255,0.72)',
-      }}
+      sx={[
+        {
+          position: 'fixed',
+          zIndex: 1,
+          top: 56,
+          left: 0,
+          right: 0,
+          transition: '0.3s',
+          ...(hidden && {
+            opacity: 0,
+            top: 0,
+          }),
+          py: 1,
+          display: { xs: 'none', md: 'block' },
+          backdropFilter: 'blur(20px)',
+          boxShadow: (theme) => `inset 0px -1px 1px ${theme.palette.grey[100]}`,
+          backgroundColor: `rgba(255,255,255,0.72)`,
+        },
+        (theme) =>
+          theme.applyDarkStyles({
+            backgroundColor: alpha(theme.palette.primaryDark[900], 0.72),
+            boxShadow: `inset 0px -1px 1px ${theme.palette.primaryDark[700]}`,
+          }),
+      ]}
     >
       <Container
         sx={{
@@ -251,18 +272,23 @@ function PricingTable({
   function renderRow(key) {
     return (
       <Box
-        sx={{
-          ...gridSx,
-          '&:hover': {
-            bgcolor: (theme) =>
-              theme.palette.mode === 'dark'
-                ? alpha(theme.palette.primaryDark[900], 0.3)
-                : alpha(theme.palette.grey[50], 0.4),
-            '@media (hover: none)': {
-              bgcolor: 'initial',
+        sx={[
+          {
+            ...gridSx,
+            '&:hover': {
+              bgcolor: (theme) => alpha(theme.palette.grey[50], 0.4),
+              '@media (hover: none)': {
+                bgcolor: 'initial',
+              },
             },
           },
-        }}
+          (theme) =>
+            theme.applyDarkStyles({
+              '&:hover': {
+                bgcolor: alpha(theme.palette.primaryDark[900], 0.3),
+              },
+            }),
+        ]}
       >
         {rowHeaders[key]}
         {plans.map((id, index) => (
@@ -297,22 +323,25 @@ function PricingTable({
           {plans.map((plan) => (
             <Box
               key={plan}
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                p: 2,
-                borderRadius: '12px 12px 0 0',
-                ...(planInfo.commercial?.title?.toLowerCase() === plan && {
-                  borderWidth: '1px 1px 0 1px',
-                  borderStyle: 'solid',
-                  borderColor: (theme) =>
-                    theme.palette.mode === 'dark' ? 'primaryDark.700' : 'grey.100',
-                  bgcolor: (theme) =>
-                    theme.palette.mode === 'dark'
-                      ? alpha(theme.palette.primaryDark[900], 0.5)
-                      : alpha(theme.palette.grey[50], 0.5),
-                }),
-              }}
+              sx={[
+                {
+                  display: 'flex',
+                  flexDirection: 'column',
+                  p: 2,
+                  borderRadius: '12px 12px 0 0',
+                  ...(planInfo.commercial?.title?.toLowerCase() === plan && {
+                    borderWidth: '1px 1px 0 1px',
+                    borderStyle: 'solid',
+                    borderColor: 'grey.100',
+                    bgcolor: (theme) => alpha(theme.palette.grey[50], 0.5),
+                  }),
+                },
+                (theme) =>
+                  theme.applyDarkStyles({
+                    borderColor: 'primaryDark.700',
+                    bgcolor: alpha(theme.palette.primaryDark[900], 0.5),
+                  }),
+              ]}
             >
               <PlanName planInfo={planInfo[plan]} />
             </Box>
@@ -404,23 +433,33 @@ function PricingList({ plans, planInfo, rowHeaders, commercialData, communityDat
         value={selectedIndex}
         variant="fullWidth"
         onChange={(_event, value) => setSelectedPlan(plans[value])}
-        sx={{
-          mb: 2,
-          position: 'sticky',
-          top: 55,
-          bgcolor: 'background.paper',
-          zIndex: 1,
-          mx: { xs: -2, sm: -3 },
-          borderTop: '1px solid',
-          borderColor: 'divider',
-          '& .MuiTab-root': {
-            borderBottom: '1px solid',
+        sx={[
+          {
+            mb: 2,
+            position: 'sticky',
+            top: 55,
+            bgcolor: 'background.paper',
+            zIndex: 1,
+            mx: { xs: -2, sm: -3 },
+            borderTop: '1px solid',
             borderColor: 'divider',
-            '&.Mui-selected': {
-              bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'primaryDark.700' : 'grey.50'),
+            '& .MuiTab-root': {
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+              '&.Mui-selected': {
+                bgcolor: 'grey.50',
+              },
             },
           },
-        }}
+          (theme) =>
+            theme.applyDarkStyles({
+              '& .MuiTab-root': {
+                '&.Mui-selected': {
+                  bgcolor: 'primaryDark.700',
+                },
+              },
+            }),
+        ]}
       >
         {plans.map((plan, index) => (
           <Tab

--- a/docs/src/components/landing/SignUp.js
+++ b/docs/src/components/landing/SignUp.js
@@ -49,18 +49,27 @@ function SignUp({ sx }) {
     return (
       <Alert
         severity="success"
-        sx={{
-          maxWidth: { sm: 540 },
-          mx: { xs: 0, sm: 'auto' },
-          bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'primaryDark.700' : 'success.50'),
-        }}
+        sx={[
+          {
+            maxWidth: { sm: 540 },
+            mx: { xs: 0, sm: 'auto' },
+            bgcolor: 'success.50',
+          },
+          (theme) =>
+            theme.applyDarkStyles({
+              bgcolor: 'primaryDark.700',
+            }),
+        ]}
         iconMapping={{
           success: (
             <CheckCircleRoundedIcon
               fontSize="small"
-              sx={{
-                color: (theme) => (theme.palette.mode === 'dark' ? 'success.600' : 'success.700'),
-              }}
+              sx={[
+                {
+                  color: 'success.700',
+                },
+                (theme) => theme.applyDarkStyles({ color: 'success.600' }),
+              ]}
             />
           ),
         }}
@@ -92,45 +101,46 @@ function SignUp({ sx }) {
           inputProps={{ required: true }}
           value={form.email}
           onChange={(event) => setForm({ email: event.target.value, status: 'initial' })}
-          sx={{
-            mr: { xs: 0, sm: 1 },
-            mb: { xs: 1, sm: 0 },
-            minWidth: { xs: 220, sm: 360 },
-            width: { xs: '100%', sm: 'auto' },
-            bgcolor: (theme) =>
-              theme.palette.mode === 'dark' ? theme.palette.primaryDark[900] : '#fff',
-            boxShadow: (theme) =>
-              theme.palette.mode === 'dark'
-                ? '0 1px 2px 0 rgba(0 0 0 / 1)'
-                : '0 2px 4px 0 rgba(0 0 0 / 0.08)',
-            borderRadius: 1,
-            border: '1px solid',
-            borderColor: (theme) =>
-              theme.palette.mode === 'dark' ? theme.palette.primaryDark[500] : 'grey.300',
-            px: 1,
-            py: 0.5,
-            // height: 48,
-            typography: 'body2',
-            '&:hover': {
-              borderColor: (theme) =>
-                theme.palette.mode === 'dark' ? theme.palette.primaryDark[300] : 'grey.400',
-              boxShadow: (theme) =>
-                theme.palette.mode === 'dark'
-                  ? '0 1px 2px 0 rgba(0 0 0 / 1)'
-                  : '0 1px 2px 0 rgba(0 0 0 / 0.2)',
+          sx={[
+            {
+              mr: { xs: 0, sm: 1 },
+              mb: { xs: 1, sm: 0 },
+              minWidth: { xs: 220, sm: 360 },
+              width: { xs: '100%', sm: 'auto' },
+              bgcolor: '#fff',
+              boxShadow: '0 1px 2px 0 rgba(0 0 0 / 0.08)',
+              borderRadius: 1,
+              border: '1px solid',
+              borderColor: 'grey.300',
+              px: 1,
+              py: 0.5,
+              // height: 48,
+              typography: 'body2',
+              '&:hover': {
+                borderColor: 'grey.400',
+                boxShadow: '0 1px 2px 0 rgba(0 0 0 / 0.2)',
+              },
+              [`&.${inputBaseClasses.focused}`]: {
+                borderColor: (theme) => theme.palette.primary[500],
+                outline: '3px solid',
+                outlineColor: (theme) => theme.palette.primary[100],
+              },
             },
-            [`&.${inputBaseClasses.focused}`]: {
-              borderColor: (theme) =>
-                theme.palette.mode === 'dark'
-                  ? theme.palette.primaryDark[300]
-                  : theme.palette.primary[500],
-              outline: '3px solid',
-              outlineColor: (theme) =>
-                theme.palette.mode === 'dark'
-                  ? theme.palette.primaryDark[500]
-                  : theme.palette.primary[100],
-            },
-          }}
+            (theme) =>
+              theme.applyDarkStyles({
+                bgcolor: theme.palette.primaryDark[900],
+                boxShadow: '0 1px 2px 0 rgba(0 0 0 / 1)',
+                borderColor: theme.palette.primaryDark[500],
+                '&:hover': {
+                  borderColor: theme.palette.primaryDark[300],
+                  boxShadow: '0 1px 2px 0 rgba(0 0 0 / 1)',
+                },
+                [`&.${inputBaseClasses.focused}`]: {
+                  borderColor: theme.palette.primary[300],
+                  outlineColor: theme.palette.primary[500],
+                },
+              }),
+          ]}
         />
         <Button
           disabled={form.status === 'loading'}
@@ -145,7 +155,10 @@ function SignUp({ sx }) {
       </Box>
       {form.status === 'failure' ? (
         <FormHelperText
-          sx={{ color: (theme) => (theme.palette.mode === 'dark' ? 'warning.500' : 'warning.800') }}
+          sx={[
+            { color: 'warning.700' },
+            (theme) => theme.applyDarkStyles({ color: 'warning.500' }),
+          ]}
         >
           Oops! something went wrong, please try again later.
         </FormHelperText>

--- a/docs/src/components/landing/SignUpToast.js
+++ b/docs/src/components/landing/SignUpToast.js
@@ -41,20 +41,23 @@ export default function NewsletterToast() {
         <Card
           variant="outlined"
           role="alert"
-          sx={{
-            p: 1,
-            position: 'absolute',
-            left: '50%',
-            transform: 'translate(-50%)',
-            opacity: hidden ? 0 : 1,
-            transition: '0.5s',
-            display: 'flex',
-            alignItems: 'center',
-            boxShadow: (theme) =>
-              theme.palette.mode === 'dark'
-                ? '0px 4px 20px rgba(0, 0, 0, 0.6)'
-                : '0px 4px 20px rgba(61, 71, 82, 0.25)',
-          }}
+          sx={[
+            {
+              p: 1,
+              position: 'absolute',
+              left: '50%',
+              transform: 'translate(-50%)',
+              opacity: hidden ? 0 : 1,
+              transition: '0.5s',
+              display: 'flex',
+              alignItems: 'center',
+              boxShadow: '0px 4px 20px rgba(61, 71, 82, 0.25)',
+            },
+            (theme) =>
+              theme.applyDarkStyles({
+                boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.6)',
+              }),
+          ]}
         >
           <MarkEmailReadTwoTone color="success" sx={{ mx: 0.5 }} />
           <div>

--- a/docs/src/components/landing/UseCases.js
+++ b/docs/src/components/landing/UseCases.js
@@ -8,32 +8,40 @@ import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
 import SectionHeadline from 'docs/src/components/typography/SectionHeadline';
 
-const cardMediaStyle = (imageUrl) => ({
-  display: 'block',
-  backgroundRepeat: 'no-repeat',
-  backgroundPosition: 'center',
-  objectFit: 'contain',
-  background: (theme) => `${theme.palette.primaryDark[800]} url(${imageUrl})`,
-  backgroundSize: 'cover',
-  borderRadius: '8px',
-  paddingTop: '55%',
-  overflow: 'auto',
-  boxShadow: (theme) =>
-    theme.palette.mode === 'dark'
-      ? `0 0 8px 2px ${theme.palette.primaryDark[600]}, 0 4px 40px ${theme.palette.primaryDark[500]}`
-      : `0 0 8px 2px ${theme.palette.primary[100]}, 0 4px 40px ${theme.palette.primary[100]}`,
-});
+const cardMediaStyle = (imageUrl) => [
+  {
+    display: 'block',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'center',
+    objectFit: 'contain',
+    background: (theme) => `${theme.palette.primaryDark[800]} url(${imageUrl})`,
+    backgroundSize: 'cover',
+    borderRadius: '8px',
+    paddingTop: '55%',
+    overflow: 'auto',
+    boxShadow: (theme) =>
+      `0 0 8px 2px ${theme.palette.primary[100]}, 0 4px 40px ${theme.palette.primary[100]}`,
+  },
+  (theme) =>
+    theme.applyDarkStyles({
+      boxShadow: `0 0 8px 2px ${theme.palette.primaryDark[600]}, 0 4px 40px ${theme.palette.primaryDark[500]}`,
+    }),
+];
 
 export default function CardGrid(props) {
   const { content } = props;
   return (
     <Box
-      sx={{
-        background: (theme) =>
-          theme.palette.mode === 'dark'
-            ? `radial-gradient(140% 150% at 50% 10%, transparent 40%,  ${theme.palette.primary[700]} 90%,  transparent 100%)`
-            : `radial-gradient(140% 150% at 50% 10%, transparent 50%,  ${theme.palette.primary[100]} 90%,  transparent 100%)`,
-      }}
+      sx={[
+        {
+          background: (theme) =>
+            `radial-gradient(140% 150% at 50% 10%, transparent 50%,  ${theme.palette.primary[100]} 90%,  transparent 100%)`,
+        },
+        (theme) =>
+          theme.applyDarkStyles({
+            background: `radial-gradient(140% 150% at 50% 10%, transparent 40%,  ${theme.palette.primary[700]} 90%,  transparent 100%)`,
+          }),
+      ]}
     >
       <Container sx={{ py: { xs: 8, sm: 12 } }}>
         <SectionHeadline overline={content.overline} title={content.Headline} />


### PR DESCRIPTION
- Closes #2261 

- For marketing pages, the components must not have conditional styles like this:
`bgcolor: theme => theme.palette.mode === 'dark' ? … : ...`
We should be using `theme.applyDarkStyles({…})` instead, which takes care of applying the styles in the right approach compatible with the page provider (either CssVarsProvider or ThemeProvider)


   <img width="1309" alt="Screenshot 2023-07-12 at 12 19 46 PM" src="https://github.com/mui/mui-toolpad/assets/19550456/c9b063b9-f4be-4305-9477-40ada043a84e">

- Also, adds a light theme to the "Marquee" section (missing in the current version):
   
   - Before:
   
      <img width="1510" alt="Screenshot 2023-07-12 at 12 23 00 PM" src="https://github.com/mui/mui-toolpad/assets/19550456/a9f5a8ae-f4e4-4313-8b9f-5fd1f0626a5d">

  - Now: 
  
    <img width="1462" alt="Screenshot 2023-07-12 at 12 25 13 PM" src="https://github.com/mui/mui-toolpad/assets/19550456/ac1e49df-1036-41a7-9af3-663d83a6fd10">

Preview: https://deploy-preview-2305--mui-toolpad-docs.netlify.app/toolpad/

- [x] I've read and followed the [contributing guide](https://github.com/mui/mui-toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [x] I've updated the relevant documentation for any new or updated feature
- [x] I've linked relevant GitHub issue with "Closes #<issue id>"
- [x] I've added a visual demonstration under the form of a screenshot or video
