### PR TITLE
[docs] Sync prism with docs-infra

### DIFF
--- a/docs/public/static/styles/prism-okaidia.css
+++ b/docs/public/static/styles/prism-okaidia.css
@@ -1,34 +1,26 @@
 /**
- * https://unpkg.com/prismjs/themes/prism-okaidia.css
- *
  * okaidia theme for JavaScript, CSS and HTML
  * Loosely based on Monokai textmate theme by http://www.monokai.nl/
  * @author ocodia
  */
 
-/* inline code */
-code {
-  padding: 0.1em;
-  border-radius: 0.3em;
-  white-space: normal;
-}
-
-code[class*='language-'] {
-  color: #f8f8f2;
-  background: none;
-  text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  font-size: 1em;
+code[class*='language-'],
+pre[class*='language-'] {
+  /* color: #f8f8f2; */
+  /* background: none; */
+  /* text-shadow: 0 1px rgba(0, 0, 0, 0.3); */
+  /* font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; */
+  /* font-size: 1em; */
   text-align: left;
   white-space: pre;
   word-spacing: normal;
   word-break: normal;
   word-wrap: normal;
-  line-height: 1.5;
+  /* line-height: 1.5; */
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+  /* -moz-tab-size: 4; */
+  /* -o-tab-size: 4; */
+  /* tab-size: 4; */
 
   -webkit-hyphens: none;
   -moz-hyphens: none;
@@ -36,21 +28,50 @@ code[class*='language-'] {
   hyphens: none;
 }
 
+/* Code blocks */
+/*
+pre[class*='language-'] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
+}$
+*/
+
+/*
+:not(pre) > code[class*='language-'],
+pre[class*='language-'] {
+  background: #272822;
+}
+*/
+
+/* Inline code */
+/*
+:not(pre) > code[class*='language-'] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+*/
+
+/*
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: slategray;
+  color: #8292a2;
 }
+*/
 
 .token.punctuation {
   color: #f8f8f2;
 }
 
-.namespace {
+.token.namespace {
   opacity: 0.7;
 }
 
+/*
 .token.property,
 .token.tag,
 .token.constant,
@@ -58,11 +79,14 @@ code[class*='language-'] {
 .token.deleted {
   color: #f92672;
 }
+*/
 
+/*
 .token.boolean,
 .token.number {
   color: #ae81ff;
 }
+*/
 
 .token.selector,
 .token.attr-name,
@@ -110,17 +134,15 @@ code[class*='language-'] {
   cursor: help;
 }
 
-/* Overrides to reach AA, copied from https://reactjs.org */
-
-code[class*='language-'] {
-  text-shadow: none;
-}
-
+/**
+ * Overrides to reach AA, copied from https://reactjs.org, on top of the
+ * source from https://unpkg.com/prismjs/themes/prism-okaidia.css that are above.
+ */
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: rgb(178, 178, 178);
+  color: #b2b2b2;
 }
 
 .token.property,
@@ -128,7 +150,7 @@ code[class*='language-'] {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: rgb(252, 146, 158);
+  color: #fc929e;
 }
 
 .token.boolean,


### PR DESCRIPTION
I saw the issue in #2353

<img width="383" alt="Screenshot 2023-09-08 at 15 29 21" src="https://github.com/mui/mui-toolpad/assets/3165635/561861ab-f555-4a4e-bdf8-320bf1ae4b64">

https://deploy-preview-2353--mui-toolpad-docs.netlify.app/toolpad/live-config/#demo

My workaround is to copy and paste the same file from docs-infra. The proper solution would be for docs-infra to import the CSS file with a bundler import, rather than using the static file.