### PR TITLE
Remove lodash from @mui/components

### DIFF
--- a/packages/toolpad-components/package.json
+++ b/packages/toolpad-components/package.json
@@ -47,7 +47,6 @@
     "@mui/x-date-pickers": "6.11.2",
     "@mui/x-license-pro": "6.10.2",
     "dayjs": "1.11.9",
-    "lodash-es": "4.17.21",
     "markdown-to-jsx": "7.3.2",
     "react-error-boundary": "4.0.11",
     "react-hook-form": "7.45.4",

--- a/packages/toolpad-components/src/Form.tsx
+++ b/packages/toolpad-components/src/Form.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Container, ContainerProps, Box, Stack, BoxProps } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import { useNode } from '@mui/toolpad-core';
+import { equalProperties } from '@mui/toolpad-utils/collections';
 import { useForm, FieldValues, ValidationMode, FieldError, Controller } from 'react-hook-form';
 import { SX_PROP_HELPER_TEXT } from './constants';
 import createBuiltin, { BuiltinArgTypeDefinitions } from './createBuiltin';
@@ -16,7 +17,7 @@ export const FormContext = React.createContext<{
 
 interface FormProps extends ContainerProps {
   value: FieldValues;
-  onChange?: (newValue: FieldValues) => void;
+  onChange: (newValue: FieldValues) => void;
   onSubmit?: (data?: FieldValues) => unknown | Promise<unknown>;
   formControlsAlign?: BoxProps['justifyContent'];
   formControlsFullWidth?: boolean;
@@ -54,12 +55,12 @@ function Form({
 
   // Set initial form values
   React.useEffect(() => {
-    onChange?.(form.getValues());
+    onChange(form.getValues());
   }, [form, onChange]);
 
   React.useEffect(() => {
     const formSubscription = form.watch((newValue) => {
-      onChange?.(newValue);
+      onChange(newValue);
     });
     return () => formSubscription.unsubscribe();
   }, [form, onChange]);
@@ -185,7 +186,7 @@ interface UseFormInputInput<V> {
   name: string;
   label?: string;
   value?: V;
-  onChange?: (newValue: V) => void;
+  onChange: (newValue: V) => void;
   emptyValue?: V;
   defaultValue?: V;
   validationProps: Partial<
@@ -227,7 +228,7 @@ export function useFormInput<V>({
   const previousDefaultValueRef = React.useRef(defaultValue);
   React.useEffect(() => {
     if (form && defaultValue !== previousDefaultValueRef.current) {
-      onChange?.(defaultValue as V);
+      onChange(defaultValue as V);
       form.setValue(formInputName, defaultValue);
       previousDefaultValueRef.current = defaultValue;
     }
@@ -238,10 +239,10 @@ export function useFormInput<V>({
   React.useEffect(() => {
     if (form) {
       if (!fieldValues[formInputName] && defaultValue && isInitialForm) {
-        onChange?.((defaultValue || emptyValue) as V);
+        onChange((defaultValue || emptyValue) as V);
         form.setValue(formInputName, defaultValue || emptyValue);
       } else if (value !== fieldValues[formInputName]) {
-        onChange?.(fieldValues[formInputName] || emptyValue);
+        onChange(fieldValues[formInputName] || emptyValue);
       }
     }
   }, [defaultValue, emptyValue, fieldValues, form, isInitialForm, formInputName, onChange, value]);
@@ -260,12 +261,7 @@ export function useFormInput<V>({
   React.useEffect(() => {
     if (
       form &&
-      !(
-        validationProps.isInvalid === previousManualValidationPropsRef.current.isInvalid &&
-        validationProps.isRequired === previousManualValidationPropsRef.current.isRequired &&
-        validationProps.minLength === previousManualValidationPropsRef.current.minLength &&
-        validationProps.maxLength === previousManualValidationPropsRef.current.maxLength
-      ) &&
+      !equalProperties(validationProps, previousManualValidationPropsRef.current) &&
       form.formState.dirtyFields[formInputName]
     ) {
       form.trigger(formInputName);
@@ -282,7 +278,7 @@ export function useFormInput<V>({
           shouldTouch: true,
         });
       }
-      onChange?.(newValue);
+      onChange(newValue);
     },
     [form, formInputName, onChange],
   );

--- a/packages/toolpad-components/src/Form.tsx
+++ b/packages/toolpad-components/src/Form.tsx
@@ -3,9 +3,6 @@ import { Container, ContainerProps, Box, Stack, BoxProps } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import { useNode } from '@mui/toolpad-core';
 import { useForm, FieldValues, ValidationMode, FieldError, Controller } from 'react-hook-form';
-// TODO: Remove lodash-es
-// eslint-disable-next-line no-restricted-imports
-import { isEqual } from 'lodash-es';
 import { SX_PROP_HELPER_TEXT } from './constants';
 import createBuiltin, { BuiltinArgTypeDefinitions } from './createBuiltin';
 
@@ -19,7 +16,7 @@ export const FormContext = React.createContext<{
 
 interface FormProps extends ContainerProps {
   value: FieldValues;
-  onChange: (newValue: FieldValues) => void;
+  onChange?: (newValue: FieldValues) => void;
   onSubmit?: (data?: FieldValues) => unknown | Promise<unknown>;
   formControlsAlign?: BoxProps['justifyContent'];
   formControlsFullWidth?: boolean;
@@ -57,12 +54,12 @@ function Form({
 
   // Set initial form values
   React.useEffect(() => {
-    onChange(form.getValues());
+    onChange?.(form.getValues());
   }, [form, onChange]);
 
   React.useEffect(() => {
     const formSubscription = form.watch((newValue) => {
-      onChange(newValue);
+      onChange?.(newValue);
     });
     return () => formSubscription.unsubscribe();
   }, [form, onChange]);
@@ -188,7 +185,7 @@ interface UseFormInputInput<V> {
   name: string;
   label?: string;
   value?: V;
-  onChange: (newValue: V) => void;
+  onChange?: (newValue: V) => void;
   emptyValue?: V;
   defaultValue?: V;
   validationProps: Partial<
@@ -230,7 +227,7 @@ export function useFormInput<V>({
   const previousDefaultValueRef = React.useRef(defaultValue);
   React.useEffect(() => {
     if (form && defaultValue !== previousDefaultValueRef.current) {
-      onChange(defaultValue as V);
+      onChange?.(defaultValue as V);
       form.setValue(formInputName, defaultValue);
       previousDefaultValueRef.current = defaultValue;
     }
@@ -241,10 +238,10 @@ export function useFormInput<V>({
   React.useEffect(() => {
     if (form) {
       if (!fieldValues[formInputName] && defaultValue && isInitialForm) {
-        onChange((defaultValue || emptyValue) as V);
+        onChange?.((defaultValue || emptyValue) as V);
         form.setValue(formInputName, defaultValue || emptyValue);
       } else if (value !== fieldValues[formInputName]) {
-        onChange(fieldValues[formInputName] || emptyValue);
+        onChange?.(fieldValues[formInputName] || emptyValue);
       }
     }
   }, [defaultValue, emptyValue, fieldValues, form, isInitialForm, formInputName, onChange, value]);
@@ -263,7 +260,12 @@ export function useFormInput<V>({
   React.useEffect(() => {
     if (
       form &&
-      !isEqual(validationProps, previousManualValidationPropsRef.current) &&
+      !(
+        validationProps.isInvalid === previousManualValidationPropsRef.current.isInvalid &&
+        validationProps.isRequired === previousManualValidationPropsRef.current.isRequired &&
+        validationProps.minLength === previousManualValidationPropsRef.current.minLength &&
+        validationProps.maxLength === previousManualValidationPropsRef.current.maxLength
+      ) &&
       form.formState.dirtyFields[formInputName]
     ) {
       form.trigger(formInputName);
@@ -280,7 +282,7 @@ export function useFormInput<V>({
           shouldTouch: true,
         });
       }
-      onChange(newValue);
+      onChange?.(newValue);
     },
     [form, formInputName, onChange],
   );

--- a/packages/toolpad-utils/src/collections.spec.ts
+++ b/packages/toolpad-utils/src/collections.spec.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from '@jest/globals';
-import { asArray } from './collections';
+import { asArray, equalProperties } from './collections';
 
 describe('asArray', () => {
   test.each([
@@ -9,5 +9,18 @@ describe('asArray', () => {
     ['', ['']],
   ])('should convert %p to %p', (got, expected) => {
     expect(asArray(got)).toEqual(expected);
+  });
+});
+
+const OBJECT = {};
+
+describe('equalProperties', () => {
+  test.each([
+    [{ a: 1, b: 2 }, { a: 1, b: 2 }, true],
+    [{ a: 1 }, { b: 1 }, false],
+    [{ a: {} }, { a: {} }, false],
+    [{ a: OBJECT }, { a: OBJECT }, true],
+  ])('should compare %p and %p', (obj1, obj2, expected) => {
+    expect(equalProperties(obj1, obj2)).toBe(expected);
   });
 });

--- a/packages/toolpad-utils/src/collections.ts
+++ b/packages/toolpad-utils/src/collections.ts
@@ -93,3 +93,18 @@ export function filterKeys<U>(
 ): Record<string, U> {
   return mapProperties(obj, ([key, value]) => (filter(key) ? [key, value] : null));
 }
+
+/**
+ * Compares the properties of two objects. Returns `true` if all properties are strictly equal, `false`
+ * otherwise.
+ * Pass a subset of properties to only compare those.
+ */
+export function equalProperties<P extends object>(obj1: P, obj2: P, subset?: (keyof P)[]): boolean {
+  const keysToCheck = new Set<PropertyKey>(subset ?? [...Object.keys(obj1), ...Object.keys(obj2)]);
+  for (const key of keysToCheck) {
+    if (obj1[key as keyof P] !== obj2[key as keyof P]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
As far as I understand this code, all that's needed is a shallow compare of those 4 properties. There's many ways to achieve it. But pulling in whole lodash for a deeply nested comparison seems a bit overkill.
