### PR TITLE
Improve rest test flakyness

### DIFF
--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -53,6 +53,7 @@ test('rest runtime basics', async ({ page, localApp }) => {
 test('rest editor basics', async ({ page, context, localApp }) => {
   const editorModel = new ToolpadEditor(page);
   await editorModel.goto();
+  await editorModel.waitForOverlay();
 
   await editorModel.pageEditor.getByRole('button', { name: 'Add query' }).click();
   await page.getByRole('button', { name: 'HTTP request' }).click();

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -7,6 +7,8 @@ import { ToolpadEditor } from '../../models/ToolpadEditor';
 import { startTestServer } from './testServer';
 import { withTemporaryEdits } from '../../utils/fs';
 
+let testServer: Awaited<ReturnType<typeof startTestServer>> | undefined;
+
 test.use({
   localAppConfig: {
     template: path.resolve(__dirname, './fixture'),
@@ -14,17 +16,13 @@ test.use({
     env: {
       TEST_VAR: 'foo',
     },
+    async setup(ctx) {
+      testServer = await startTestServer();
+      const targetUrl = `http://localhost:${testServer.port}/`;
+      const configFilePath = path.resolve(ctx.dir, './toolpad/pages/page1/page.yml');
+      await fileReplaceAll(configFilePath, `http://localhost:8080/`, targetUrl);
+    },
   },
-});
-
-let testServer: Awaited<ReturnType<typeof startTestServer>> | undefined;
-
-test.beforeAll(async ({ localApp }) => {
-  testServer = await startTestServer();
-
-  const targetUrl = `http://localhost:${testServer.port}/`;
-  const configFilePath = path.resolve(localApp.dir, './toolpad/pages/page1/page.yml');
-  await fileReplaceAll(configFilePath, `http://localhost:8080/`, targetUrl);
 });
 
 test.afterAll(async () => {

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -19,8 +19,8 @@ test.use({
     async setup(ctx) {
       testServer = await startTestServer();
       const targetUrl = `http://localhost:${testServer.port}/`;
-      const configFilePath = path.resolve(ctx.dir, './toolpad/pages/page1/page.yml');
-      await fileReplaceAll(configFilePath, `http://localhost:8080/`, targetUrl);
+      const pageFilePath = path.resolve(ctx.dir, './toolpad/pages/page1/page.yml');
+      await fileReplaceAll(pageFilePath, `http://localhost:8080/`, targetUrl);
     },
   },
 });


### PR DESCRIPTION
Checking the traces of https://app.circleci.com/pipelines/github/mui/mui-toolpad/9320/workflows/5ef0f164-077b-4de9-ba2f-1ebaf2ab5480/jobs/40994/artifacts

![Screenshot 2023-08-07 at 11 36 44](https://github.com/mui/mui-toolpad/assets/2109932/9d7f8c90-68ec-49b7-9be1-6de00616b3b8)

It looks like the test app gets stuck on old urls embedded in the project files. At the moment we rely on the project reloading correctly when we update the files, but there seem to be some race conditions during startup of Toolpad.

This PR just replaces the file contents before starting Toolpad. Which was always the intent of this test.