### PR TITLE
Require a helperText for builtin components and argTupes

### DIFF
--- a/packages/toolpad-components/src/Autocomplete.tsx
+++ b/packages/toolpad-components/src/Autocomplete.tsx
@@ -4,7 +4,7 @@ import {
   AutocompleteProps as MuiAutocompleteProps,
   TextField,
 } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import { SX_PROP_HELPER_TEXT } from './constants';
 import {
   FORM_INPUT_ARG_TYPES,
@@ -117,7 +117,8 @@ function Autocomplete({
 
 const FormWrappedAutocomplete = withComponentForm(Autocomplete);
 
-export default createComponent(FormWrappedAutocomplete, {
+export default createBuiltin(FormWrappedAutocomplete, {
+  helperText: 'A text input with autocomplete suggestions.',
   layoutDirection: 'both',
   loadingProp: 'loading',
   argTypes: {

--- a/packages/toolpad-components/src/Button.tsx
+++ b/packages/toolpad-components/src/Button.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { LoadingButton as MuiButton, LoadingButtonProps as MuiButtonProps } from '@mui/lab';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import { SX_PROP_HELPER_TEXT } from './constants';
 
 interface ButtonProps extends Omit<MuiButtonProps, 'children'> {
@@ -11,7 +11,7 @@ function Button({ content, ...rest }: ButtonProps) {
   return <MuiButton {...rest}>{content}</MuiButton>;
 }
 
-export default createComponent(Button, {
+export default createBuiltin(Button, {
   helperText:
     'The Material UI [Button](https://mui.com/material-ui/react-button/) component.\n\nButtons allow users to take actions, and make choices, with a single tap.',
   layoutDirection: 'both',

--- a/packages/toolpad-components/src/Chart.tsx
+++ b/packages/toolpad-components/src/Chart.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { createComponent } from '@mui/toolpad-core';
 import { Container, ContainerProps } from '@mui/material';
 import {
   XAxis,
@@ -14,6 +13,7 @@ import {
   Area,
   Scatter,
 } from 'recharts';
+import createBuiltin from './createBuiltin';
 import { SX_PROP_HELPER_TEXT } from './constants';
 
 export const CHART_DATA_SERIES_KINDS = ['line', 'bar', 'area', 'scatter'];
@@ -176,7 +176,8 @@ function Chart({ data = [], height, sx }: ChartProps) {
   );
 }
 
-export default createComponent(Chart, {
+export default createBuiltin(Chart, {
+  helperText: 'A chart component.',
   resizableHeightProp: 'height',
   argTypes: {
     data: {
@@ -214,6 +215,7 @@ export default createComponent(Chart, {
       control: { type: 'ChartData', bindable: false },
     },
     height: {
+      helperText: 'The height of the chart.',
       type: 'number',
       default: 400,
       minimum: 100,

--- a/packages/toolpad-components/src/Container.tsx
+++ b/packages/toolpad-components/src/Container.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Container as MUIContainer, ContainerProps } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import { SX_PROP_HELPER_TEXT } from './constants';
 
 interface Props extends ContainerProps {
@@ -15,7 +15,8 @@ function Container({ children, visible, sx, ...props }: Props) {
   ) : null;
 }
 
-export default createComponent(Container, {
+export default createBuiltin(Container, {
+  helperText: 'A container component.',
   argTypes: {
     children: {
       type: 'element',

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -501,7 +501,7 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
   );
 });
 
-export default createComponent(DataGridComponent, {
+export default createBuiltin(DataGridComponent, {
   helperText:
     'The MUI X [Data Grid](https://mui.com/x/react-data-grid/) component.\n\nThe datagrid lets users display tabular data in a flexible grid.',
   errorProp: 'error',

--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DesktopDatePicker, DesktopDatePickerProps } from '@mui/x-date-pickers/DesktopDatePicker';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { createComponent } from '@mui/toolpad-core';
 import dayjs from 'dayjs';
+import createBuiltin from './createBuiltin';
 import {
   FORM_INPUT_ARG_TYPES,
   FormInputComponentProps,
@@ -158,7 +158,7 @@ function DatePicker({
 
 const FormWrappedDatePicker = withComponentForm(DatePicker);
 
-export default createComponent(FormWrappedDatePicker, {
+export default createBuiltin(FormWrappedDatePicker, {
   helperText:
     'The MUI X [Date Picker](https://mui.com/x/react-date-pickers/date-picker/) component.\n\nThe date picker lets the user select a date.',
   argTypes: {

--- a/packages/toolpad-components/src/FilePicker.tsx
+++ b/packages/toolpad-components/src/FilePicker.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { TextField as MuiTextField, TextFieldProps as MuiTextFieldProps } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import {
   FORM_INPUT_ARG_TYPES,
   FormInputComponentProps,
   useFormInput,
   withComponentForm,
 } from './Form';
+import { SX_PROP_HELPER_TEXT } from './constants';
 
 interface FullFile {
   name: string;
@@ -89,13 +90,23 @@ function FilePicker({
 
 const FormWrappedFilePicker = withComponentForm(FilePicker);
 
-export default createComponent(FormWrappedFilePicker, {
+export default createBuiltin(FormWrappedFilePicker, {
   helperText: 'File Picker component.\nIt allows users to take select and read files.',
   argTypes: {
     value: {
+      helperText: 'The value that is controlled by this FilePicker.',
       type: 'object',
       visible: false,
       onChangeProp: 'onChange',
+      schema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          type: { type: 'string' },
+          size: { type: 'number' },
+          base64: { type: 'string' },
+        },
+      },
     },
     label: {
       helperText: 'A label that describes the content of the FilePicker. e.g. "Profile Image".',
@@ -112,6 +123,7 @@ export default createComponent(FormWrappedFilePicker, {
     },
     ...FORM_INPUT_ARG_TYPES,
     sx: {
+      helperText: SX_PROP_HELPER_TEXT,
       type: 'object',
     },
   },

--- a/packages/toolpad-components/src/Form.tsx
+++ b/packages/toolpad-components/src/Form.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { Container, ContainerProps, Box, Stack, BoxProps } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
-import { ArgTypeDefinitions, createComponent, useNode } from '@mui/toolpad-core';
+import { useNode } from '@mui/toolpad-core';
 import { useForm, FieldValues, ValidationMode, FieldError, Controller } from 'react-hook-form';
 // TODO: Remove lodash-es
 // eslint-disable-next-line no-restricted-imports
 import { isEqual } from 'lodash-es';
 import { SX_PROP_HELPER_TEXT } from './constants';
+import createBuiltin, { BuiltinArgTypeDefinitions } from './createBuiltin';
 
 export const FormContext = React.createContext<{
   form: ReturnType<typeof useForm> | null;
@@ -127,9 +128,11 @@ function Form({
   );
 }
 
-export default createComponent(Form, {
+export default createBuiltin(Form, {
+  helperText: 'A form component.',
   argTypes: {
     children: {
+      helperText: 'The form content.',
       type: 'element',
       control: { type: 'layoutSlot' },
     },
@@ -144,6 +147,7 @@ export default createComponent(Form, {
       type: 'event',
     },
     formControlsAlign: {
+      helperText: 'Form controls alignment.',
       type: 'string',
       enum: ['start', 'center', 'end'],
       default: 'end',
@@ -343,7 +347,7 @@ export function withComponentForm<P extends Record<string, any>>(
   };
 }
 
-export const FORM_INPUT_ARG_TYPES: ArgTypeDefinitions<
+export const FORM_INPUT_ARG_TYPES: BuiltinArgTypeDefinitions<
   Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'>
 > = {
   name: {
@@ -364,7 +368,7 @@ export const FORM_INPUT_ARG_TYPES: ArgTypeDefinitions<
   },
 };
 
-export const FORM_TEXT_INPUT_ARG_TYPES: ArgTypeDefinitions<
+export const FORM_TEXT_INPUT_ARG_TYPES: BuiltinArgTypeDefinitions<
   Pick<FormInputComponentProps, 'minLength' | 'maxLength'>
 > = {
   minLength: {

--- a/packages/toolpad-components/src/Image.tsx
+++ b/packages/toolpad-components/src/Image.tsx
@@ -1,6 +1,6 @@
 import { Box, Skeleton, SxProps, styled } from '@mui/material';
 import * as React from 'react';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import { SX_PROP_HELPER_TEXT } from './constants';
 import ErrorOverlay from './components/ErrorOverlay';
 
@@ -81,7 +81,7 @@ function Image({
   );
 }
 
-export default createComponent(Image, {
+export default createBuiltin(Image, {
   helperText: 'The Image component lets you display images.',
   layoutDirection: 'both',
   loadingPropSource: ['src'],
@@ -111,6 +111,7 @@ export default createComponent(Image, {
       default: 400,
     },
     height: {
+      helperText: 'The image height in pixels',
       type: 'number',
       default: 300,
     },

--- a/packages/toolpad-components/src/List.tsx
+++ b/packages/toolpad-components/src/List.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createComponent, TemplateRenderer } from '@mui/toolpad-core';
+import { TemplateRenderer } from '@mui/toolpad-core';
 import { Box, List as MuiList, ListItem, SxProps } from '@mui/material';
 import { SX_PROP_HELPER_TEXT } from './constants';
+import createBuiltin from './createBuiltin';
 
 export type ListProps = {
   itemCount: number;
@@ -22,7 +23,8 @@ function List({ itemCount, renderItem, disablePadding = false, sx }: ListProps) 
   );
 }
 
-export default createComponent(List, {
+export default createBuiltin(List, {
+  helperText: 'A list component.',
   argTypes: {
     itemCount: {
       helperText: 'Number of items to render.',
@@ -30,6 +32,7 @@ export default createComponent(List, {
       default: 3,
     },
     renderItem: {
+      helperText: 'List item template to render.',
       type: 'template',
       control: { type: 'layoutSlot' },
     },

--- a/packages/toolpad-components/src/Metric.tsx
+++ b/packages/toolpad-components/src/Metric.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Skeleton, Typography, Paper } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
 import {
   NumberFormat,
   createFormat,
   NUMBER_FORMAT_SCHEMA,
   FormattedNumber,
 } from '@mui/toolpad-core/numberFormat';
+import createBuiltin from './createBuiltin';
 
 export interface ColorScaleStop {
   value: number;
@@ -78,7 +78,7 @@ function Metric({
   );
 }
 
-export default createComponent(Metric, {
+export default createBuiltin(Metric, {
   helperText:
     'The Metric component can be used to display a single numerical value. it supports multiple numerical formats such as bytes, currency, percentage... It also supports conditional formatting to adapt the color based on the numerical value.',
   loadingPropSource: ['value'],

--- a/packages/toolpad-components/src/PageColumn.tsx
+++ b/packages/toolpad-components/src/PageColumn.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Box } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 
 export interface PageColumnProps {
   gap?: number;
@@ -23,13 +23,16 @@ function PageColumn({ gap, children }: PageColumnProps) {
   );
 }
 
-export default createComponent(PageColumn, {
+export default createBuiltin(PageColumn, {
+  helperText: 'A page column component.',
   argTypes: {
     gap: {
+      helperText: 'The gap between children.',
       type: 'number',
       default: 1,
     },
     children: {
+      helperText: 'The content of the component.',
       type: 'element',
       control: { type: 'slots' },
     },

--- a/packages/toolpad-components/src/PageRow.tsx
+++ b/packages/toolpad-components/src/PageRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Box } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 
 export interface PageRowProps {
   layoutColumnSizes?: number[];
@@ -28,14 +28,17 @@ function PageRow({ layoutColumnSizes = [], gap, children }: PageRowProps) {
   );
 }
 
-export default createComponent(PageRow, {
+export default createBuiltin(PageRow, {
+  helperText: 'A page row component.',
   argTypes: {
     gap: {
+      helperText: 'The gap between children.',
       type: 'number',
       default: 1,
       minimum: 1,
     },
     children: {
+      helperText: 'The content of the component.',
       type: 'element',
       control: { type: 'slots' },
     },

--- a/packages/toolpad-components/src/Paper.tsx
+++ b/packages/toolpad-components/src/Paper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Paper as MuiPaper, PaperProps as MuiPaperProps } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import { SX_PROP_HELPER_TEXT } from './constants';
 
 function Paper({ children, sx, ...rest }: MuiPaperProps) {
@@ -11,7 +11,8 @@ function Paper({ children, sx, ...rest }: MuiPaperProps) {
   );
 }
 
-export default createComponent(Paper, {
+export default createBuiltin(Paper, {
+  helperText: 'A paper component.',
   layoutDirection: 'vertical',
   argTypes: {
     elevation: {
@@ -22,6 +23,7 @@ export default createComponent(Paper, {
       default: 1,
     },
     children: {
+      helperText: 'The content of the component.',
       type: 'element',
       control: { type: 'layoutSlot' },
     },

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TextFieldProps, MenuItem, TextField } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import {
   FORM_INPUT_ARG_TYPES,
   FormInputComponentProps,
@@ -85,7 +85,7 @@ function Select({
 
 const FormWrappedSelect = withComponentForm(Select);
 
-export default createComponent(FormWrappedSelect, {
+export default createBuiltin(FormWrappedSelect, {
   helperText: 'The Select component lets you select a value from a set of options.',
   layoutDirection: 'both',
   loadingPropSource: ['value', 'options'],

--- a/packages/toolpad-components/src/Stack.tsx
+++ b/packages/toolpad-components/src/Stack.tsx
@@ -1,32 +1,39 @@
 import { Stack } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import { SX_PROP_HELPER_TEXT } from './constants';
 
-export default createComponent(Stack, {
+export default createBuiltin(Stack, {
+  helperText: 'A stack component.',
   argTypes: {
     direction: {
+      helperText: 'The flex layout direction.',
       type: 'string',
       enum: ['row', 'row-reverse', 'column', 'column-reverse'],
       default: 'row',
     },
     alignItems: {
+      helperText: 'The flex layout align items.',
       type: 'string',
       enum: ['start', 'center', 'end', 'stretch', 'baseline'],
       default: 'start',
     },
     justifyContent: {
+      helperText: 'The flex layout justify content.',
       type: 'string',
       enum: ['start', 'center', 'end', 'space-between', 'space-around', 'space-evenly'],
       default: 'start',
     },
     gap: {
+      helperText: 'The gap between children.',
       type: 'number',
       default: 2,
     },
     margin: {
+      helperText: 'The margin around the component.',
       type: 'number',
     },
     children: {
+      helperText: 'The content of the component.',
       type: 'element',
       control: { type: 'slots' },
     },

--- a/packages/toolpad-components/src/Tabs.tsx
+++ b/packages/toolpad-components/src/Tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tabs as MUITabs, Tab } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 
 interface TabProps {
   title: string;
@@ -29,7 +29,8 @@ function Tabs({ value, onChange, tabs, defaultValue }: TabsProps) {
   );
 }
 
-export default createComponent(Tabs, {
+export default createBuiltin(Tabs, {
+  helperText: 'A tabs component.',
   layoutDirection: 'horizontal',
   argTypes: {
     value: {

--- a/packages/toolpad-components/src/Text.tsx
+++ b/packages/toolpad-components/src/Text.tsx
@@ -8,9 +8,10 @@ import {
   TextareaAutosize,
   SxProps,
 } from '@mui/material';
-import { createComponent, useNode } from '@mui/toolpad-core';
+import { useNode } from '@mui/toolpad-core';
 import ErrorIcon from '@mui/icons-material/Error';
 import { errorFrom } from '@mui/toolpad-utils/errors';
+import createBuiltin from './createBuiltin';
 import { SX_PROP_HELPER_TEXT } from './constants';
 
 const Markdown = React.lazy(async () => import('markdown-to-jsx'));
@@ -279,7 +280,7 @@ function Text(props: TextProps) {
   }
 }
 
-export default createComponent(Text, {
+export default createBuiltin(Text, {
   helperText:
     'The Text component lets you display text. Text can be rendered in multiple forms: plain, as a link, or as markdown.',
   layoutDirection: 'both',
@@ -307,7 +308,7 @@ export default createComponent(Text, {
       helperText: 'The url that is being linked.',
       type: 'string',
       default: 'about:blank',
-      visible: ({ mode }) => mode === 'link',
+      visible: ({ mode }: TextProps) => mode === 'link',
     },
     variant: {
       helperText:
@@ -316,7 +317,7 @@ export default createComponent(Text, {
       enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2'],
       default: 'body1',
       label: 'Variant',
-      visible: ({ mode }) => mode === 'text',
+      visible: ({ mode }: TextProps) => mode === 'text',
     },
     loading: {
       helperText:
@@ -327,7 +328,7 @@ export default createComponent(Text, {
     sx: {
       helperText: SX_PROP_HELPER_TEXT,
       type: 'object',
-      visible: ({ mode }) => mode !== 'markdown',
+      visible: ({ mode }: TextProps) => mode !== 'markdown',
     },
   },
 });

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -4,7 +4,7 @@ import {
   TextFieldProps as MuiTextFieldProps,
   BoxProps,
 } from '@mui/material';
-import { createComponent } from '@mui/toolpad-core';
+import createBuiltin from './createBuiltin';
 import {
   FORM_INPUT_ARG_TYPES,
   FORM_TEXT_INPUT_ARG_TYPES,
@@ -65,7 +65,7 @@ function TextField({
 
 const FormWrappedTextField = withComponentForm(TextField);
 
-export default createComponent(FormWrappedTextField, {
+export default createBuiltin(FormWrappedTextField, {
   helperText: 'The TextField component lets you input a text value.',
   layoutDirection: 'both',
   argTypes: {

--- a/packages/toolpad-components/src/createBuiltin.tsx
+++ b/packages/toolpad-components/src/createBuiltin.tsx
@@ -1,0 +1,24 @@
+import { ArgTypeDefinition, ComponentConfig, createComponent } from '@mui/toolpad-core';
+
+export type BuiltinArgTypeDefinition<P extends object, K extends keyof P> = ArgTypeDefinition<
+  P,
+  K
+> & {
+  helperText: string;
+};
+
+export type BuiltinArgTypeDefinitions<P extends object> = {
+  [K in keyof P & string]?: BuiltinArgTypeDefinition<P, K> | undefined;
+};
+
+export type BuiltinComponentConfig<P extends object> = ComponentConfig<P> & {
+  helperText: string;
+  argTypes: BuiltinArgTypeDefinitions<P>;
+};
+
+export default function createBuiltin<P extends object>(
+  Component: React.ComponentType<P>,
+  config: BuiltinComponentConfig<P>,
+) {
+  return createComponent(Component, config);
+}


### PR DESCRIPTION
Starting an effort in improving component documentation.

This change marks `helperText` as a mandatory property on Builtin components and argTypes of builtin components