### PR TITLE
Fix query editor panels orientation

### DIFF
--- a/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/googleSheets/client.tsx
@@ -140,7 +140,7 @@ function QueryEditor({
   const previewGridKey = React.useMemo(() => getObjectKey(columns), [columns]);
 
   return (
-    <PanelGroup autoSaveId="toolpad-google-sheets-panel" direction="vertical">
+    <PanelGroup autoSaveId="toolpad-google-sheets-panel" direction="horizontal">
       <Panel defaultSize={50}>
         <QueryInputPanel onRunPreview={handleRunPreview}>
           <Stack direction="column" gap={2} sx={{ px: 3, pt: 1 }}>

--- a/packages/toolpad-app/src/toolpadDataSources/local/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/local/client.tsx
@@ -264,8 +264,8 @@ function QueryEditor({
   ]);
 
   return (
-    <PanelGroup direction="vertical">
-      <Panel defaultSize={40} maxSize={70} minSize={20}>
+    <PanelGroup direction="horizontal">
+      <Panel defaultSize={50} minSize={20}>
         <QueryInputPanel
           previewDisabled={!selectedOption}
           onRunPreview={handleRunPreview}
@@ -388,7 +388,7 @@ function QueryEditor({
         </QueryInputPanel>
       </Panel>
       <PanelResizeHandle />
-      <Panel defaultSize={60} maxSize={80} minSize={30}>
+      <Panel defaultSize={50} minSize={20}>
         <QueryPreview isLoading={previewIsLoading} error={preview?.error}>
           <JsonView sx={{ height: '100%' }} copyToClipboard src={preview?.data} />
         </QueryPreview>

--- a/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/rest/client.tsx
@@ -409,9 +409,9 @@ function QueryEditor({
   );
 
   return (
-    <PanelGroup direction="vertical">
-      <Panel defaultSize={70}>
-        <PanelGroup direction="horizontal">
+    <PanelGroup direction="horizontal">
+      <Panel defaultSize={50} minSize={20}>
+        <PanelGroup direction="vertical">
           <Panel defaultSize={60} minSize={40}>
             <QueryInputPanel onRunPreview={handleRunPreview}>
               <Stack gap={2} sx={{ px: 3, pt: 1 }}>
@@ -539,8 +539,8 @@ function QueryEditor({
 
       <PanelResizeHandle />
 
-      <Panel defaultSize={30} maxSize={50} minSize={20}>
-        <PanelGroup direction="horizontal">
+      <Panel defaultSize={50} minSize={20}>
+        <PanelGroup direction="vertical">
           <Panel defaultSize={60}>
             <QueryPreview isLoading={previewIsLoading} error={preview?.error}>
               <ResolvedPreview

--- a/packages/toolpad-app/src/toolpadDataSources/sql/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/sql/client.tsx
@@ -233,9 +233,9 @@ export function QueryEditor({
   const previewGridKey = React.useMemo(() => getObjectKey(columns), [columns]);
 
   return (
-    <PanelGroup autoSaveId="toolpad-sql-panel" direction="vertical">
+    <PanelGroup autoSaveId="toolpad-sql-panel" direction="horizontal">
       <Panel defaultSize={50}>
-        <PanelGroup direction="horizontal">
+        <PanelGroup direction="vertical">
           <Panel defaultSize={85}>
             <QueryInputPanel onRunPreview={handleRunPreview}>
               <Box sx={{ flex: 1, minHeight: 0 }}>

--- a/test/integration/backend-basic/index.spec.ts
+++ b/test/integration/backend-basic/index.spec.ts
@@ -62,7 +62,7 @@ test('function editor reload', async ({ page, localApp }) => {
   });
 });
 
-test('function editor parameters update', async ({ page, localApp }) => {
+test('function editor parameters update', async ({ page, localApp, argosScreenshot }) => {
   const editorModel = new ToolpadEditor(page);
   await editorModel.goToPageById(BASIC_TESTS_PAGE_ID);
 
@@ -72,6 +72,8 @@ test('function editor parameters update', async ({ page, localApp }) => {
   await expect(queryEditor).toBeVisible();
   await expect(queryEditor.getByLabel('foo', { exact: true })).toBeVisible();
   await expect(queryEditor.getByLabel('bar', { exact: true })).not.toBeVisible();
+
+  await argosScreenshot('function-editor');
 
   await setPageHidden(page, true); // simulate page hidden
 

--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -50,7 +50,7 @@ test('rest runtime basics', async ({ page, localApp }) => {
   });
 });
 
-test('rest editor basics', async ({ page, context, localApp }) => {
+test('rest editor basics', async ({ page, context, localApp, argosScreenshot }) => {
   const editorModel = new ToolpadEditor(page);
   await editorModel.goto();
   await editorModel.waitForOverlay();
@@ -61,6 +61,8 @@ test('rest editor basics', async ({ page, context, localApp }) => {
   const newQueryEditor = page.getByRole('dialog', { name: 'query' });
 
   await expect(newQueryEditor).toBeVisible();
+
+  await argosScreenshot('function-editor');
 
   const envFilePath = path.resolve(localApp.dir, './.env');
   await withTemporaryEdits(envFilePath, async () => {


### PR DESCRIPTION
Also bring some consistence in the sizing

Closes https://github.com/mui/mui-toolpad/issues/2555

Fix the direction of the query editor panels