### PR TITLE
Exclude esm folder from icons alias

### DIFF
--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -228,7 +228,7 @@ export function createViteConfig({
         alias: [
           {
             // FIXME(https://github.com/mui/material-ui/issues/35233)
-            find: /^@mui\/icons-material\/([^/]*)/,
+            find: /^@mui\/icons-material\/(?!esm\/)([^/]*)/,
             replacement: '@mui/icons-material/esm/$1',
           },
         ],

--- a/packages/toolpad-app/src/toolpad/propertyControls/NumberFormat.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/NumberFormat.tsx
@@ -12,7 +12,9 @@ function GridColumnsPropEditor({
 }: EditorProps<NumberFormat>) {
   return (
     <PropertyControl propType={propType}>
-      <NumberFormatEditor label={label} disabled={disabled} value={value} onChange={onChange} />
+      <span>
+        <NumberFormatEditor label={label} disabled={disabled} value={value} onChange={onChange} />
+      </span>
     </PropertyControl>
   );
 }

--- a/packages/toolpad-app/src/toolpad/propertyControls/NumberFormat.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/NumberFormat.tsx
@@ -3,7 +3,7 @@ import { NumberFormat, NumberFormatEditor } from '@mui/toolpad-core/numberFormat
 import type { EditorProps } from '../../types';
 import PropertyControl from '../../components/PropertyControl';
 
-function GridColumnsPropEditor({
+function NumberFormatPropEditor({
   propType,
   label,
   value,
@@ -19,4 +19,4 @@ function GridColumnsPropEditor({
   );
 }
 
-export default GridColumnsPropEditor;
+export default NumberFormatPropEditor;

--- a/test/integration/bindings/fixture/toolpad/pages/bindings/page.yml
+++ b/test/integration/bindings/fixture/toolpad/pages/bindings/page.yml
@@ -23,3 +23,6 @@ spec:
         sx:
           $$jsExpression: "{"
         value: -test2-
+    - component: Metric
+      name: metric
+      children: []

--- a/test/integration/bindings/fixture/toolpad/pages/bindings/page.yml
+++ b/test/integration/bindings/fixture/toolpad/pages/bindings/page.yml
@@ -23,6 +23,3 @@ spec:
         sx:
           $$jsExpression: "{"
         value: -test2-
-    - component: Metric
-      name: metric
-      children: []


### PR DESCRIPTION
Haven't ran into this, but just to give the [good example](https://github.com/mui/material-ui/pull/38742#issuecomment-1702441234).

Also fixing tooltips on the NumberFormat property control that is used in the Metric component. (Saw this warning popping up while testing the other change)

```
MarkdownTooltip.tsx:32 Warning: Failed prop type: Invalid prop `children` supplied to `ForwardRef(Tooltip2)`. Expected an element that can hold a ref. Did you accidentally use a plain function component for an element instead? For more information see https://mui.com/r/caveat-with-refs-guide
    at Tooltip2 (http://localhost:3000/_toolpad/@fs/Users/janpotoms/Projects/toolpad/packages/toolpad-app/node_modules/.vite/deps/chunk-UYZY5CSJ.js?v=d7ee65a1:290:17)
    at MarkdownTooltip (http://localhost:3000/_toolpad/@fs/Users/janpotoms/Projects/toolpad/packages/toolpad-app/src/components/MarkdownTooltip.tsx:22:3)
    at PropertyControl (http://localhost:3000/_toolpad/@fs/Users/janpotoms/Projects/toolpad/packages/toolpad-app/src/components/PropertyControl.tsx:19:3)
    at GridColumnsPropEditor (http://localhost:3000/_toolpad/propertyControls/NumberFormat.tsx?t=1693561880565:20:3)
    ...
```