### PR TITLE
[core] Remove dead code html meta

### DIFF
--- a/packages/toolpad-app/src/toolpad/index.html
+++ b/packages/toolpad-app/src/toolpad/index.html
@@ -7,7 +7,6 @@
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
     />
     <link rel="manifest" href="/static/manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />


### PR DESCRIPTION
I kept the version documented in https://mui.com/material-ui/getting-started/usage/#responsive-meta-tag.