### PR TITLE
Fix full page error overflow

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ErrorAlert.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ErrorAlert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, AlertTitle, IconButton, Collapse, Box } from '@mui/material';
+import { Alert, AlertTitle, IconButton, Collapse, Box, SxProps } from '@mui/material';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { indent } from '@mui/toolpad-utils/strings';
@@ -7,6 +7,7 @@ import Pre from '../../../components/Pre';
 
 export interface ErrorAlertProps {
   error: unknown;
+  sx?: SxProps;
 }
 
 function formatStack(maybeError: unknown): string | null {
@@ -27,7 +28,7 @@ function formatStack(maybeError: unknown): string | null {
   return thisStack || causeStack ? [thisStack, causeStack].filter(Boolean).join('\n') : null;
 }
 
-export default function ErrorAlert({ error }: ErrorAlertProps) {
+export default function ErrorAlert({ error, sx }: ErrorAlertProps) {
   const message: string =
     typeof (error as any)?.message === 'string' ? (error as any).message : String(error);
   const stack: string | null = formatStack(error);
@@ -36,7 +37,7 @@ export default function ErrorAlert({ error }: ErrorAlertProps) {
   const toggleExpanded = React.useCallback(() => setExpanded((actual) => !actual), []);
 
   return (
-    <Alert severity="error" sx={{ position: 'relative', m: 1 }}>
+    <Alert severity="error" sx={{ ...sx, position: 'relative' }}>
       {stack ? (
         <IconButton
           color="inherit"

--- a/packages/toolpad-app/src/toolpad/Toolpad.tsx
+++ b/packages/toolpad-app/src/toolpad/Toolpad.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from '../ThemeContext';
 
 const Centered = styled('div')({
   height: '100%',
+  width: '100%',
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
@@ -28,8 +29,8 @@ interface FullPageErrorProps {
 
 function FullPageError({ error }: FullPageErrorProps) {
   return (
-    <Centered>
-      <ErrorAlert error={error} />
+    <Centered sx={{ p: 4 }}>
+      <ErrorAlert sx={{ width: '100%' }} error={error} />
     </Centered>
   );
 }

--- a/packages/toolpad-app/src/toolpadDataSources/QueryPreview.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/QueryPreview.tsx
@@ -17,7 +17,7 @@ export default function QueryPreview({ children, error, isLoading }: QueryPrevie
     >
       {isLoading ? <LinearProgress /> : null}
       <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-        {error ? <ErrorAlert error={error} /> : children}
+        {error ? <ErrorAlert sx={{ m: 2 }} error={error} /> : children}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Suspense fallback error message is very hard to read

Before:
<img width="961" alt="Screenshot 2023-08-09 at 10 40 45" src="https://github.com/mui/mui-toolpad/assets/2109932/06869fdd-d421-4100-a61f-2055fc886a04">

After:
<img width="966" alt="Screenshot 2023-08-09 at 10 40 28" src="https://github.com/mui/mui-toolpad/assets/2109932/64ed1349-77fc-44d7-8d0b-c20438f99192">
