### PR TITLE
Remove logging of RPC errors

### DIFF
--- a/packages/toolpad-app/src/server/rpc.ts
+++ b/packages/toolpad-app/src/server/rpc.ts
@@ -5,8 +5,6 @@ import * as z from 'zod';
 import { fromZodError } from 'zod-validation-error';
 import { hasOwnProperty } from '@mui/toolpad-utils/collections';
 import { errorFrom, serializeError } from '@mui/toolpad-utils/errors';
-import { indent } from '@mui/toolpad-utils/strings';
-import chalk from 'chalk';
 import { asyncHandler } from '../utils/express';
 import type { ToolpadProject } from './localMode';
 

--- a/packages/toolpad-app/src/server/rpc.ts
+++ b/packages/toolpad-app/src/server/rpc.ts
@@ -86,18 +86,6 @@ export function createRpcHandler(definition: Definition): express.RequestHandler
         : { result: superjson.stringify(rawResult) };
 
       res.json(responseData);
-
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.log(`${chalk.red('error')} - RPC error`);
-        if (error.stack) {
-          // eslint-disable-next-line no-console
-          console.log(indent(error.stack, 2));
-        } else {
-          // eslint-disable-next-line no-console
-          console.log(indent(`${error.name}: ${error.message}`, 2));
-        }
-      }
     }),
   );
   return router;


### PR DESCRIPTION
This log appears regardless of whether the error is handled downstream. Which could lead to false positives.
