### PR TITLE
[Enhancement] Edit page title from page editor

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageOptionsPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageOptionsPanel.tsx
@@ -6,6 +6,7 @@ import QueryEditor from './QueryEditor';
 import UrlQueryEditor from './UrlQueryEditor';
 import NodeNameEditor from '../NodeNameEditor';
 import * as appDom from '../../../appDom';
+import PageTitleEditor from '../PageTitleEditor';
 
 const PAGE_DISPLAY_OPTIONS: { value: appDom.PageDisplayMode; label: string }[] = [
   { value: 'shell', label: 'App shell' },
@@ -38,6 +39,7 @@ export default function PageOptionsPanel() {
     <Stack spacing={1} alignItems="start" data-testid="page-editor">
       <Typography variant="subtitle1">Page:</Typography>
       <NodeNameEditor node={page} />
+      <PageTitleEditor node={page} />
       <TextField
         select
         defaultValue="shell"

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageTitleEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageTitleEditor.tsx
@@ -7,6 +7,13 @@ interface PageTitleEditorProps {
   node: PageNode;
 }
 
+function validateInput(input: string) {
+  if (!input) {
+    return 'Input required';
+  }
+  return null;
+}
+
 export default function PageTitleEditor({ node }: PageTitleEditorProps) {
   const domApi = useDomApi();
   const [pageTitleInput, setPageTitleInput] = React.useState(node.attributes.title);
@@ -30,13 +37,6 @@ export default function PageTitleEditor({ node }: PageTitleEditorProps) {
     },
     [handleCommit],
   );
-
-  const validateInput = (input: string) => {
-    if (!input) {
-      return 'Input required';
-    }
-    return null;
-  };
 
   return (
     <TextField

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageTitleEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageTitleEditor.tsx
@@ -1,8 +1,7 @@
 import { TextField } from '@mui/material';
 import * as React from 'react';
-import { AppDom, PageNode } from '../../appDom';
+import { AppDom, PageNode, setNodeNamespacedProp } from '../../appDom';
 import { useDomApi } from '../AppState';
-import { update } from '../../utils/immutability';
 
 interface PageTitleEditorProps {
   node: PageNode;
@@ -11,7 +10,6 @@ interface PageTitleEditorProps {
 export default function PageTitleEditor({ node }: PageTitleEditorProps) {
   const domApi = useDomApi();
   const [pageTitleInput, setPageTitleInput] = React.useState(node.attributes.title);
-  const [isValid, setIsValid] = React.useState(true);
 
   const handlePageTitleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => setPageTitleInput(event.target.value),
@@ -19,20 +17,10 @@ export default function PageTitleEditor({ node }: PageTitleEditorProps) {
   );
 
   const handleCommit = React.useCallback(() => {
-    if (!isValid) {
-      return;
-    }
-    domApi.update((appDom: AppDom) => {
-      return update(appDom, {
-        nodes: update(appDom.nodes, {
-          [node.id]: {
-            ...node,
-            attributes: { ...node.attributes, title: pageTitleInput },
-          },
-        }),
-      });
-    });
-  }, [domApi, node, pageTitleInput, isValid]);
+    domApi.update((appDom: AppDom) =>
+      setNodeNamespacedProp(appDom, node, 'attributes', 'title', pageTitleInput),
+    );
+  }, [node, pageTitleInput, domApi]);
 
   const handleKeyPress = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -43,13 +31,12 @@ export default function PageTitleEditor({ node }: PageTitleEditorProps) {
     [handleCommit],
   );
 
-  React.useEffect(() => {
-    if (!pageTitleInput) {
-      setIsValid(false);
-      return;
+  const validateInput = (input: string) => {
+    if (!input) {
+      return 'Input required';
     }
-    setIsValid(true);
-  }, [pageTitleInput]);
+    return null;
+  };
 
   return (
     <TextField
@@ -59,8 +46,8 @@ export default function PageTitleEditor({ node }: PageTitleEditorProps) {
       onChange={handlePageTitleChange}
       onBlur={handleCommit}
       onKeyDown={handleKeyPress}
-      error={!isValid}
-      helperText={!isValid && 'Title cannot be empty'}
+      error={!pageTitleInput}
+      helperText={validateInput(pageTitleInput)}
     />
   );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageTitleEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageTitleEditor.tsx
@@ -1,0 +1,66 @@
+import { TextField } from '@mui/material';
+import * as React from 'react';
+import { AppDom, PageNode } from '../../appDom';
+import { useDomApi } from '../AppState';
+import { update } from '../../utils/immutability';
+
+interface PageTitleEditorProps {
+  node: PageNode;
+}
+
+export default function PageTitleEditor({ node }: PageTitleEditorProps) {
+  const domApi = useDomApi();
+  const [pageTitleInput, setPageTitleInput] = React.useState(node.attributes.title);
+  const [isValid, setIsValid] = React.useState(true);
+
+  const handlePageTitleChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => setPageTitleInput(event.target.value),
+    [],
+  );
+
+  const handleCommit = React.useCallback(() => {
+    if (!isValid) {
+      return;
+    }
+    domApi.update((appDom: AppDom) => {
+      return update(appDom, {
+        nodes: update(appDom.nodes, {
+          [node.id]: {
+            ...node,
+            attributes: { ...node.attributes, title: pageTitleInput },
+          },
+        }),
+      });
+    });
+  }, [domApi, node, pageTitleInput, isValid]);
+
+  const handleKeyPress = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.code === 'Enter') {
+        handleCommit();
+      }
+    },
+    [handleCommit],
+  );
+
+  React.useEffect(() => {
+    if (!pageTitleInput) {
+      setIsValid(false);
+      return;
+    }
+    setIsValid(true);
+  }, [pageTitleInput]);
+
+  return (
+    <TextField
+      fullWidth
+      label="Page title"
+      value={pageTitleInput}
+      onChange={handlePageTitleChange}
+      onBlur={handleCommit}
+      onKeyDown={handleKeyPress}
+      error={!isValid}
+      helperText={!isValid && 'Title cannot be empty'}
+    />
+  );
+}


### PR DESCRIPTION
This PR adds a Textfield to the page panel and allows a user to change their page title. It closes #2125.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I've read and followed the [contributing guide](https://github.com/mui/mui-toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [ ] I've updated the relevant documentation for any new or updated feature
- [x] I've linked relevant GitHub issue with "Closes #<issue id>"
- [x] I've added a visual demonstration under the form of a screenshot or video
![image](https://github.com/mui/mui-toolpad/assets/52700465/389b2018-5fe7-43cd-87ea-65d5e3ecfdd6)

