### PR TITLE
Improve open code snackbar

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/CreateCodeComponentNodeDialog.tsx
@@ -112,7 +112,13 @@ export default function CreateCodeComponentDialog({
             anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
             action={
               <React.Fragment>
-                <OpenCodeEditorButton filePath={name} variant="text" fileType="component" />
+                <OpenCodeEditorButton
+                  filePath={name}
+                  variant="text"
+                  fileType="component"
+                  color="primary"
+                  onSuccess={handleSnackbarClose}
+                />
                 <IconButton
                   size="small"
                   aria-label="close"

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/CreateCodeComponentNodeDialog.tsx
@@ -110,7 +110,6 @@ export default function CreateCodeComponentDialog({
             onClose={handleSnackbarClose}
             message={`Component "${lastSnackbarState.name}" created`}
             anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-            autoHideDuration={3000}
             action={
               <React.Fragment>
                 <OpenCodeEditorButton filePath={name} variant="text" fileType="component" />


### PR DESCRIPTION
- Don't autoHide, 99% of the time the user wants to open the code editor after creating a component (3s is way too short to discover and click this button)
- Close the snackbar after opening the code editor
- Add loading state and disable the button while opening the editor (Opened https://github.com/mui/material-ui/issues/38595 along the way)
- 