### PR TITLE
[test] Fail the CI when new unexpected files are created

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
       - install_js
       - run:
           name: Should not have any git not staged
-          command: git diff --exit-code
+          command: git add -A && git diff --exit-code --staged
       - run:
           name: Check for duplicated packages
           command: yarn deduplicate
@@ -127,12 +127,12 @@ jobs:
           name: '`yarn jsonSchemas` changes committed?'
           command: |
             yarn jsonSchemas
-            git diff --exit-code
+            git add -A && git diff --exit-code --staged
       - run:
           name: '`yarn docs:build:api` changes committed?'
           command: |
             yarn docs:build:api
-            git diff --exit-code
+            git add -A && git diff --exit-code --staged
 
   test_unit:
     <<: *defaults


### PR DESCRIPTION
Same as https://github.com/mui/material-ui/pull/38039. In most cases, it's not needed, but it sounds simpler to blindly apply the same code, in case of a strange behavior.