### PR TITLE
Adjust timeout and import node-fetch in create-toolpad-app test (#2414)

### DIFF
--- a/packages/create-toolpad-app/package.json
+++ b/packages/create-toolpad-app/package.json
@@ -40,7 +40,8 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
-    "@types/inquirer": "9.0.3"
+    "@types/inquirer": "9.0.3",
+    "node-fetch": "2.6.12"
   },
   "gitHead": "c4bbeaeaf5c34b43fa52b31955b2c34f07700bc3"
 }

--- a/packages/create-toolpad-app/tests/index.spec.ts
+++ b/packages/create-toolpad-app/tests/index.spec.ts
@@ -6,8 +6,9 @@ import { Readable } from 'stream';
 import { execa, ExecaChildProcess } from 'execa';
 import { jest } from '@jest/globals';
 import { once } from 'events';
+import fetch from 'node-fetch';
 
-jest.setTimeout(60000);
+jest.setTimeout(process.env.CI ? 60000 : 600000);
 
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 


### PR DESCRIPTION
As a result of the errors that were occurring when running the `yarn test` after cloning repositories I've made changes with
help of @Janpot. I've imported `node-fetch` package and adjusted the `jest.setTimeout` method to allow for more time if necessary.

All tests now pass.

Closes #2414 
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I've read and followed the [contributing guide](https://github.com/mui/mui-toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [ ] I've updated the relevant documentation for any new or updated feature
- [ ] I've linked relevant GitHub issue with "Closes #<issue id>"

