### PR TITLE
[website] Add "Book Demo" button

### DIFF
--- a/docs/src/components/landing/GetStartedButtons.js
+++ b/docs/src/components/landing/GetStartedButtons.js
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
+import Link from 'docs/src/modules/components/Link';
+import NpmCopyButton from 'docs/src/components/action/NpmCopyButton';
+
+export default function GetStartedButtons(props) {
+  const { installation, primaryLabel, primaryUrl, secondaryLabel, secondaryUrl, ...other } = props;
+  return (
+    <React.Fragment>
+      <Box
+        {...other}
+        sx={{
+          display: 'flex',
+          flexWrap: { xs: 'wrap', md: 'nowrap' },
+          '&& > *': {
+            minWidth: { xs: '100%', md: '0%' },
+          },
+          ...other.sx,
+        }}
+      >
+        <Button
+          href={primaryUrl}
+          component={Link}
+          noLinkStyle
+          size="large"
+          variant="contained"
+          endIcon={<KeyboardArrowRightRounded />}
+          sx={{
+            flexShrink: 0,
+            mr: { xs: 0, md: 1.5 },
+            mb: { xs: 2, md: 0 },
+          }}
+        >
+          {primaryLabel}
+        </Button>
+        {secondaryUrl ? (
+          <Button
+            href={secondaryUrl}
+            component={Link}
+            noLinkStyle
+            target={'_blank'}
+            variant="outlined"
+            size="large"
+            color="secondary"
+            endIcon={<KeyboardArrowRightRounded />}
+          >
+            {secondaryLabel}
+          </Button>
+        ) : null}
+      </Box>
+      <NpmCopyButton installation={installation} sx={{ mt: 2 }} />
+    </React.Fragment>
+  );
+}
+
+GetStartedButtons.propTypes = {
+  installation: PropTypes.string.isRequired,
+  primaryLabel: PropTypes.string.isRequired,
+  primaryUrl: PropTypes.string.isRequired,
+  secondaryLabel: PropTypes.string,
+  secondaryUrl: PropTypes.string,
+};

--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -10,7 +10,7 @@ import SvgMuiLogo from 'docs/src/icons/SvgMuiLogomark';
 import IconImage from 'docs/src/components/icon/IconImage';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import GradientText from 'docs/src/components/typography/GradientText';
-import GetStartedButtons from 'docs/src/components/home/GetStartedButtons';
+import GetStartedButtons from './GetStartedButtons';
 import GithubStars from './GithubStars';
 import CodeBlock from './CodeBlock';
 import ROUTES from '../../route';
@@ -196,8 +196,11 @@ export default function Hero() {
           to data sources with your own code.
         </Typography>
         <GetStartedButtons
+          primaryLabel={'Get started'}
+          primaryUrl={ROUTES.toolpadQuickstart}
+          secondaryLabel={'Book a demo'}
+          secondaryUrl={ROUTES.toolpadDemoBooking}
           installation={'npx create-toolpad-app@latest'}
-          to={ROUTES.toolpadQuickstart}
         />
         <Box
           sx={{

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -5,6 +5,7 @@ const ROUTES = {
   toolpadUpvote: 'https://github.com/mui/mui-toolpad/labels/waiting%20for%20%F0%9F%91%8D',
   toolpadMoreExamples: 'https://github.com/mui/mui-toolpad/tree/master/examples',
   toolpadBetaBlog: 'https://mui.com/blog/2023-toolpad-beta-announcement/',
+  toolpadDemoBooking: 'https://calendly.com/prakhar-mui/toolpad',
   // https://docs.netlify.com/site-deploys/overview/#deploy-contexts
   TOOLPAD_SIGN_UP_URL:
     process.env.DEPLOY_ENV !== 'production'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Closes #2402 

<img width="1261" alt="Screenshot 2023-08-02 at 6 11 18 PM" src="https://github.com/mui/mui-toolpad/assets/19550456/297549f9-a542-4236-897f-510fa3c44459">

- This adds a new `GetStartedButtons` component which we can remove once https://github.com/mui/material-ui/pull/38256 is merged