### PR TITLE
Clean up worker communication with devserver

### DIFF
--- a/packages/toolpad-app/cli/appBuilder.ts
+++ b/packages/toolpad-app/cli/appBuilder.ts
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 import { buildApp } from '../src/server/toolpadAppBuilder';
-import { buildProject, getAppOutputFolder, getComponents } from '../src/server/localMode';
+import { initProject, getAppOutputFolder, getComponents } from '../src/server/localMode';
 
 async function main() {
   invariant(
@@ -11,7 +11,9 @@ async function main() {
 
   const projectDir = process.env.TOOLPAD_PROJECT_DIR;
 
-  await buildProject(projectDir);
+  const project = await initProject('build', projectDir);
+
+  await project.build();
 
   await buildApp({
     root: projectDir,
@@ -19,6 +21,8 @@ async function main() {
     getComponents,
     outDir: getAppOutputFolder(projectDir),
   });
+
+  await project.dispose();
 }
 
 main().catch((err) => {

--- a/packages/toolpad-app/cli/server.ts
+++ b/packages/toolpad-app/cli/server.ts
@@ -139,6 +139,8 @@ async function main({
 
   const project = await initProject(cmd, projectDir);
 
+  await project.start();
+
   const app = express();
   const httpServer = createServer(app);
 

--- a/packages/toolpad-app/cli/server.ts
+++ b/packages/toolpad-app/cli/server.ts
@@ -23,11 +23,7 @@ import {
   getComponents,
   initProject,
 } from '../src/server/localMode';
-import {
-  Command as AppDevServerCommand,
-  Event as AppDevServerEvent,
-  AppViteServerConfig,
-} from './appServer';
+import type { Command as AppDevServerCommand, AppViteServerConfig, WorkerRpc } from './appServer';
 import { createRpcHandler, createRpcServer } from '../src/server/rpc';
 import { RUNTIME_CONFIG_WINDOW_PROPERTY } from '../src/constants';
 import type { RuntimeConfig } from '../src/config';
@@ -65,6 +61,7 @@ async function createDevHandler(
       port: devPort,
     } satisfies AppViteServerConfig,
     env: {
+      ...process.env,
       NODE_ENV: 'development',
     },
   });
@@ -74,15 +71,13 @@ async function createDevHandler(
     process.exit(1);
   });
 
-  const readyPromise: Promise<Error | void> = new Promise<void>((resolve) => {
-    worker.on('message', async (msg: AppDevServerEvent) => {
-      if (msg.kind === 'ready') {
-        resolve();
-      }
-    });
-  }).catch((err) => err);
+  let resolveReadyPromise: () => void | undefined;
+  const readyPromise = new Promise<void>((resolve) => {
+    resolveReadyPromise = resolve;
+  });
 
-  createWorkerRpcServer(worker, {
+  createWorkerRpcServer<WorkerRpc>(worker, {
+    notifyReady: async () => resolveReadyPromise?.(),
     loadDom: async () => project.loadDom(),
     getComponents: async () => getComponents(project.getRoot()),
   });

--- a/packages/toolpad-app/src/server/localMode.ts
+++ b/packages/toolpad-app/src/server/localMode.ts
@@ -1178,15 +1178,5 @@ export async function initProject(cmd: 'dev' | 'start' | 'build', root: string) 
   // eslint-disable-next-line no-underscore-dangle
   globalThis.__toolpadProject = project;
 
-  await project.start();
-
   return project;
-}
-
-export async function buildProject(root: string) {
-  const project = new ToolpadProject(root, { cmd: 'build', dev: false });
-
-  await project.build();
-
-  await project.dispose();
 }

--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -194,6 +194,10 @@ export interface CreateViteConfigParams {
   getComponents: (root: string) => Promise<ComponentEntry[]>;
 }
 
+export interface CreateViteConfigResult {
+  viteConfig: InlineConfig;
+}
+
 export function createViteConfig({
   outDir,
   root,
@@ -201,93 +205,96 @@ export function createViteConfig({
   base,
   plugins = [],
   getComponents,
-}: CreateViteConfigParams): InlineConfig {
+}: CreateViteConfigParams): CreateViteConfigResult {
   const mode = dev ? 'development' : 'production';
+
   return {
-    configFile: false,
-    mode,
-    build: {
-      outDir,
-      chunkSizeWarningLimit: Infinity,
-      rollupOptions: {
-        onwarn(warning, warn) {
-          if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
-            return;
-          }
-          warn(warning);
+    viteConfig: {
+      configFile: false,
+      mode,
+      build: {
+        outDir,
+        chunkSizeWarningLimit: Infinity,
+        rollupOptions: {
+          onwarn(warning, warn) {
+            if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+              return;
+            }
+            warn(warning);
+          },
         },
       },
-    },
-    envFile: false,
-    resolve: {
-      alias: [
-        {
-          // FIXME(https://github.com/mui/material-ui/issues/35233)
-          find: /^@mui\/icons-material\/([^/]*)/,
-          replacement: '@mui/icons-material/esm/$1',
-        },
-      ],
-    },
-    server: {
-      fs: {
-        allow: [root, path.resolve(__dirname, '../../../../')],
+      envFile: false,
+      resolve: {
+        alias: [
+          {
+            // FIXME(https://github.com/mui/material-ui/issues/35233)
+            find: /^@mui\/icons-material\/([^/]*)/,
+            replacement: '@mui/icons-material/esm/$1',
+          },
+        ],
       },
-    },
-    optimizeDeps: {
-      include: [
-        '@emotion/cache',
-        '@emotion/react',
-        '@mui/icons-material/ArrowDropDownRounded',
-        '@mui/icons-material/DarkMode',
-        '@mui/icons-material/Edit',
-        '@mui/icons-material/Error',
-        '@mui/icons-material/HelpOutlined',
-        '@mui/icons-material/LightMode',
-        '@mui/icons-material/OpenInNew',
-        '@mui/icons-material/SettingsBrightnessOutlined',
-        '@mui/lab',
-        '@mui/material',
-        '@mui/material/Button',
-        '@mui/material/colors',
-        '@mui/material/styles',
-        '@mui/material/useMediaQuery',
-        '@mui/utils',
-        '@mui/x-data-grid-pro',
-        '@mui/x-date-pickers/AdapterDayjs',
-        '@mui/x-date-pickers/DesktopDatePicker',
-        '@mui/x-date-pickers/LocalizationProvider',
-        '@tanstack/react-query',
-        '@tanstack/react-query-devtools/build/lib/index.prod.js',
-        'dayjs',
-        'dayjs/locale/en',
-        'dayjs/locale/fr',
-        'dayjs/locale/nl',
-        'fractional-indexing',
-        'invariant',
-        'lodash-es',
-        'markdown-to-jsx',
-        'nanoid/non-secure',
-        'react',
-        'react-dom/client',
-        'react-error-boundary',
-        'react-hook-form',
-        'react-is',
-        'react-router-dom',
-        'react/jsx-dev-runtime',
-        'react/jsx-runtime',
-        'recharts',
-        'superjson',
-        'zod',
-      ],
-    },
-    appType: 'custom',
-    logLevel: 'info',
-    root,
-    plugins: [react(), toolpadVitePlugin({ root, base, getComponents }), ...plugins],
-    base,
-    define: {
-      'process.env.NODE_ENV': `'${mode}'`,
-      'process.env.BASE_URL': `'${base}'`,
+      server: {
+        fs: {
+          allow: [root, path.resolve(__dirname, '../../../../')],
+        },
+      },
+      optimizeDeps: {
+        include: [
+          '@emotion/cache',
+          '@emotion/react',
+          '@mui/icons-material/ArrowDropDownRounded',
+          '@mui/icons-material/DarkMode',
+          '@mui/icons-material/Edit',
+          '@mui/icons-material/Error',
+          '@mui/icons-material/HelpOutlined',
+          '@mui/icons-material/LightMode',
+          '@mui/icons-material/OpenInNew',
+          '@mui/icons-material/SettingsBrightnessOutlined',
+          '@mui/lab',
+          '@mui/material',
+          '@mui/material/Button',
+          '@mui/material/colors',
+          '@mui/material/styles',
+          '@mui/material/useMediaQuery',
+          '@mui/utils',
+          '@mui/x-data-grid-pro',
+          '@mui/x-date-pickers/AdapterDayjs',
+          '@mui/x-date-pickers/DesktopDatePicker',
+          '@mui/x-date-pickers/LocalizationProvider',
+          '@tanstack/react-query',
+          '@tanstack/react-query-devtools/build/lib/index.prod.js',
+          'dayjs',
+          'dayjs/locale/en',
+          'dayjs/locale/fr',
+          'dayjs/locale/nl',
+          'fractional-indexing',
+          'invariant',
+          'lodash-es',
+          'markdown-to-jsx',
+          'nanoid/non-secure',
+          'react',
+          'react-dom/client',
+          'react-error-boundary',
+          'react-hook-form',
+          'react-is',
+          'react-router-dom',
+          'react/jsx-dev-runtime',
+          'react/jsx-runtime',
+          'recharts',
+          'superjson',
+          'zod',
+        ],
+      },
+      appType: 'custom',
+      logLevel: 'info',
+      root,
+      plugins: [react(), toolpadVitePlugin({ root, base, getComponents }), ...plugins],
+      base,
+      define: {
+        'process.env.NODE_ENV': `'${mode}'`,
+        'process.env.BASE_URL': `'${base}'`,
+      },
     },
   };
 }
@@ -300,5 +307,6 @@ export interface ToolpadBuilderParams {
 }
 
 export async function buildApp({ root, base, getComponents, outDir }: ToolpadBuilderParams) {
-  await build(createViteConfig({ dev: false, root, base, getComponents, outDir }));
+  const { viteConfig } = createViteConfig({ dev: false, root, base, outDir, getComponents });
+  await build(viteConfig);
 }


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-toolpad/pull/2406
- [x] Remove a few obsolete types and move the ready command to the rpc mechanism
- [x] Bring in a few refactors from https://github.com/mui/mui-toolpad/pull/2406. Mostly moving things around, but this should make it easier to resolve future merge conflicts