### PR TITLE
Try out memory improvements on datagrid example

### DIFF
--- a/examples/custom-datagrid-column/package.json
+++ b/examples/custom-datagrid-column/package.json
@@ -8,6 +8,6 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "https://pkg.csb.dev/mui/mui-toolpad/commit/78f0dcf2/@mui/toolpad"
+    "@mui/toolpad": "https://pkg.csb.dev/mui/mui-toolpad/commit/336da8cb/@mui/toolpad"
   }
 }

--- a/examples/custom-datagrid-column/package.json
+++ b/examples/custom-datagrid-column/package.json
@@ -8,6 +8,6 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.21"
+    "@mui/toolpad": "https://pkg.csb.dev/mui/mui-toolpad/commit/78f0dcf2/@mui/toolpad"
   }
 }

--- a/examples/npm-stats/package.json
+++ b/examples/npm-stats/package.json
@@ -8,7 +8,7 @@
     "start": "NODE_OPTIONS='--max-old-space-size=396' toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.21",
+    "@mui/toolpad": "https://pkg.csb.dev/mui/mui-toolpad/commit/336da8cb/@mui/toolpad",
     "recharts": "2.7.2"
   }
 }

--- a/examples/npm-stats/package.json
+++ b/examples/npm-stats/package.json
@@ -8,7 +8,7 @@
     "start": "NODE_OPTIONS='--max-old-space-size=396' toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "https://pkg.csb.dev/mui/mui-toolpad/commit/336da8cb/@mui/toolpad",
+    "@mui/toolpad": "0.1.21",
     "recharts": "2.7.2"
   }
 }


### PR DESCRIPTION
Seeing 50% improvement in memory in the runtime when running https://github.com/mui/mui-toolpad/pull/2354 on tools-public. Let's see if we see the same improvement with this example.