### PR TITLE
Show page parameters in url form and add link to docs

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/UrlQueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/UrlQueryEditor.tsx
@@ -25,21 +25,10 @@ interface UrlQueryStringProps {
 }
 
 function UrlQueryString({ input }: UrlQueryStringProps) {
-  const [queryString, setQueryString] = React.useState('');
-
-  const createQueryString = React.useCallback(() => {
-    return input?.reduce(
-      (accumulator, fieldAndValue: string[], currentIndex: number) => {
-        const [field, value] = fieldAndValue;
-        return `${accumulator}${currentIndex > 0 ? '&' : ''}${field}=${value}`;
-      },
-      input.length ? '?' : '',
-    );
+  const queryString = React.useMemo(() => {
+    const search = new URLSearchParams(input).toString();
+    return search.length ? search : '';
   }, [input]);
-
-  React.useEffect(() => {
-    setQueryString(createQueryString() as string);
-  }, [createQueryString, input]);
 
   return (
     <Typography

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/UrlQueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/UrlQueryEditor.tsx
@@ -5,6 +5,7 @@ import {
   DialogContent,
   DialogTitle,
   Typography,
+  Link,
 } from '@mui/material';
 import * as React from 'react';
 import AddIcon from '@mui/icons-material/Add';
@@ -17,6 +18,38 @@ import useUnsavedChangesConfirm from '../../hooks/useUnsavedChangesConfirm';
 
 export interface UrlQueryEditorProps {
   pageNodeId: NodeId;
+}
+
+interface UrlQueryStringProps {
+  input: [string, string][] | undefined;
+}
+
+function UrlQueryString({ input }: UrlQueryStringProps) {
+  const [queryString, setQueryString] = React.useState('');
+
+  const createQueryString = React.useCallback(() => {
+    return input?.reduce(
+      (accumulator, fieldAndValue: string[], currentIndex: number) => {
+        const [field, value] = fieldAndValue;
+        return `${accumulator}${currentIndex > 0 ? '&' : ''}${field}=${value}`;
+      },
+      input.length ? '?' : '',
+    );
+  }, [input]);
+
+  React.useEffect(() => {
+    setQueryString(createQueryString() as string);
+  }, [createQueryString, input]);
+
+  return (
+    <Typography
+      sx={{
+        marginTop: '20px',
+      }}
+    >
+      <code>{queryString}</code>
+    </Typography>
+  );
 }
 
 export default function UrlQueryEditor({ pageNodeId }: UrlQueryEditorProps) {
@@ -83,10 +116,14 @@ export default function UrlQueryEditor({ pageNodeId }: UrlQueryEditorProps) {
         <DialogTitle>Edit page parameters</DialogTitle>
         <DialogContent>
           <Typography>
-            The parameters you define below will be made available in bindings under the{' '}
-            <code>page.parameters</code> global variable. You can set these parameters in the url
-            with query variables (<code>?param=value</code>).
+            Page parameters allow you to pass external data into the Toolpad page state via the URL
+            query. Read more in the{' '}
+            <Link href="https://mui.com/toolpad/concepts/managing-state/#page-parameters">
+              docs
+            </Link>
+            .
           </Typography>
+          <UrlQueryString input={input} />
           <MapEntriesEditor
             sx={{ my: 3 }}
             fieldLabel="Parameter"

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/UrlQueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/UrlQueryEditor.tsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
   Typography,
   Link,
+  Divider,
 } from '@mui/material';
 import * as React from 'react';
 import AddIcon from '@mui/icons-material/Add';
@@ -31,13 +32,13 @@ function UrlQueryString({ input }: UrlQueryStringProps) {
   }, [input]);
 
   return (
-    <Typography
-      sx={{
-        marginTop: '20px',
-      }}
-    >
-      <code>{queryString}</code>
-    </Typography>
+    <React.Fragment>
+      <Divider variant="middle" sx={{ alignSelf: 'stretch', marginTop: '20px' }} />
+      <Typography variant="overline">Usage Preview:</Typography>
+      <Typography>
+        <code>{queryString}</code>
+      </Typography>
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
It'll show the user what the page how the params will look in url form. It also changes the dialog to include a link to the relevant docs page.

The PR will close issue #2423 
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I've read and followed the [contributing guide](https://github.com/mui/mui-toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [x] I've linked relevant GitHub issue with "Closes #<issue id>"
- [x] I've added a visual demonstration under the form of a screenshot or video

![page-params](https://github.com/mui/mui-toolpad/assets/52700465/d43050f9-c925-481b-9955-1112bf774d7d)

