### PR TITLE
Add an explanation on why we use structuredClone in the canvas

### DIFF
--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -106,6 +106,14 @@ export default function AppCanvas({
     );
 
     const unsetUpdate = setCommandHandler(bridge.canvasCommands, 'update', (newState) => {
+      // `update` will be called from the parent window. Since the canvas runs in an iframe, it's
+      // running in another javascript realm than the one this object was constructed in. This makes
+      // the MUI core `deepMerge` function fail. The `deepMerge` function uses `isPLainObject` which checks
+      // whether the object constructor property is the global `Object`. Since different realms have
+      // different globals, this function erroneously marks it as not being a plain object.
+      // For now we've use structuredClone to make the `update` method behave as if it was built using
+      // `window.postMessage`, which we should probably move towards anyways at some point. structuredClone
+      // clones the object as if it was passed using `postMessage` and corrects the `constructor` property.
       React.startTransition(() => setState(structuredClone(newState)));
     });
 

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -108,9 +108,10 @@ export default function AppCanvas({
     const unsetUpdate = setCommandHandler(bridge.canvasCommands, 'update', (newState) => {
       // `update` will be called from the parent window. Since the canvas runs in an iframe, it's
       // running in another javascript realm than the one this object was constructed in. This makes
-      // the MUI core `deepMerge` function fail. The `deepMerge` function uses `isPLainObject` which checks
-      // whether the object constructor property is the global `Object`. Since different realms have
-      // different globals, this function erroneously marks it as not being a plain object.
+      // the MUI core `deepMerge` function fail. The `deepMerge` function uses `isPlainObject` which checks
+      // whether the object constructor property is the global `Object`.
+      // See https://github.com/mui/material-ui/blob/b935d3e8f48b5d54f6cd08154fe2f7aa035ab576/packages/mui-utils/src/deepmerge.ts#L2.
+      // Since different realms have different globals, this function erroneously marks it as not being a plain object.
       // For now we've use structuredClone to make the `update` method behave as if it was built using
       // `window.postMessage`, which we should probably move towards anyways at some point. structuredClone
       // clones the object as if it was passed using `postMessage` and corrects the `constructor` property.


### PR DESCRIPTION
Since it came up in last grooming session, let's document why we do this.

Adding a clarification on why we used `structuredClone`

> `update` will be called from the parent window. Since the canvas runs in an iframe, it's running in another javascript realm than the one this object was constructed in. This makes the MUI core `deepMerge` function fail. The `deepMerge` function uses `isPlainObject` which checks whether the object constructor property is the global `Object`. See https://github.com/mui/material-ui/blob/b935d3e8f48b5d54f6cd08154fe2f7aa035ab576/packages/mui-utils/src/deepmerge.ts#L2 Since different realms have different globals, this function erroneously marks it as not being a plain object. For now we've use structuredClone to make the `update` method behave as if it was built using `window.postMessage`, which we should probably move towards anyways at some point. structuredClone clones the object as if it was passed using `postMessage` and corrects the `constructor` property.

cc @mui/core because this is an edge case on the [`isPlainObject`](https://github.com/mui/material-ui/blob/b935d3e8f48b5d54f6cd08154fe2f7aa035ab576/packages/mui-utils/src/deepmerge.ts#L2) function which doesn't work correctly cross-realm. It's quite an edge case but maybe there have been some issues reported around this before?

_edit: Just found https://github.com/mui/material-ui/issues/23739_