### PR TITLE
Fix cycle of SIGINT disposal event

### DIFF
--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -21,7 +21,7 @@ async function runCommand(cmd: 'dev' | 'start', { dir, ...args }: Omit<RunOption
     cmd,
   });
 
-  process.on('SIGINT', () => {
+  process.once('SIGINT', () => {
     app.dispose().then(() => {
       process.exit(0);
     });

--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -22,7 +22,7 @@ async function runCommand(cmd: 'dev' | 'start', { dir, ...args }: Omit<RunOption
   });
 
   process.once('SIGINT', () => {
-    app.dispose().then(() => {
+    app.dispose().finally(() => {
       process.exit(0);
     });
   });


### PR DESCRIPTION
This `process.on` was causing a cycle of `SIGINT` signals, stopping the app from terminating.
Using `process.once` instead of `process.on` seems to not cause the cycle.