### PR TITLE
Fix rest tests flakyness around env reloading

### DIFF
--- a/packages/toolpad-app/src/server/EnvManager.ts
+++ b/packages/toolpad-app/src/server/EnvManager.ts
@@ -20,6 +20,8 @@ interface IToolpadProject {
 export default class EnvManager {
   private project: IToolpadProject;
 
+  private originalEnv: Record<string, string | undefined> = { ...process.env };
+
   private values: Awaitable<Record<string, string>> = {};
 
   constructor(project: IToolpadProject) {
@@ -30,8 +32,16 @@ export default class EnvManager {
     this.initWatcher();
   }
 
+  private resetEnv() {
+    Object.keys(process.env).forEach((key) => {
+      delete process.env[key];
+    });
+    Object.assign(process.env, this.originalEnv);
+  }
+
   private loadEnvFile() {
     const envFilePath = this.getEnvFilePath();
+    this.resetEnv();
     const { parsed = {} } = dotenv.config({ path: envFilePath, override: true });
     this.values = parsed;
     // eslint-disable-next-line no-console

--- a/test/integration/backend-basic/index.spec.ts
+++ b/test/integration/backend-basic/index.spec.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import * as fs from 'fs/promises';
 import { fileReplace } from '../../../packages/toolpad-utils/src/fs';
 import { test, expect } from '../../playwright/localTest';
 import { ToolpadRuntime } from '../../models/ToolpadRuntime';
@@ -7,6 +6,7 @@ import { ToolpadEditor } from '../../models/ToolpadEditor';
 import { waitForMatch } from '../../utils/streams';
 import { expectBasicPageContent } from './shared';
 import { setPageHidden } from '../../utils/page';
+import { withTemporaryEdits } from '../../utils/fs';
 
 const BASIC_TESTS_PAGE_ID = '5q1xd0t';
 const EXTRACTED_TYPES_PAGE_ID = 'dt1T4rY';
@@ -31,18 +31,6 @@ test.use({
     },
   },
 });
-
-async function withTemporaryEdits<T = void>(
-  filePath: string,
-  doWork: () => Promise<T>,
-): Promise<T> {
-  const envOriginal = await fs.readFile(filePath, 'utf-8');
-  try {
-    return await doWork();
-  } finally {
-    await fs.writeFile(filePath, envOriginal);
-  }
-}
 
 test('functions basics', async ({ page }) => {
   const runtimeModel = new ToolpadRuntime(page);

--- a/test/utils/fs.ts
+++ b/test/utils/fs.ts
@@ -4,10 +4,10 @@ export async function withTemporaryEdits<T = void>(
   filePath: string,
   doWork: () => Promise<T>,
 ): Promise<T> {
-  const envOriginal = await fs.readFile(filePath, 'utf-8');
+  const originalContent = await fs.readFile(filePath);
   try {
     return await doWork();
   } finally {
-    await fs.writeFile(filePath, envOriginal);
+    await fs.writeFile(filePath, originalContent);
   }
 }

--- a/test/utils/fs.ts
+++ b/test/utils/fs.ts
@@ -1,0 +1,13 @@
+import * as fs from 'fs/promises';
+
+export async function withTemporaryEdits<T = void>(
+  filePath: string,
+  doWork: () => Promise<T>,
+): Promise<T> {
+  const envOriginal = await fs.readFile(filePath, 'utf-8');
+  try {
+    return await doWork();
+  } finally {
+    await fs.writeFile(filePath, envOriginal);
+  }
+}


### PR DESCRIPTION
- [x] reset the fixture env file after changing it
- [x] reset environment variables before reloading so that we pick up removal of variables from the env file

The rest tests are flaky because of this. The second test starts with env variables left from the first test. They don't reset. The second test always fails because of this the first time around. It always passes because playwright retries and runs the second test in isolation in which case it starts with fresh env variables. This is a big drawback of using retries, it can hide legitimate bugs.