### PR TITLE
[docs] Follow Docs-infra default design

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -1,14 +1,9 @@
 import type { MuiPage } from '@mui/monorepo/docs/src/MuiPage';
-import BuildIcon from '@mui/icons-material/Build';
-import CodeIcon from '@mui/icons-material/Code';
-import DescriptionIcon from '@mui/icons-material/Description';
-import VisibilityIcon from '@mui/icons-material/Visibility';
 import componentsManifest from './toolpad/reference/components/manifest.json';
 
 const pages: MuiPage[] = [
   {
     pathname: '/toolpad/getting-started',
-    icon: DescriptionIcon,
     children: [
       { pathname: '/toolpad/getting-started/overview' },
       { pathname: '/toolpad/getting-started/installation' },
@@ -26,7 +21,6 @@ const pages: MuiPage[] = [
   },
   {
     pathname: '/toolpad/concepts',
-    icon: VisibilityIcon,
     children: [
       {
         pathname: '/toolpad/concepts/building-ui',
@@ -71,7 +65,6 @@ const pages: MuiPage[] = [
   {
     pathname: '/toolpad/how-to-guides',
     title: 'How-to guides',
-    icon: BuildIcon,
     children: [
       {
         pathname: '/toolpad/how-to-guides/connect-to-datasource',
@@ -136,7 +129,6 @@ const pages: MuiPage[] = [
   {
     pathname: '/toolpad/reference-group',
     title: 'Reference',
-    icon: CodeIcon,
     children: [
       {
         pathname: '/toolpad/reference/file-schema',


### PR DESCRIPTION
Danilo nor I intended for this to work:

Before:

<img width="293" alt="Screenshot 2023-08-08 at 21 55 18" src="https://github.com/mui/mui-toolpad/assets/3165635/bf994492-bfb2-4b4b-b7df-a750eb8aca44">

https://mui.com/toolpad/getting-started/first-app/

After https://deploy-preview-2458--mui-toolpad-docs.netlify.app/toolpad/getting-started/first-app/