### PR TITLE
Disallow binding to event handlers and list templates

### DIFF
--- a/test/integration/bindings/fixture/toolpad/pages/globalScope/page.yml
+++ b/test/integration/bindings/fixture/toolpad/pages/globalScope/page.yml
@@ -5,14 +5,29 @@ spec:
   title: globalScope
   display: shell
   content:
+    - component: Button
+      name: button
+      children: []
+      props:
+        onClick:
+          $$jsExpressionAction: console.log('hello')
+    - component: List
+      name: list
+      children: []
+      props:
+        itemCount: 1
+        renderItem:
+          $$template:
+            - component: Text
+              name: text8
     - component: Text
       name: text5
       children: []
       layout:
         columnSize: 1
       props:
-        variant: h2
         value: "Bindings: global scope access"
+        variant: h2
     - component: Text
       name: text
       children: []
@@ -49,31 +64,49 @@ spec:
     - component: Text
       name: text3
       children: []
-      layout:
-        columnSize: 1
       props:
         value:
           $$jsExpression: |
             `Disallows localStorage globals |test4 ${
               typeof localStorage === "undefined" ? "ok" : "nok"
             }|`
-    - component: Text
-      name: text4
-      children: []
       layout:
         columnSize: 1
+    - component: Text
+      name: text4
       props:
         value:
           $$jsExpression: |
             `Disallows globalThis.localStorage |test5 ${
               typeof globalThis.localStorage === "undefined" ? "ok" : "nok"
             }|`
+      children: []
+      layout:
+        columnSize: 1
     - component: Text
       name: text6
-      children: []
       props:
         value:
           $$jsExpression: |
             `Allows Intl |test6 ${
               typeof Intl?.NumberFormat !== "undefined" ? "ok" : "nok"
             }|`
+      children: []
+    - component: Text
+      name: text7
+      props:
+        value:
+          $$jsExpression: >
+            `Disallows binding to event handlers |test7 ${
+              Object.prototype.hasOwnProperty.call(button, "onClick") ? "nok" : "ok"
+            }|`
+      children: []
+    - component: Text
+      name: text9
+      props:
+        value:
+          $$jsExpression: >
+            `Disallows binding to list templates |test8 ${
+              Object.prototype.hasOwnProperty.call(list, "renderItem") ? "nok" : "ok"
+            }|`
+      children: []

--- a/test/integration/bindings/index.spec.ts
+++ b/test/integration/bindings/index.spec.ts
@@ -41,6 +41,8 @@ test('global scope', async ({ page }) => {
   await expect(page.getByText('|test4 ok|')).toBeVisible();
   await expect(page.getByText('|test5 ok|')).toBeVisible();
   await expect(page.getByText('|test6 ok|')).toBeVisible();
+  await expect(page.getByText('|test7 ok|')).toBeVisible();
+  await expect(page.getByText('|test8 ok|')).toBeVisible();
 });
 
 test('encoding', async ({ page }) => {


### PR DESCRIPTION
Avoid `onClick` handlers and list `renderItems` showing up in global scope. Their value was always `undefined` anyway.