### PR TITLE
Auto-create a theme when the user starts editing

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentPanel.tsx
@@ -102,7 +102,7 @@ export default function ComponentPanel({ className }: ComponentPanelProps) {
           </TabPanel>
           <TabPanel value="theme" className={classes.panel}>
             <Typography className={classes.themesDocsLink} variant="body2">
-              Customize the app with a MUI theme. Read more about this in the{' '}
+              Customize the app with a MUI theme. Read more about theming in the{' '}
               <Link href="https://mui.com/toolpad/concepts/theming" target="_blank" rel="noopener">
                 docs
               </Link>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ThemeEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ThemeEditor.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Button } from '@mui/material';
 import * as appDom from '../../../appDom';
 import { useDom, useDomApi } from '../../AppState';
 import MuiThemeEditor from '../../../components/MuiThemeEditor';
@@ -16,30 +15,27 @@ export default function ComponentEditor({ className }: ComponentEditorProps) {
   const { themes = [] } = appDom.getChildNodes(dom, app);
   const theme = themes.length > 0 ? themes[0] : null;
 
-  const handleAddThemeClick = () => {
-    const newTheme = appDom.createNode(dom, 'theme', {
-      name: 'Theme',
-      theme: {},
-      attributes: {},
-    });
-    domApi.update((draft) => appDom.addNode(draft, newTheme, app, 'themes'));
-  };
-
   return (
     <div className={className} data-testid="theme-editor">
-      {theme ? (
-        <MuiThemeEditor
-          value={theme.theme || {}}
-          onChange={(newTheme) => {
-            domApi.update((draft) => {
+      <MuiThemeEditor
+        value={theme?.theme || {}}
+        onChange={(newTheme) => {
+          domApi.update((draft) => {
+            if (theme) {
               draft = appDom.setNodeProp(draft, theme, 'theme', newTheme);
               return draft;
+            }
+
+            const newThemeNode = appDom.createNode(dom, 'theme', {
+              name: 'Theme',
+              theme: newTheme,
+              attributes: {},
             });
-          }}
-        />
-      ) : (
-        <Button onClick={handleAddThemeClick}>Add theme</Button>
-      )}
+            draft = appDom.addNode(draft, newThemeNode, app, 'themes');
+            return draft;
+          });
+        }}
+      />
     </div>
   );
 }

--- a/test/integration/theme/index.spec.ts
+++ b/test/integration/theme/index.spec.ts
@@ -22,8 +22,6 @@ test('can change between light and dark themes', async ({ page }) => {
 
   await expect(canvasBodyLocator).toHaveCSS('background-color', 'rgb(255, 255, 255)');
 
-  await editorModel.themeEditor.getByRole('button', { name: 'Add theme' }).click();
-
   await editorModel.themeEditor.getByRole('button', { name: 'Dark' }).click();
   await expect(canvasBodyLocator).toHaveCSS('background-color', 'rgb(18, 18, 18)');
 


### PR DESCRIPTION
There is a button that asks the user to add a theme before they can start editing it. Instead we can just show a default theme editor and auto-create the file as soon as the user starts editing


https://github.com/mui/mui-toolpad/assets/2109932/f479f9dd-2c5a-4677-97cb-c6485f4634c3


