### PR TITLE
Fix some flakyness in the visual regression testing

### DIFF
--- a/packages/toolpad-app/src/runtime/index.tsx
+++ b/packages/toolpad-app/src/runtime/index.tsx
@@ -5,6 +5,7 @@ import { ToolpadComponents } from '@mui/toolpad-core';
 import { Emitter } from '@mui/toolpad-utils/events';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
+import { Box } from '@mui/material';
 import RuntimeToolpadApp, { ToolpadAppProps } from './ToolpadApp';
 import { RuntimeState } from '../types';
 
@@ -49,6 +50,7 @@ function Root({ ToolpadApp, initialState, base }: RootProps) {
         {/* For some reason this helps with https://github.com/vitejs/vite/issues/12423 */}
         <Button sx={{ display: 'none' }} />
         <ToolpadApp basename={base} state={initialState} loadComponents={loadComponents} />
+        <Box data-testid="page-ready-marker" sx={{ display: 'none' }} />
       </CacheProvider>
     </React.StrictMode>
   );

--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -273,6 +273,7 @@ export function createViteConfig({
         'react-router-dom',
         'react/jsx-dev-runtime',
         'react/jsx-runtime',
+        'recharts',
         'superjson',
         'zod',
       ],

--- a/test/integration/bindings/navigation.spec.ts
+++ b/test/integration/bindings/navigation.spec.ts
@@ -20,7 +20,6 @@ test('navigation action', async ({ page }) => {
 
   const navigationButton = page.getByRole('button', { name: 'goToPage2' });
   await navigationButton.click();
-  await runtimeModel.waitForNavigation();
 
   await expect(page.getByText('welcome to page 2')).toBeVisible();
   expect(getPageUrlSearch()).toBe('?abc=zyx&def=goToPage2');

--- a/test/models/ToolpadRuntime.ts
+++ b/test/models/ToolpadRuntime.ts
@@ -34,7 +34,10 @@ export class ToolpadRuntime {
     await this.page.goto(`${this.getPrefix()}/pages/${pageId}`);
   }
 
-  async waitForNavigation() {
-    await this.page.waitForURL((url) => url.pathname.startsWith(`${this.getPrefix()}/pages`));
+  async waitForPageReady() {
+    await this.page.waitForTimeout(1000);
+    await this.page.waitForSelector('[data-testid="page-ready-marker"]', {
+      state: 'attached',
+    });
   }
 }

--- a/test/playwright/localTest.ts
+++ b/test/playwright/localTest.ts
@@ -214,6 +214,7 @@ const test = base.extend<
         const screenshotPath = path.resolve(PROJECT_ROOT, ARGOS_OUTPUT_FOLDER, relative);
         await page.screenshot({
           path: screenshotPath,
+          animations: 'disabled',
           ...options,
         });
       });

--- a/test/visual/components/index.spec.ts
+++ b/test/visual/components/index.spec.ts
@@ -15,6 +15,8 @@ test('rendering components in the app runtime', async ({ page, argosScreenshot }
   const runtimeModel = new ToolpadRuntime(page);
   await runtimeModel.gotoPage('components');
 
+  await runtimeModel.waitForPageReady();
+
   await argosScreenshot('components', { fullPage: true });
 });
 


### PR DESCRIPTION
I sometimes see an empty page turning up in argos. It seems that sometimes the screenshot is being taken before it's fully rendered. Argos doesn't care whether changes were approved or not. If it's flaky on master, too bad, it will become the new baseline. I introduced `page-ready=marker` to signal that the runtime DOM actually is being rendered. Wait for this marker before taking the screenshot for visual regression testing.

Also disabling animation for VRT screenshots as we seem to be having some non-determinism on the tabs animation after selection

<img width="1145" alt="Screenshot 2023-07-19 at 13 27 11" src="https://github.com/mui/mui-toolpad/assets/2109932/e7345736-9a65-471e-965a-21e9093e320a">


Also removed `waitForNavigation`, it wasn't doing anything for the cases where it was used as the condition was already fulfulled before this function is called.

Also adding `recharts` to the `optimizeDeps`, this also improves test performance, and flakyness