### PR TITLE
Automerge Toolpad updates in the examples

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -113,6 +113,7 @@
     "addLabels": ["priority: important"]
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": "before 6:00am on the first day of the month"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -99,6 +99,7 @@
       "groupName": "Update @mui/toolpad in examples",
       "matchPackageNames": ["@mui/toolpad"],
       "matchFiles": ["examples/*/package.json"],
+      "schedule": ["at any time"],
       "automerge": true
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -94,6 +94,12 @@
     {
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"]
+    },
+    {
+      "groupName": "Update @mui/toolpad in examples",
+      "matchPackageNames": ["@mui/toolpad"],
+      "matchFiles": ["examples/*/package.json"],
+      "automerge": true
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],
@@ -105,5 +111,8 @@
   "vulnerabilityAlerts": {
     "schedule": ["at any time"],
     "addLabels": ["priority: important"]
+  },
+  "lockFileMaintenance": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/2150

- Isolate `@mui/toolpad` updates in examples and automatically merge them
- enable `lockFileMaintenance`, Keep transitive dependencies up to date, we can potentially enable automerging for this as well.