### PR TITLE
Use page name on preview url

### DIFF
--- a/packages/toolpad-app/src/runtime/AppNavigation.tsx
+++ b/packages/toolpad-app/src/runtime/AppNavigation.tsx
@@ -54,8 +54,8 @@ export default function AppNavigation({ pages, clipped = false }: AppNavigationP
             <ListItem key={page.id} disablePadding>
               <ListItemButton
                 component={Link}
-                to={`pages/${page.id}${search}`}
-                selected={activePagePath === `/pages/${page.id}`}
+                to={`pages/${page.name}${search}`}
+                selected={activePagePath === `/pages/${page.name}`}
               >
                 <ListItemText primary={page.name} sx={{ ml: 2 }} />
               </ListItemButton>

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -98,7 +98,7 @@ const Pre = styled('pre')(({ theme }) => ({
   fontFamily: theme.fontFamilyMonospaced,
 }));
 
-const PREVIEW_PAGE_ROUTE = '/preview/pages/:nodeId';
+const PREVIEW_PAGE_ROUTE = '/preview/pages/:pageName';
 
 export const internalComponents: ToolpadComponents = Object.fromEntries(
   [...INTERNAL_COMPONENTS].map(([name]) => {
@@ -1419,7 +1419,7 @@ function RenderedPages({ pages, defaultPage }: RenderedPagesProps) {
       {pages.map((page) => (
         <React.Fragment key={page.id}>
           <Route
-            path={`/pages/${page.id}`}
+            path={`/pages/${page.name}`}
             element={
               <RenderedPage
                 nodeId={page.id}
@@ -1434,8 +1434,8 @@ function RenderedPages({ pages, defaultPage }: RenderedPagesProps) {
       {pages.map((page) => (
         <React.Fragment key={page.id}>
           <Route
-            path={`/pages/${page.name}`}
-            element={<Navigate to={`/pages/${page.id}`} replace />}
+            path={`/pages/${page.id}`}
+            element={<Navigate to={`/pages/${page.name}`} replace />}
           />
         </React.Fragment>
       ))}
@@ -1493,9 +1493,10 @@ function ToolpadAppLayout({ dom, hasShell: hasShellProp = true }: ToolpadAppLayo
   const urlParams = React.useMemo(() => new URLSearchParams(search), [search]);
 
   const pageMatch = matchPath(PREVIEW_PAGE_ROUTE, `/preview${pathname}`);
-  const pageId = pageMatch?.params.nodeId;
+  const pageName = pageMatch?.params.pageName;
 
   const defaultPage = pages[0];
+  const pageId = appDom.getNodeIdByName(dom, pageName as string);
   const page = pageId ? appDom.getMaybeNode(dom, pageId as NodeId, 'page') : defaultPage;
 
   const displayMode = urlParams.get('toolpad-display') || page?.attributes.display;
@@ -1506,7 +1507,7 @@ function ToolpadAppLayout({ dom, hasShell: hasShellProp = true }: ToolpadAppLayo
 
   return (
     <React.Fragment>
-      {showPreviewHeader ? <PreviewHeader pageId={pageId} /> : null}
+      {showPreviewHeader ? <PreviewHeader pageId={pageId as NodeId} /> : null}
       <Box sx={{ flex: 1, display: 'flex' }}>
         {hasShell && pages.length > 0 ? (
           <AppNavigation pages={pages} clipped={showPreviewHeader} />


### PR DESCRIPTION
Uses page name on url pathname, and replaces previous use of id.

For backwards compatibility, if url uses id, it is redirected to url using page e.g `/pages/5q1xd0t` will be redirected to `/pages/basic_class`

Closes #1905 
![pageNameInUrl](https://github.com/mui/mui-toolpad/assets/52700465/dd2323d0-2f3f-498a-ab02-4de43986cfa3)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I've read and followed the [contributing guide](https://github.com/mui/mui-toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [x] I've linked relevant GitHub issue with "Closes #<issue id>"
- [x] I've added a visual demonstration under the form of a screenshot or video
