### PR TITLE
Try to improve undo/redo flakyness

### DIFF
--- a/test/integration/undo-redo/basic.spec.ts
+++ b/test/integration/undo-redo/basic.spec.ts
@@ -55,6 +55,8 @@ test('test batching text input actions into single undo entry', async ({ page })
 
   await page.keyboard.type('some value');
 
+  await expect(input).toHaveValue('some value');
+
   // Wait for undo stack to be updated
   await page.waitForTimeout(500);
 


### PR DESCRIPTION
Can't really replicate the flakyness locally but I think we should only start the timeout after we've verified that the page has processed the change. The update only being processed on the page when we're already 45ms into the timeout could explain the flakyness I'm seeing in some test results