### PR TITLE
Fix TreeView types after core update

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -13,11 +13,12 @@ import { useNodeNameValidation } from '../PagesExplorer/validation';
 import { DomView } from '../../../utils/domView';
 import { removePageLayoutNode } from '../pageLayout';
 
-function CustomTreeItem(
-  props: TreeItemProps & {
-    node: appDom.ElementNode;
-  },
-) {
+export interface CustomTreeItemProps extends TreeItemProps {
+  ref?: React.RefObject<HTMLLIElement>;
+  node: appDom.ElementNode;
+}
+
+function CustomTreeItem(props: CustomTreeItemProps) {
   const domApi = useDomApi();
   const { dom } = useDom();
   const appStateApi = useAppStateApi();

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -39,7 +39,8 @@ const StyledTreeItem = styled(TreeItem)({
   },
 });
 
-type StyledTreeItemProps = TreeItemProps & {
+interface StyledTreeItemProps extends TreeItemProps {
+  ref?: React.RefObject<HTMLLIElement>;
   onDeleteNode?: (nodeId: NodeId) => void;
   onDuplicateNode?: (nodeId: NodeId) => void;
   onCreate?: React.MouseEventHandler;
@@ -49,7 +50,7 @@ type StyledTreeItemProps = TreeItemProps & {
   deleteLabelText?: string;
   duplicateLabelText?: string;
   toolpadNodeId?: NodeId;
-};
+}
 
 function PagesExplorerTreeItem(props: StyledTreeItemProps) {
   const {

--- a/packages/toolpad-app/src/toolpadDataSources/local/client.tsx
+++ b/packages/toolpad-app/src/toolpadDataSources/local/client.tsx
@@ -192,7 +192,7 @@ function QueryEditor({
     [setSelectedHandler],
   );
 
-  const handlerTreeRef = React.useRef<HTMLDivElement>(null);
+  const handlerTreeRef = React.useRef<HTMLUListElement>(null);
 
   React.useEffect(() => {
     handlerTreeRef.current?.querySelector(`.${treeItemClasses.selected}`)?.scrollIntoView();


### PR DESCRIPTION
We have build failures on master due to an update to MUI core which broke the types. For some reason the `test_types` check was not in the required checks for the master branch (anymore?).

Fixing the types in this PR. I've also enabled the check-types check branch protection rule