### PR TITLE
Add visual regression tests for text component

### DIFF
--- a/packages/toolpad-components/src/Text.tsx
+++ b/packages/toolpad-components/src/Text.tsx
@@ -45,7 +45,7 @@ interface TextProps {
 const MarkdownContainer = styled('div')(({ theme }) => ({
   display: 'block',
   width: '100%',
-  overflowWrap: 'break-word',
+  overflowWrap: 'anywhere',
   '&:empty::before, & > span:empty::before': {
     content: '""',
     display: 'inline-block',
@@ -248,7 +248,7 @@ function TextContent({ value, loading, sx, variant }: TextContentProps) {
         [`&:empty::before`]: { content: '""', display: 'inline-block' },
         outline: 'none',
         whiteSpace: 'pre-wrap',
-        overflowWrap: 'break-word',
+        overflowWrap: 'anywhere',
       }}
       variant={variant}
       onDoubleClick={() => {

--- a/packages/toolpad-components/src/Text.tsx
+++ b/packages/toolpad-components/src/Text.tsx
@@ -45,6 +45,7 @@ interface TextProps {
 const MarkdownContainer = styled('div')(({ theme }) => ({
   display: 'block',
   width: '100%',
+  overflowWrap: 'break-word',
   '&:empty::before, & > span:empty::before': {
     content: '""',
     display: 'inline-block',

--- a/test/visual/components/fixture/toolpad/pages/components/page.yml
+++ b/test/visual/components/fixture/toolpad/pages/components/page.yml
@@ -4,76 +4,76 @@ spec:
   id: f703ps3
   title: components
   content:
-    - component: PageRow
-      name: pageRow3
-      children:
-        - component: Button
-          name: button
-          props:
-            content: foo button
-    - component: PageRow
-      name: pageRow4
-      children:
-        - component: Image
-          name: image
-          props:
-            alt: foo image
-    - component: PageRow
-      name: pageRow
-      children:
-        - component: codeComponent.MyComponent
-          name: codeComponent_eb03t9a
-          props:
-            msg: "1"
-    - component: PageRow
-      name: pageRow5
-      children:
-        - component: DataGrid
-          name: dataGrid
-          props:
-            rows:
-              - id: 1
-                foo datagrid column: bar
-            columns:
-              - type: number
-                field: id
-              - type: string
-                field: foo datagrid column
-    - component: PageRow
-      name: pageRow6
-      children:
-        - component: TextField
-          name: textField
-          props:
-            label: foo textfield
-    - component: PageRow
-      name: pageRow7
-      children:
-        - component: Text
-          name: typography1
-          props:
-            value: foo typography
-    - component: PageRow
-      name: pageRow8
-      children:
-        - component: Select
-          name: select
-          props:
-            label: foo select
-    - component: PageRow
-      name: pageRow9
-      children:
-        - component: List
-          name: list
-          props:
-            renderItem:
-              $$template:
-                - component: PageRow
-                  name: pageRow2
-                  children:
-                    - component: Button
-                      name: button1
-                      props:
-                        content:
-                          $$jsExpression: |
-                            `List Button ${i + 1}`
+    - component: Button
+      name: button
+      children: []
+      layout:
+        columnSize: 1
+      props:
+        content: foo button
+    - component: Image
+      name: image
+      children: []
+      layout:
+        columnSize: 1
+      props:
+        alt: foo image
+    - component: codeComponent.MyComponent
+      name: codeComponent_eb03t9a
+      children: []
+      layout:
+        columnSize: 1
+      props:
+        msg: "1"
+    - component: DataGrid
+      name: dataGrid
+      children: []
+      layout:
+        columnSize: 1
+      props:
+        rows:
+          - id: 1
+            foo datagrid column: bar
+        columns:
+          - type: number
+            field: id
+          - type: string
+            field: foo datagrid column
+    - component: TextField
+      name: textField
+      children: []
+      layout:
+        columnSize: 1
+      props:
+        label: foo textfield
+    - component: Text
+      name: typography1
+      children: []
+      layout:
+        columnSize: 1
+      props:
+        value: foo typography
+    - component: Select
+      name: select
+      children: []
+      layout:
+        columnSize: 1
+      props:
+        label: foo select
+    - component: List
+      name: list
+      children: []
+      layout:
+        columnSize: 1
+      props:
+        renderItem:
+          $$template:
+            - component: PageRow
+              name: pageRow2
+              children:
+                - component: Button
+                  name: button1
+                  props:
+                    content:
+                      $$jsExpression: |
+                        `List Button ${i + 1}`

--- a/test/visual/components/fixture/toolpad/pages/rows/page.yml
+++ b/test/visual/components/fixture/toolpad/pages/rows/page.yml
@@ -10,5 +10,7 @@ spec:
       children:
         - component: Text
           name: text
+          children: []
         - component: Text
           name: text1
+          children: []

--- a/test/visual/components/fixture/toolpad/pages/text/page.yml
+++ b/test/visual/components/fixture/toolpad/pages/text/page.yml
@@ -53,7 +53,7 @@ spec:
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
     - component: Text
       name: text4

--- a/test/visual/components/fixture/toolpad/pages/text/page.yml
+++ b/test/visual/components/fixture/toolpad/pages/text/page.yml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: page
+spec:
+  id: QYjq2fJ
+  title: text
+  display: shell
+  content:
+    - component: Text
+      name: text5
+      children: []
+      props:
+        value: short text
+    - component: Text
+      name: text
+      props:
+        value: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+          veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+          ea commodo consequat. Duis aute irure dolor in reprehenderit in
+          voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+          sint occaecat cupidatat non proident, sunt in culpa qui officia
+          deserunt mollit anim id est laborum.
+      children: []
+    - component: Text
+      name: text1
+      children: []
+      props:
+        value: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+          veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+          ea commodo consequat. Duis aute irure dolor in reprehenderit in
+          voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+          sint occaecat cupidatat non proident, sunt in culpa qui officia
+          deserunt mollit anim id est laborum.
+        variant: body2
+    - component: Text
+      name: text2
+      children: []
+      props:
+        value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    - component: Text
+      name: text3
+      children: []
+      props:
+        mode: markdown
+        value: >+
+          ## hello
+
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+    - component: Text
+      name: text4
+      props:
+        variant: h2
+      children: []
+    - component: Text
+      name: text6
+      children: []
+      props:
+        mode: link
+        value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/test/visual/components/index.spec.ts
+++ b/test/visual/components/index.spec.ts
@@ -13,11 +13,14 @@ test.use({
 
 test('rendering components in the app runtime', async ({ page, argosScreenshot }) => {
   const runtimeModel = new ToolpadRuntime(page);
+
   await runtimeModel.gotoPage('components');
-
   await runtimeModel.waitForPageReady();
-
   await argosScreenshot('components', { fullPage: true });
+
+  await runtimeModel.gotoPage('text');
+  await runtimeModel.waitForPageReady();
+  await argosScreenshot('text', { fullPage: true });
 });
 
 test('rendering components in the app editor', async ({ page, argosScreenshot }) => {


### PR DESCRIPTION
Establishing a baseline of how the text component deals with width.

Also aligning the overflow of markdown paragraphs with the text mode as this was causing issues with the width