### PR TITLE
Stabilize visual regression test

### DIFF
--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -62,7 +62,11 @@ test('rest editor basics', async ({ page, context, localApp, argosScreenshot }) 
 
   await expect(newQueryEditor).toBeVisible();
 
-  await argosScreenshot('function-editor');
+  const urlInput = newQueryEditor.getByLabel('url', { exact: true });
+  await urlInput.click();
+  await urlInput.fill('http://foo.bar');
+
+  await argosScreenshot('rest-editor');
 
   const envFilePath = path.resolve(localApp.dir, './.env');
   await withTemporaryEdits(envFilePath, async () => {


### PR DESCRIPTION
I introduced a new visual regression test over the fetch query editor, but the default url changes every time the test runs. This causes an instability in the url field as can be seen in https://app.argos-ci.com/mui/mui-toolpad/builds/648/56575418

Result: https://app.argos-ci.com/mui/mui-toolpad/builds/649/56577776