### PR TITLE
[Toolpad Editor] Add themes docs link to theme panel

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentPanel.tsx
@@ -1,5 +1,5 @@
 import { TabContext, TabList, TabPanel } from '@mui/lab';
-import { Tab, Box, styled, Typography } from '@mui/material';
+import { Tab, Box, styled, Typography, Link } from '@mui/material';
 import * as React from 'react';
 import PageOptionsPanel from './PageOptionsPanel';
 import ComponentEditor from './ComponentEditor';
@@ -45,6 +45,7 @@ const propTypeControls: PropTypeControls = {
 
 const classes = {
   panel: 'Toolpad_Panel',
+  themesDocsLink: 'Toolpad_ThemesDocsLink',
 };
 
 const ComponentPanelRoot = styled('div')(({ theme }) => ({
@@ -55,6 +56,9 @@ const ComponentPanelRoot = styled('div')(({ theme }) => ({
     flex: 1,
     padding: theme.spacing(2),
     overflow: 'auto',
+  },
+  [`& .${classes.themesDocsLink}`]: {
+    marginBottom: theme.spacing(1),
   },
 }));
 
@@ -97,6 +101,7 @@ export default function ComponentPanel({ className }: ComponentPanelProps) {
             )}
           </TabPanel>
           <TabPanel value="theme" className={classes.panel}>
+            <Typography className={classes.themesDocsLink} variant="body2">Customize the app with a MUI theme. Read more about this in the <Link href="https://mui.com/toolpad/concepts/theming" target="_blank" rel="noopener">docs</Link>.</Typography>
             <ThemeEditor />
           </TabPanel>
         </TabContext>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #2561 
This PR targets to add docs link to the theme panel which will allow users to directly jump to the right docs from the tool itself. 

Usage : 
Added Typography with variant as "body2" as it was looking perfect , body1 look inconsistent and larger in the side panel. 
Imported and added Link component which points to the Docs page which opens in new page with rel "noopener" 

### Screenshots

#### Dark Mode without theme selector : 
| Before  | After  |
| :---:   | :---: | 
|![before dark](https://github.com/mui/mui-toolpad/assets/30728574/5fbbfe04-139a-47da-8b10-63ef75b24af0) |  ![after dark large screen with theme selection](https://github.com/mui/mui-toolpad/assets/30728574/f3c9baf9-2b6c-4965-98c0-2e58910ff19e) |

#### Dark Mode with theme selector : 

| Before  | After  |
| :---:   | :---: | 
| ![befork dark with theme selector](https://github.com/mui/mui-toolpad/assets/30728574/1d765243-fa5d-4b43-8923-de59b7d152cb) | ![after dark large screen](https://github.com/mui/mui-toolpad/assets/30728574/96a42825-1d82-4fb2-9837-91e12618dcec) |


#### Light Mode without theme selector : 


| Before  | After  |
| :---:   | :---: | 
| ![before light ](https://github.com/mui/mui-toolpad/assets/30728574/b09deeea-ddfc-4b36-b76c-6254c987f254) | ![after light theme ](https://github.com/mui/mui-toolpad/assets/30728574/fd3ced58-1c03-44c6-8ef3-f51d8e522ae3)|


#### Light Mode with theme selector : 


| Before  | After  |
| :---:   | :---: | 
| ![before light with theme selector](https://github.com/mui/mui-toolpad/assets/30728574/de0cf2ae-8bcb-4031-aae5-bc169be1a2ce) | ![after light with theme selection](https://github.com/mui/mui-toolpad/assets/30728574/9acc58df-cfaf-4580-9ba9-5350336bcba7) |




- [x] I've read and followed the [contributing guide](https://github.com/mui/mui-toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [x] I've updated the relevant documentation for any new or updated feature
- [x] I've linked relevant GitHub issue with "Closes #<issue id>"
- [x] I've added a visual demonstration under the form of a screenshot or video
