### PR TITLE
Default vertical alignment to top instead of center

### DIFF
--- a/packages/toolpad-app/src/runtime/toolpadComponents/layoutBox.ts
+++ b/packages/toolpad-app/src/runtime/toolpadComponents/layoutBox.ts
@@ -21,7 +21,7 @@ export const layoutBoxArgTypes: {
     helperText: 'Vertical alignment of the component.',
     type: 'string',
     enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
-    default: 'center',
+    default: 'start',
     label: 'Vertical alignment',
     control: { type: 'VerticalAlign' },
   },

--- a/packages/toolpad-app/src/runtime/toolpadComponents/layoutBox.ts
+++ b/packages/toolpad-app/src/runtime/toolpadComponents/layoutBox.ts
@@ -15,7 +15,7 @@ export const layoutBoxArgTypes: {
     enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
     default: 'start',
     label: 'Horizontal alignment',
-    control: { type: 'HorizontalAlign' },
+    control: { type: 'HorizontalAlign', hideLabel: true },
   },
   verticalAlign: {
     helperText: 'Vertical alignment of the component.',
@@ -23,6 +23,6 @@ export const layoutBoxArgTypes: {
     enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
     default: 'start',
     label: 'Vertical alignment',
-    control: { type: 'VerticalAlign' },
+    control: { type: 'VerticalAlign', hideLabel: true },
   },
 };

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
@@ -148,18 +148,26 @@ function ComponentPropsEditor<P extends object>({
             Layout:
           </Typography>
 
-          <div className={classes.control}>
-            <NodeAttributeEditor
-              node={node}
-              namespace="layout"
-              name={hasLayoutHorizontalControls ? 'horizontalAlign' : 'verticalAlign'}
-              argType={
-                hasLayoutHorizontalControls
-                  ? layoutBoxArgTypes.horizontalAlign
-                  : layoutBoxArgTypes.verticalAlign
-              }
-            />
-          </div>
+          {hasLayoutHorizontalControls ? (
+            <div className={classes.control}>
+              <NodeAttributeEditor
+                node={node}
+                namespace="layout"
+                name="horizontalAlign"
+                argType={layoutBoxArgTypes.horizontalAlign}
+              />
+            </div>
+          ) : null}
+          {hasLayoutVerticalControls ? (
+            <div className={classes.control}>
+              <NodeAttributeEditor
+                node={node}
+                namespace="layout"
+                name="verticalAlign"
+                argType={layoutBoxArgTypes.verticalAlign}
+              />
+            </div>
+          ) : null}
 
           <Divider sx={{ mt: 1 }} />
         </React.Fragment>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
@@ -148,26 +148,28 @@ function ComponentPropsEditor<P extends object>({
             Layout:
           </Typography>
 
-          {hasLayoutHorizontalControls ? (
-            <div className={classes.control}>
-              <NodeAttributeEditor
-                node={node}
-                namespace="layout"
-                name="horizontalAlign"
-                argType={layoutBoxArgTypes.horizontalAlign}
-              />
-            </div>
-          ) : null}
-          {hasLayoutVerticalControls ? (
-            <div className={classes.control}>
-              <NodeAttributeEditor
-                node={node}
-                namespace="layout"
-                name="verticalAlign"
-                argType={layoutBoxArgTypes.verticalAlign}
-              />
-            </div>
-          ) : null}
+          <div className={classes.control}>
+            <Typography variant="body2">Alignment:</Typography>
+            <Stack direction="row">
+              {hasLayoutHorizontalControls ? (
+                <NodeAttributeEditor
+                  node={node}
+                  namespace="layout"
+                  name="horizontalAlign"
+                  argType={layoutBoxArgTypes.horizontalAlign}
+                  sx={{ maxWidth: 110 }}
+                />
+              ) : null}
+              {hasLayoutVerticalControls ? (
+                <NodeAttributeEditor
+                  node={node}
+                  namespace="layout"
+                  name="verticalAlign"
+                  argType={layoutBoxArgTypes.verticalAlign}
+                />
+              ) : null}
+            </Stack>
+          </div>
 
           <Divider sx={{ mt: 1 }} />
         </React.Fragment>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
@@ -6,7 +6,7 @@ import {
   RuntimeScope,
   ScopeMeta,
 } from '@mui/toolpad-core';
-import { Alert, Box } from '@mui/material';
+import { Alert, Box, SxProps } from '@mui/material';
 import { useBrowserJsRuntime } from '@mui/toolpad-core/jsBrowserRuntime';
 import * as appDom from '../../../appDom';
 import { useDomApi } from '../../AppState';
@@ -30,6 +30,7 @@ export interface NodeAttributeEditorProps<P extends object, K extends keyof P = 
   name: string;
   argType: ArgTypeDefinition<P, K>;
   props?: P;
+  sx?: SxProps;
 }
 
 export default function NodeAttributeEditor<P extends object>({
@@ -38,6 +39,7 @@ export default function NodeAttributeEditor<P extends object>({
   name,
   argType,
   props,
+  sx,
 }: NodeAttributeEditorProps<P>) {
   const domApi = useDomApi();
 
@@ -78,7 +80,7 @@ export default function NodeAttributeEditor<P extends object>({
       liveBinding={liveBinding}
       globalScope={bindingScope?.values ?? {}}
       globalScopeMeta={scopeMeta}
-      label={argType.label || name}
+      label={argType.control?.hideLabel ? '' : argType.label || name}
       bindable={isBindable}
       disabled={isDisabled}
       propType={argType}
@@ -90,6 +92,7 @@ export default function NodeAttributeEditor<P extends object>({
       )}
       value={propValue}
       onChange={handlePropChange}
+      sx={sx}
     />
   ) : (
     <Alert severity="warning">

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageSettingsEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageSettingsEditor.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import PageOptionsPanel from './PageOptionsPanel';
+
+export default function PageSettingsEditor() {
+  return <PageOptionsPanel />;
+}

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageSettingsEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageSettingsEditor.tsx
@@ -1,7 +1,0 @@
-import * as React from 'react';
-
-import PageOptionsPanel from './PageOptionsPanel';
-
-export default function PageSettingsEditor() {
-  return <PageOptionsPanel />;
-}

--- a/packages/toolpad-app/src/toolpad/propertyControls/HorizontalAlign.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/HorizontalAlign.tsx
@@ -25,7 +25,7 @@ function HorizontalAlignPropEditor({
   return (
     <PropertyControl propType={propType}>
       <Box>
-        <Typography variant="body2">{label}:</Typography>
+        {label ? <Typography variant="body2">{label}:</Typography> : null}
         <ToggleButtonGroup
           exclusive
           disabled={disabled}

--- a/packages/toolpad-app/src/toolpad/propertyControls/VerticalAlign.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/VerticalAlign.tsx
@@ -22,7 +22,7 @@ function VerticalAlignPropEditor({
   return (
     <PropertyControl propType={propType}>
       <Box>
-        <Typography variant="body2">{label}:</Typography>
+        {label ? <Typography variant="body2">{label}:</Typography> : null}
         <ToggleButtonGroup
           exclusive
           disabled={disabled}

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -200,6 +200,7 @@ export interface ArgControlSpec {
     | 'ColorScale'
     | 'RowIdFieldSelect'; // Row id field specialized select
   bindable?: boolean;
+  hideLabel?: boolean;
 }
 
 export type PrimitiveValueType =


### PR DESCRIPTION
Default vertical alignment of elements to top instead of center to address https://github.com/mui/mui-toolpad/issues/2281.
Closes https://github.com/mui/mui-toolpad/issues/2281.

Also restores having both vertical and horizontal alignment controls as in:
<img width="1622" alt="Screenshot 2023-07-14 at 18 18 25" src="https://github.com/mui/mui-toolpad/assets/10789765/762d5b9e-12b3-44c9-b9ff-7fe03e795af3">

This had been removed in https://github.com/mui/mui-toolpad/pull/1499 but I am not sure why, do we not want this vertical alignment option? Not sure if it could be confusing or if we could find a better alternative.