### PR TITLE
Fix gap and direction in layout slots

### DIFF
--- a/packages/toolpad-app/src/canvas/getPageViewState.ts
+++ b/packages/toolpad-app/src/canvas/getPageViewState.ts
@@ -114,7 +114,9 @@ export function getNodesViewInfo(rootElm: HTMLElement): {
             const display = window.getComputedStyle(childContainerElm).display;
 
             let flowDirection = 'row';
-            if (display === 'grid') {
+            if (slotType === 'layout') {
+              flowDirection = 'column';
+            } else if (display === 'grid') {
               const gridAutoFlow = window.getComputedStyle(childContainerElm).gridAutoFlow;
               flowDirection = gridAutoFlow === 'row' ? 'column' : 'row';
             } else if (display === 'flex') {

--- a/packages/toolpad-core/src/runtime.tsx
+++ b/packages/toolpad-core/src/runtime.tsx
@@ -4,6 +4,7 @@ import { Emitter } from '@mui/toolpad-utils/events';
 import * as ReactIs from 'react-is';
 import { hasOwnProperty } from '@mui/toolpad-utils/collections';
 import { createProvidedContext } from '@mui/toolpad-utils/react';
+import { Stack } from '@mui/material';
 import { RuntimeEvents, ToolpadComponents, ToolpadComponent, ArgTypeDefinition } from './types';
 import { RUNTIME_PROP_NODE_ID, RUNTIME_PROP_SLOTS, TOOLPAD_COMPONENT } from './constants';
 import type { SlotType, ComponentConfig, RuntimeEvent, RuntimeError } from './types';
@@ -44,7 +45,20 @@ interface SlotsWrapperProps {
   parentId: string;
 }
 
-function SlotsWrapper({ children }: SlotsWrapperProps) {
+function SlotsWrapper({ children, slotType }: SlotsWrapperProps) {
+  if (slotType === 'layout') {
+    return (
+      <Stack
+        direction="column"
+        sx={{
+          gap: 1,
+        }}
+      >
+        {children}
+      </Stack>
+    );
+  }
+
   return <React.Fragment>{children}</React.Fragment>;
 }
 


### PR DESCRIPTION
Dragging-and-dropping in containers was still not working 100% after the placing the second element.
This PR fixes the layout direction and adds a gap of 1 to the layout slot, just like the top page, making it so that layout slots act as a mini-page.

https://github.com/mui/mui-toolpad/assets/10789765/8667b1a4-2717-4df5-b085-d545c21d50ed