### PR TITLE
Improve visual test for resizing columns

### DIFF
--- a/test/visual/components/fixture/toolpad/pages/rows/page.yml
+++ b/test/visual/components/fixture/toolpad/pages/rows/page.yml
@@ -6,11 +6,21 @@ spec:
   display: shell
   content:
     - component: PageRow
-      name: pageRow
+      name: pageRow1
       children:
-        - component: Text
-          name: text
-          children: []
-        - component: Text
-          name: text1
-          children: []
+        [
+          {
+              component: TextField,
+              name: textField,
+              props: { fullWidth: true },
+              children: []
+            },
+          {
+              component: TextField,
+              name: textField1,
+              props: { fullWidth: true },
+              children: []
+            }
+        ]
+      props:
+        justifyContent: start

--- a/test/visual/components/index.spec.ts
+++ b/test/visual/components/index.spec.ts
@@ -43,23 +43,23 @@ test('showing grid while resizing elements', async ({ page, argosScreenshot }) =
 
   await editorModel.waitForOverlay();
 
-  const firstText = editorModel.appCanvas.getByText('text').first();
+  const firstInput = editorModel.appCanvas.locator('input').first();
 
-  await clickCenter(page, firstText);
+  await clickCenter(page, firstInput);
 
-  const firstTextBoundingBox = await firstText.boundingBox();
+  const firstInputBoundingBox = await firstInput.boundingBox();
 
   await page.mouse.move(
-    firstTextBoundingBox!.x + firstTextBoundingBox!.width - 5,
-    firstTextBoundingBox!.y + firstTextBoundingBox!.height / 2,
+    firstInputBoundingBox!.x + firstInputBoundingBox!.width - 5,
+    firstInputBoundingBox!.y + firstInputBoundingBox!.height / 2,
     { steps: 10 },
   );
 
   await page.mouse.down();
 
   await page.mouse.move(
-    firstTextBoundingBox!.x + firstTextBoundingBox!.width / 2,
-    firstTextBoundingBox!.y + firstTextBoundingBox!.height / 2,
+    firstInputBoundingBox!.x + firstInputBoundingBox!.width / 2,
+    firstInputBoundingBox!.y + firstInputBoundingBox!.height / 2,
     { steps: 10 },
   );
 


### PR DESCRIPTION
Improve visual test for resizing columns, as it assumes that the components in the test take up the full-width of their container.

Fixes regression found in https://github.com/mui/mui-toolpad/pull/2587 due to Text components not taking up full-width.
