### PR TITLE
Add build step after installing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "check-types": "lerna run check-types",
     "toolpad": "toolpad",
     "jsonSchemas": "tsx ./scripts/docs/generateJsonSchemas.ts",
-    "test:rest:start": "tsx ./scripts/restTestServer.ts"
+    "test:rest:start": "tsx ./scripts/restTestServer.ts",
+    "postinstall": "lerna run build --scope @mui/toolpad-core --scope @mui/toolpad-components --stream"
   },
   "devDependencies": {
     "@argos-ci/core": "^0.9.0",


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/2499 (possible solution).

This is the exact same script as `test:build`, we can merge them into the same script if it makes sense and we give it a name that works well, or we can keep things as in this PR.