### PR TITLE
[docs] Official URL

### DIFF
--- a/docs/data/toolpad/concepts/display-mode.md
+++ b/docs/data/toolpad/concepts/display-mode.md
@@ -1,4 +1,4 @@
-# Display Mode
+# Display mode
 
 <p class="description">Toolpad apps allow for a display mode configurable per-page.</p>
 

--- a/docs/data/toolpad/how-to-guides/embed-pages.md
+++ b/docs/data/toolpad/how-to-guides/embed-pages.md
@@ -18,10 +18,9 @@
    using
 
    ```html
-   <iframe src="https://tools-public.onrender.com/prod/pages/fn03hvq" loading="lazy">
-   </iframe>
+   <iframe src="https://tools-public.mui.com/prod/pages/fn03hvq"></iframe>
    ```
 
    we can embed a Toolpad page, like so:
 
-    <iframe src="https://tools-public.onrender.com/prod/pages/fn03hvq" loading="lazy" style="display: block; margin: auto"></iframe>
+    <iframe src="https://tools-public.mui.com/prod/pages/fn03hvq" loading="lazy" style="display: block; margin: auto"></iframe>

--- a/docs/data/toolpad/how-to-guides/embed-pages.md
+++ b/docs/data/toolpad/how-to-guides/embed-pages.md
@@ -4,7 +4,7 @@
 
 ## Using an `iframe`
 
-1. Set the display mode on the page to be embedded to **No shell**
+1. Set the [display mode](/toolpad/concepts/display-mode/) on the page to be embedded to **No shell**
 
 {{"component": "modules/components/DocsImage.tsx", "src": "/static/toolpad/docs/how-to-guides/embed-page/no-shell.png", "alt": "No shell display mode", "caption": "Set display mode to no shell", "indent": 1 }}
 


### PR DESCRIPTION
In case we migrate to a different hosting solution, like https://railway.app/. It also better communicates that MUI is dog flooding. Noticed with @prakhargupta1 in a meeting.

---

The content on the page doesn't make a lot of sense to me:

- [ ] I personally never use the "No shell" layout anymore, it's too much of a pain when you want to browse all the apps you have to not have the sidenav. Instead, I use `?toolpad-display=standalone`, much better.
- [x] I think https://mui.com/toolpad/how-to-guides/embed-pages/ should cross-link back to https://mui.com/toolpad/concepts/display-mode/