### PR TITLE
Support reading cookies in backend functions

### DIFF
--- a/docs/data/toolpad/concepts/custom-functions.md
+++ b/docs/data/toolpad/concepts/custom-functions.md
@@ -139,3 +139,18 @@ export async function askGPT(messages: string[]) {
 You can then use this function on your page:
 
 {{"component": "modules/components/DocsImage.tsx", "src": "/static/toolpad/docs/concepts/connecting-to-data/ask-gpt.gif", "alt": "Custom function with secret", "caption": "Using a custom function with environment variables", "indent": 1 }}
+
+## Request context
+
+When you run Toolpad in an authenticated context it may be useful to be able to access authentication information in backend functions. For this purpose we offer the `getContext` API which allows you to inspect the cookies of the request that initiated the backend function.
+
+```jsx
+import { getContext } from '@mui/toolpad/server';
+import { parseAuth } from '../../src/lib/auth';
+
+export async function myBackendFunction() {
+  const ctx = getContext();
+  const user = await parseAuth(ctx.cookie.authentication);
+  return user?.id;
+}
+```

--- a/docs/data/toolpad/reference/api/get-context.md
+++ b/docs/data/toolpad/reference/api/get-context.md
@@ -1,0 +1,48 @@
+# getContext API
+
+<p class="description">Support reading contextual information in backend functions.</p>
+
+```jsx
+import { getContext } from '@mui/toolpad/server';
+```
+
+## Description
+
+```jsx
+import { getContext } from '@mui/toolpad/server';
+import { parseAuth } from '../../src/lib/auth';
+
+export async function myBackendFunction() {
+  const ctx = getContext();
+  const user = await parseAuth(ctx.cookie.authentication);
+  return user?.id;
+}
+```
+
+Within backend functions, you can call `getContext` to get access to the request context that resulted in calling this backend function. This is useful if you are running Toolpad in an authenticated context and want to reuse access tokens available in a cookie.
+
+## Parameters
+
+No parameters
+
+## Returns
+
+a `ServerContext` containing information on the context the backend function was called under.
+
+## types
+
+### ServerContext
+
+This described a certain context under which a backend function was called.
+
+**Properties**
+
+| Name      | Type                     | Description                                       |
+| :-------- | :----------------------- | :------------------------------------------------ |
+| `cookies` | `Record<string, string>` | A dictionary mapping cookie name to cookie value. |
+
+## Usage
+
+:::info
+See [custom functions](/toolpad/concepts/custom-functions/)
+:::

--- a/packages/toolpad-app/src/server/DataManager.ts
+++ b/packages/toolpad-app/src/server/DataManager.ts
@@ -1,4 +1,5 @@
 import { NodeId, ExecFetchResult } from '@mui/toolpad-core';
+import { withContext, createServerContext } from '@mui/toolpad-core/server';
 import { createServerJsRuntime } from '@mui/toolpad-core/jsServerRuntime';
 import express from 'express';
 import cors from 'cors';
@@ -181,7 +182,10 @@ export default class DataManager {
         }
 
         try {
-          const result = await this.execQuery(dataNode, req.body);
+          const ctx = createServerContext(req);
+          const result = await withContext(ctx, async () => {
+            return this.execQuery(dataNode, req.body);
+          });
           res.json(withSerializedError(result));
         } catch (error) {
           res.json(withSerializedError({ error }));

--- a/packages/toolpad-app/src/server/rpc.ts
+++ b/packages/toolpad-app/src/server/rpc.ts
@@ -5,6 +5,7 @@ import * as z from 'zod';
 import { fromZodError } from 'zod-validation-error';
 import { hasOwnProperty } from '@mui/toolpad-utils/collections';
 import { errorFrom, serializeError } from '@mui/toolpad-utils/errors';
+import { withContext, createServerContext } from '@mui/toolpad-core/server';
 import { asyncHandler } from '../utils/express';
 import type { ToolpadProject } from './localMode';
 
@@ -74,7 +75,10 @@ export function createRpcHandler(definition: Definition): express.RequestHandler
       let rawResult;
       let error: Error | null = null;
       try {
-        rawResult = await method({ params, req, res });
+        const ctx = createServerContext(req);
+        rawResult = await withContext(ctx, async () => {
+          return method({ params, req, res });
+        });
       } catch (rawError) {
         error = errorFrom(rawError);
       }

--- a/packages/toolpad-core/package.json
+++ b/packages/toolpad-core/package.json
@@ -45,12 +45,14 @@
     "@mui/toolpad-utils": "0.1.23",
     "@tanstack/react-query": "4.32.6",
     "@types/json-schema": "^7.0.12",
+    "cookie": "0.5.0",
     "invariant": "2.2.4",
     "quickjs-emscripten": "0.23.0",
     "react-error-boundary": "4.0.11",
     "react-is": "18.2.0"
   },
   "devDependencies": {
+    "@types/cookie": "0.5.1",
     "@types/react-is": "18.2.1",
     "concurrently": "8.2.0"
   },

--- a/packages/toolpad-core/src/index.tsx
+++ b/packages/toolpad-core/src/index.tsx
@@ -27,5 +27,3 @@ export * from './constants';
 export * from './browser';
 
 export * from './types';
-
-export * from './server';

--- a/test/integration/backend-basic/fixture/toolpad/pages/basic/page.yml
+++ b/test/integration/backend-basic/fixture/toolpad/pages/basic/page.yml
@@ -147,6 +147,15 @@ spec:
             value:
               $$jsExpression: |
                 `Raw text: ${getRawText.data}`
+    - component: PageRow
+      name: pageRow14
+      children:
+        - component: Text
+          name: text7
+          props:
+            value:
+              $$jsExpression: |
+                `my custom cookie: ${context.data.cookies.MY_TOOLPAD_COOKIE}`
   queries:
     - name: hello
       query:
@@ -226,4 +235,8 @@ spec:
     - name: getRawText
       query:
         function: functions.ts#getRawText
+        kind: local
+    - name: context
+      query:
+        function: functions.ts#inspectContext
         kind: local

--- a/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
+++ b/test/integration/backend-basic/fixture/toolpad/resources/functions.ts
@@ -1,4 +1,4 @@
-import { createFunction } from '@mui/toolpad/server';
+import { createFunction, getContext } from '@mui/toolpad/server';
 import rawText from './raw.txt';
 import rawSql from './raw.sql';
 
@@ -127,4 +127,8 @@ export function neverResolving() {
 
 export async function getRawText() {
   return [rawText, rawSql].join(' | ');
+}
+
+export async function inspectContext() {
+  return getContext();
 }

--- a/test/integration/backend-basic/index.spec.ts
+++ b/test/integration/backend-basic/index.spec.ts
@@ -32,7 +32,11 @@ test.use({
   },
 });
 
-test('functions basics', async ({ page }) => {
+test('functions basics', async ({ page, context }) => {
+  await context.addCookies([
+    { name: 'MY_TOOLPAD_COOKIE', value: 'foo-bar-baz', domain: 'localhost', path: '/' },
+  ]);
+
   const runtimeModel = new ToolpadRuntime(page);
   await runtimeModel.gotoPage('basic');
 

--- a/test/integration/backend-basic/prod.spec.ts
+++ b/test/integration/backend-basic/prod.spec.ts
@@ -24,7 +24,11 @@ test.use({
   },
 });
 
-test('functions basics', async ({ page }) => {
+test('functions basics', async ({ page, context }) => {
+  await context.addCookies([
+    { name: 'MY_TOOLPAD_COOKIE', value: 'foo-bar-baz', domain: 'localhost', path: '/' },
+  ]);
+
   const runtimeModel = new ToolpadRuntime(page, { prod: true });
   await runtimeModel.gotoPage('basic');
 

--- a/test/integration/backend-basic/shared.ts
+++ b/test/integration/backend-basic/shared.ts
@@ -19,4 +19,5 @@ export async function expectBasicPageContent(page: Page) {
   await expect(
     page.getByText("Raw text: Hello, I'm raw text! | SELECT NOW()", { exact: true }),
   ).toBeVisible();
+  await expect(page.getByText('my custom cookie: foo-bar-baz', { exact: true })).toBeVisible();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,6 +3035,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.5.1.tgz#b29aa1f91a59f35e29ff8f7cb24faf1a3a750554"
+  integrity sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==
+
 "@types/cors@2.8.13":
   version "2.8.13"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.13.tgz#b8ade22ba455a1b8cb3b5d3f35910fd204f84f94"


### PR DESCRIPTION
Fixes https://github.com/mui/mui-toolpad/issues/2468

This proposes to add a `getContext` method which returns the context under which a backend function was called. The context contains a dictionary that maps cookie name to cookie value. We can expand this interface as more use cases arise.