### PR TITLE
Increase localApp fixture timeout

### DIFF
--- a/test/playwright/localTest.ts
+++ b/test/playwright/localTest.ts
@@ -168,7 +168,7 @@ const test = base.extend<
         await use(app);
       });
     },
-    { scope: 'worker' },
+    { scope: 'worker', timeout: 60000 },
   ],
   baseURL: async ({ localApp }, use) => {
     await use(localApp.url);


### PR DESCRIPTION
Noticed some flakeyness around these tests that build production the artifact for toolpad apps. It's actually not the test failing or timing out, it's the fixture timing out while building the application. This starts happening because we're moving more work into the build time and out of the runtime.
This PR increases the timeout for the fixture specifically

I'd expect this PR to actually reduce a bit the time it takes to run our test suite as fewer retries will be happening