### PR TITLE
Experiment with completion provider for Toolpad values

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/JsExpressionEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/JsExpressionEditor.tsx
@@ -144,7 +144,8 @@ export function JsExpressionEditor({
                 insertText: `${globalVariable}.${property}`,
                 kind: monaco.languages.CompletionItemKind.Variable,
                 documentation: '',
-                sortText: `${globalVariable}.${property}`,
+                // To give it precedence over other default typescript completions:
+                sortText: `\0\0${globalVariable}.${property}`,
                 range,
               } satisfies monaco.languages.CompletionItem;
             });


### PR DESCRIPTION
A naive implementation that adds all the top level objects in the global scope and their properties as completion items. The actual value is displayed on the right, when an item is selected.


https://github.com/mui/mui-toolpad/assets/2109932/2813afbd-b49f-426d-acef-dd6155a69fc1


