### PR TITLE
Remove redundant integration tests section from contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ The playwright tests can be run in one of two modes:
    TOOLPAD_NEXT_DEV=1 yarn test:integration --project chromium
    ```
 
-- Use the `--ui` flag to run the tests interactively
+Use the `--ui` flag to run the tests interactively
 
 ## Building and running the documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ The playwright tests can be run in one of two modes:
    TOOLPAD_NEXT_DEV=1 yarn test:integration --project chromium
    ```
 
-Use the `--ui` flag to run the tests interactively
+Use the `--ui` flag to run the tests interactively.
 
 ## Building and running the documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,8 @@ The playwright tests can be run in one of two modes:
    TOOLPAD_NEXT_DEV=1 yarn test:integration --project chromium
    ```
 
+- Use the `--ui` flag to run the tests interactively
+
 ## Building and running the documentation
 
 1. If you haven't already, install the project dependencies using
@@ -188,35 +190,6 @@ The playwright tests can be run in one of two modes:
   ```bash
   yarn toolpad dev /path/to/my/toolpad/project
   ```
-
-## Integration tests
-
-- To run Toolpad on a fixture
-
-  ```bash
-  yarn toolpad dev --dev ./path/to/fixture
-  ```
-
-- To run the tests locally in production mode
-
-  ```bash
-  yarn release:build
-  yarn test:integration --project chromium
-  ```
-
-- To run the tests locally in dev mode
-
-  ```bash
-  yarn dev
-  ```
-
-  then run
-
-  ```bash
-  TOOLPAD_NEXT_DEV=1 yarn test:integration --project chromium
-  ```
-
-- Use the `--ui` flag to run the tests interactively
 
 ## Using CodeSandbox CI
 


### PR DESCRIPTION
This section seems to have duplicate information, so we could condense the 2 sections about integration tests into 1? 
Or did I miss something?