### PR TITLE
Make module exports compatible with node module resolution in typescript

### DIFF
--- a/packages/toolpad-app/package.json
+++ b/packages/toolpad-app/package.json
@@ -24,7 +24,10 @@
     "public",
     "scripts",
     "dist",
-    "cli.js"
+    "cli.js",
+    "browser",
+    "server",
+    "runtime"
   ],
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
Make sure a default project can resolve the types of the subpath imports `@mui/toolpad/server`, `@mui/toolpad/browser` and `@mui/toolpad/runtime`.

This is a short term solution for https://github.com/mui/mui-toolpad/issues/2519.