### PR TITLE
Improve Toolpad startup time

### DIFF
--- a/packages/toolpad-app/cli/appBuilder.ts
+++ b/packages/toolpad-app/cli/appBuilder.ts
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 import { buildApp } from '../src/server/toolpadAppBuilder';
-import { buildProject } from '../src/server/localMode';
+import { buildProject, getAppOutputFolder, getComponents } from '../src/server/localMode';
 
 async function main() {
   invariant(
@@ -13,7 +13,12 @@ async function main() {
 
   await buildProject(projectDir);
 
-  await buildApp({ root: projectDir, base: '/prod' });
+  await buildApp({
+    root: projectDir,
+    base: '/prod',
+    getComponents,
+    outDir: getAppOutputFolder(projectDir),
+  });
 }
 
 main().catch((err) => {

--- a/packages/toolpad-app/cli/appServer.ts
+++ b/packages/toolpad-app/cli/appServer.ts
@@ -1,6 +1,6 @@
+import { parentPort, workerData, MessageChannel, MessagePort } from 'worker_threads';
 import invariant from 'invariant';
 import { createServer, Plugin } from 'vite';
-import { parentPort, workerData, MessageChannel, MessagePort } from 'worker_threads';
 import {
   getHtmlContent,
   postProcessHtml,

--- a/packages/toolpad-app/cli/server.ts
+++ b/packages/toolpad-app/cli/server.ts
@@ -280,8 +280,7 @@ export async function runApp({ cmd, port, dev = false, projectDir }: RunAppOptio
     }
   }
 
-  const editorDevMode =
-    !!process.env.TOOLPAD_NEXT_DEV || process.env.NODE_ENV === 'development' || dev;
+  const editorDevMode = !!process.env.TOOLPAD_NEXT_DEV || dev;
 
   const externalUrl = process.env.TOOLPAD_EXTERNAL_URL || `http://localhost:${port}`;
 

--- a/packages/toolpad-app/cli/server.ts
+++ b/packages/toolpad-app/cli/server.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { IncomingMessage, createServer } from 'http';
 import * as fs from 'fs/promises';
+import { Worker } from 'worker_threads';
 import express from 'express';
 import invariant from 'invariant';
 import getPort from 'get-port';
@@ -14,7 +15,6 @@ import { listen } from '@mui/toolpad-utils/http';
 import openBrowser from 'react-dev-utils/openBrowser';
 import { folderExists } from '@mui/toolpad-utils/fs';
 import chalk from 'chalk';
-import { Worker } from 'worker_threads';
 import { errorFrom } from '@mui/toolpad-utils/errors';
 import { asyncHandler } from '../src/utils/express';
 import { createProdHandler } from '../src/server/toolpadAppServer';

--- a/packages/toolpad-app/cli/server.ts
+++ b/packages/toolpad-app/cli/server.ts
@@ -3,7 +3,6 @@ import { IncomingMessage, createServer } from 'http';
 import * as fs from 'fs/promises';
 import express from 'express';
 import invariant from 'invariant';
-import { execaNode } from 'execa';
 import getPort from 'get-port';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { mapValues } from '@mui/toolpad-utils/collections';

--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -1,11 +1,10 @@
 import * as path from 'path';
-import { Server } from 'http';
 import { InlineConfig, Plugin, build } from 'vite';
 import react from '@vitejs/plugin-react';
 import serializeJavascript from 'serialize-javascript';
 import { indent } from '@mui/toolpad-utils/strings';
 import { MUI_X_PRO_LICENSE, RUNTIME_CONFIG_WINDOW_PROPERTY } from '../constants';
-import { getComponents, getAppOutputFolder } from './localMode';
+import type { ComponentEntry } from './localMode';
 import type { RuntimeConfig } from '../config';
 import * as appDom from '../appDom';
 import createRuntimeState from '../runtime/createRuntimeState';
@@ -86,9 +85,10 @@ export function postProcessHtml(html: string, { config, dom }: PostProcessHtmlPa
 interface ToolpadVitePluginParams {
   root: string;
   base: string;
+  getComponents: (root: string) => Promise<ComponentEntry[]>;
 }
 
-function toolpadVitePlugin({ root, base }: ToolpadVitePluginParams): Plugin {
+function toolpadVitePlugin({ root, base, getComponents }: ToolpadVitePluginParams): Plugin {
   const resolvedRuntimeEntryPointId = `\0${MAIN_ENTRY}`;
   const resolvedCanvasEntryPointId = `\0${CANVAS_ENTRY}`;
 
@@ -186,26 +186,28 @@ function toolpadVitePlugin({ root, base }: ToolpadVitePluginParams): Plugin {
 }
 
 export interface CreateViteConfigParams {
-  middlewareMode?: boolean;
-  server?: Server;
-  dev: boolean;
+  outDir: string;
   root: string;
+  dev: boolean;
   base: string;
   plugins?: Plugin[];
+  getComponents: (root: string) => Promise<ComponentEntry[]>;
 }
 
 export function createViteConfig({
+  outDir,
   root,
   dev,
   base,
   plugins = [],
+  getComponents,
 }: CreateViteConfigParams): InlineConfig {
   const mode = dev ? 'development' : 'production';
   return {
     configFile: false,
     mode,
     build: {
-      outDir: getAppOutputFolder(root),
+      outDir,
       chunkSizeWarningLimit: Infinity,
       rollupOptions: {
         onwarn(warning, warn) {
@@ -281,7 +283,7 @@ export function createViteConfig({
     appType: 'custom',
     logLevel: 'info',
     root,
-    plugins: [react(), toolpadVitePlugin({ root, base }), ...plugins],
+    plugins: [react(), toolpadVitePlugin({ root, base, getComponents }), ...plugins],
     base,
     define: {
       'process.env.NODE_ENV': `'${mode}'`,
@@ -291,10 +293,12 @@ export function createViteConfig({
 }
 
 export interface ToolpadBuilderParams {
+  outDir: string;
+  getComponents: (root: string) => Promise<ComponentEntry[]>;
   root: string;
   base: string;
 }
 
-export async function buildApp({ root, base }: ToolpadBuilderParams) {
-  await build(createViteConfig({ dev: false, root, base }));
+export async function buildApp({ root, base, getComponents, outDir }: ToolpadBuilderParams) {
+  await build(createViteConfig({ dev: false, root, base, getComponents, outDir }));
 }

--- a/packages/toolpad-app/src/server/workerRpc.ts
+++ b/packages/toolpad-app/src/server/workerRpc.ts
@@ -1,0 +1,68 @@
+import { Worker, parentPort, MessageChannel, MessagePort } from 'worker_threads';
+import invariant from 'invariant';
+import { Methods } from '../types';
+
+type MessageRequest = {
+  kind: 'worker-rpc';
+  method: string;
+  args: any[];
+  port: MessagePort;
+};
+
+interface MsgResponse<T = unknown> {
+  error?: unknown;
+  result?: T;
+}
+
+export function createWorkerRpcClient<M extends Methods>(): M {
+  return new Proxy({} as M, {
+    get: (target, prop) => {
+      if (typeof prop !== 'string') {
+        return Reflect.get(target, prop);
+      }
+      return (...args: any[]) => {
+        return new Promise((resolve, reject) => {
+          invariant(parentPort, 'Worker client is not running in a worker thread');
+          const { port1, port2 } = new MessageChannel();
+          port1.on('message', (msg: MsgResponse) => {
+            if (msg.error) {
+              reject(msg.error);
+            } else {
+              resolve(msg.result);
+            }
+          });
+          parentPort.postMessage(
+            {
+              kind: 'worker-rpc',
+              method: prop,
+              args,
+              port: port2,
+            } satisfies MessageRequest,
+            [port2],
+          );
+        });
+      };
+    },
+  });
+}
+
+export function createWorkerRpcServer<M extends Methods>(worker: Worker, methods: M) {
+  const methodMap = new Map(Object.entries(methods));
+  worker.on('message', async (msg: MessageRequest) => {
+    if (msg.kind === 'worker-rpc') {
+      const method = methodMap.get(msg.method);
+      if (method) {
+        try {
+          const result = await method(...msg.args);
+          msg.port.postMessage({ result } satisfies MsgResponse);
+        } catch (error) {
+          msg.port.postMessage({ error } satisfies MsgResponse);
+        }
+      } else {
+        msg.port.postMessage({
+          error: new Error(`Method "${msg.method}" not found`),
+        } satisfies MsgResponse);
+      }
+    }
+  });
+}

--- a/packages/toolpad-app/tsup.config.ts
+++ b/packages/toolpad-app/tsup.config.ts
@@ -20,7 +20,6 @@ export default defineConfig([
   {
     entry: {
       index: './cli/index.ts',
-      server: './cli/server.ts',
       appServer: './cli/appServer.ts',
       appBuilder: './cli/appBuilder.ts',
       functionsDevWorker: './src/server/functionsDevWorker.ts',


### PR DESCRIPTION
Introduced some integration test performance regression in https://github.com/mui/mui-toolpad/pull/1999. 

<img width="1130" alt="Screenshot 2023-08-03 at 10 44 06" src="https://github.com/mui/mui-toolpad/assets/2109932/1ca4b93c-9632-43fb-94a8-c00e23cecfde">


This PR
* replaces the childprocess with a worker thread
* stops blocking the startup of the app while initializing the worker. We can simply stall the incoming requests until the devserver is ready
* optimizes the appServer worker build and communicates with the main thread to get project data. (Fixes issues where worker threads are starting worker threads)

On my mac this brings the Toolpad startup time down to ~65ms from ~1.8s. 27 times faster. The application now starts near instantly.


The tests job now takes ~4m less compared to before (about 18% faster)

before:
<img width="1137" alt="Screenshot 2023-08-03 at 12 45 41" src="https://github.com/mui/mui-toolpad/assets/2109932/2de26cf8-dc5e-4992-8a5d-bb2c6c8abb1d">



after:
<img width="1124" alt="Screenshot 2023-08-03 at 12 45 26" src="https://github.com/mui/mui-toolpad/assets/2109932/447c6930-4374-447e-bc89-2bcef0d6efff">
