### PR TITLE
Fix esbuild warning

### DIFF
--- a/packages/toolpad-app/src/server/FunctionsManager.ts
+++ b/packages/toolpad-app/src/server/FunctionsManager.ts
@@ -17,7 +17,7 @@ import { createWorker as createDevWorker } from './functionsDevWorker';
 import type { ExtractTypesParams, IntrospectionResult } from './functionsTypesWorker';
 import { Awaitable } from '../utils/types';
 import { format } from '../utils/prettier';
-import { tsConfig } from './functionsShared';
+import { compilerOptions } from './functionsShared';
 
 function createDefaultFunction(): string {
   return format(`
@@ -188,7 +188,7 @@ export default class FunctionsManager {
       platform: 'node',
       packages: 'external',
       target: 'es2022',
-      tsconfigRaw: JSON.stringify(tsConfig),
+      tsconfigRaw: JSON.stringify({ compilerOptions }),
       loader: {
         '.txt': 'text',
         '.sql': 'text',

--- a/packages/toolpad-app/src/server/functionsShared.ts
+++ b/packages/toolpad-app/src/server/functionsShared.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-export const tsConfig: ts.CompilerOptions = {
+export const compilerOptions: ts.CompilerOptions = {
   noEmit: true,
   target: ts.ScriptTarget.ESNext,
   lib: ['lib.esnext.d.ts'],

--- a/packages/toolpad-app/src/server/functionsTypesWorker.ts
+++ b/packages/toolpad-app/src/server/functionsTypesWorker.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import { JSONSchema7, JSONSchema7TypeName, JSONSchema7Type } from 'json-schema';
 import { asArray } from '@mui/toolpad-utils/collections';
 import { PrimitiveValueType } from '@mui/toolpad-core';
-import { tsConfig } from './functionsShared';
+import { compilerOptions } from './functionsShared';
 
 export interface ReturnTypeIntrospectionResult {
   schema: JSONSchema7 | null;
@@ -397,7 +397,7 @@ export default async function extractTypes({
     windowsPathsNoEscape: true,
   });
 
-  const program = ts.createProgram(entryPoints, tsConfig);
+  const program = ts.createProgram(entryPoints, compilerOptions);
 
   const checker = program.getTypeChecker();
 


### PR DESCRIPTION
Warning coming up since last dependencies update:

```
▲ [WARNING] Expected the "target" option to be nested inside a "compilerOptions" object [tsconfig.json]

    <tsconfig.json>:1:15:
      1 │ {"noEmit":true,"target":99,"lib":["lib.esnext.d.ts"],"types":["node"],"strictNullChecks":true,"module":1,"moduleResolution":100,"esModuleInterop":true,"allowSyntheticDefaultImports":t...
        ╵                ~~~~~~~~
```

We were passing `CompilerOptions` to esbuild instead of `{ compilerOptions: CompilerOptions}`