### PR TITLE
[docs] Fix /toolpad/reference/api/get-context/ 404

### DIFF
--- a/docs/data/toolpad/reference/api/create-component.md
+++ b/docs/data/toolpad/reference/api/create-component.md
@@ -26,7 +26,7 @@ export default createComponent(MyComponent, config);
 
 A React component that will be available in the drag and drop editor with the defined `argTypes` as its properties.
 
-## types
+## Types
 
 ### ComponentConfig
 
@@ -36,14 +36,14 @@ Describes the custom component.
 
 | Name                   | Type                                   | Description                                                                                                                                              |
 | :--------------------- | :------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `helperText?`          | `string`                               | A short explanatory text that'll be shown in the editor UI when this component is referenced. May contain Markdown                                       |
+| `helperText?`          | `string`                               | A short explanatory text that'll be shown in the editor UI when this component is referenced. May contain Markdown.                                      |
 | `errorProp?`           | `string`                               | Designates a property as "the error property". If Toolpad detects an error on any of the inputs, it will forward it to this property.                    |
 | `errorPropSource?`     | `string[]`                             | Configures which properties result in propagating error state to `errorProp`.                                                                            |
-| `loadingProp?`         | `string`                               | Designates a property as "the loading property". If Toolpad detects any of the inputs is still loading it will set this property to `true`               |
+| `loadingProp?`         | `string`                               | Designates a property as "the loading property". If Toolpad detects any of the inputs is still loading it will set this property to `true`.              |
 | `loadingPropSource?`   | `string[]`                             | Configures which properties result in propagating loading state to `loadingProp`.                                                                        |
 | `layoutDirection?`     | `'vertical' \| 'horizontal' \| 'both'` | Enables controlling the alignment of the component container box.                                                                                        |
 | `resizableHeightProp?` | `string`                               | Designates a property as "the resizable height property". If Toolpad detects any vertical resizing of the component it will forward it to this property. |
-| `argTypes?`            | `{ [name: string]: ArgumentType }`     | Describes the individual properties for this component. See [ArgumentType](#argumenttype)                                                                |
+| `argTypes?`            | `{ [name: string]: ArgumentType }`     | Describes the individual properties for this component. See [ArgumentType](#argumenttype).                                                               |
 
 ### ArgumentType
 
@@ -62,9 +62,9 @@ Argument types describe the type and constraints of custom component properties.
 | `onChangeProp?`     | `string`                                                                                         | The property that is used to control this property.                                                                                                                                                                    |
 | `onChangeHandler?`  | `(...params: any[]) => any`                                                                      | Provides a way to manipulate the value from the onChange event before it is assigned to state.                                                                                                                         |
 | `visible?`          | `boolean`                                                                                        | For compound components, this property is used to control the visibility of this property based on the selected value of another property. If this property is not defined, the property will be visible at all times. |
-| `enum?`             | `string[]`                                                                                       | For the `'string'` type only. Defines a set of valid values for the property                                                                                                                                           |
-| `minimum?`          | `number`                                                                                         | For the `'number'` type only. Defines the minimum allowed value of the property                                                                                                                                        |
-| `maximum?`          | `number`                                                                                         | For the `'number'` type only. Defines the maximum allowed value of the property                                                                                                                                        |
+| `enum?`             | `string[]`                                                                                       | For the `'string'` type only. Defines a set of valid values for the property.                                                                                                                                          |
+| `minimum?`          | `number`                                                                                         | For the `'number'` type only. Defines the minimum allowed value of the property.                                                                                                                                       |
+| `maximum?`          | `number`                                                                                         | For the `'number'` type only. Defines the maximum allowed value of the property.                                                                                                                                       |
 
 ## Usage
 

--- a/docs/data/toolpad/reference/api/create-function.md
+++ b/docs/data/toolpad/reference/api/create-function.md
@@ -32,7 +32,7 @@ You can define parameters to bind to page state. The actual values for these par
 
 a function that is recognizable by Toolpad
 
-## types
+## Types
 
 ### FunctionConfig
 
@@ -40,9 +40,9 @@ This describes the behavior of the custom function.
 
 **Properties**
 
-| Name          | Type                                      | Description                                                                                                                                |
-| :------------ | :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
-| `parameters?` | `{ [name: string]: ParameterDefinition }` | Describes the parameters that will be passed in the `parameters` property of the function. See [ParameterDefinition](#parameterdefinition) |
+| Name          | Type                                      | Description                                                                                                                                 |
+| :------------ | :---------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------ |
+| `parameters?` | `{ [name: string]: ParameterDefinition }` | Describes the parameters that will be passed in the `parameters` property of the function. See [ParameterDefinition](#parameterdefinition). |
 
 ### ParameterDefinition
 
@@ -56,9 +56,9 @@ this describes the type of the parameter that will be passed to the custom funct
 | `default?`     | `any`                                                      | A default value for the property.                                                                                  |
 | `helperText?`  | `string`                                                   | A short explanatory text that'll be shown in the editor UI when this property is referenced. May contain Markdown. |
 | `description?` | `string`                                                   | A description of the property, to be used to supply extra information to the user.                                 |
-| `enum?`        | `string[]`                                                 | For the `'string'` type only. Defines a set of valid values for the property                                       |
-| `minimum?`     | `number`                                                   | For the `'number'` type only. Defines the minimum allowed value of the property                                    |
-| `maximum?`     | `number`                                                   | For the `'number'` type only. Defines the maximum allowed value of the property                                    |
+| `enum?`        | `string[]`                                                 | For the `'string'` type only. Defines a set of valid values for the property.                                      |
+| `minimum?`     | `number`                                                   | For the `'number'` type only. Defines the minimum allowed value of the property.                                   |
+| `maximum?`     | `number`                                                   | For the `'number'` type only. Defines the maximum allowed value of the property.                                   |
 
 ## Usage
 

--- a/docs/data/toolpad/reference/api/get-context.md
+++ b/docs/data/toolpad/reference/api/get-context.md
@@ -29,7 +29,7 @@ No parameters
 
 a `ServerContext` containing information on the context the backend function was called under.
 
-## types
+## Types
 
 ### ServerContext
 
@@ -40,7 +40,7 @@ This described a certain context under which a backend function was called.
 | Name        | Type                                    | Description                                       |
 | :---------- | :-------------------------------------- | :------------------------------------------------ |
 | `cookies`   | `Record<string, string>`                | A dictionary mapping cookie name to cookie value. |
-| `setCookie` | `(name: string, value: string) => void` | Use to set a cookie `name` with `value`           |
+| `setCookie` | `(name: string, value: string) => void` | Use to set a cookie `name` with `value`.          |
 
 ## Usage
 

--- a/docs/data/toolpad/reference/api/index.md
+++ b/docs/data/toolpad/reference/api/index.md
@@ -6,3 +6,4 @@
 
 - [createComponent](/toolpad/reference/api/create-component/)
 - [createFunction](/toolpad/reference/api/create-function/)
+- [getContext](/toolpad/reference/api/get-context/)

--- a/docs/pages/toolpad/reference/api/get-context.js
+++ b/docs/pages/toolpad/reference/api/get-context.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from '@mui/monorepo/docs/src/modules/components/MarkdownDocs';
+import * as pageProps from '../../../../data/toolpad/reference/api/get-context.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/packages/toolpad-core/src/serverRuntime.ts
+++ b/packages/toolpad-core/src/serverRuntime.ts
@@ -3,7 +3,13 @@ import { IncomingMessage, ServerResponse } from 'node:http';
 import * as cookie from 'cookie';
 
 export interface ServerContext {
+  /**
+   * A dictionary mapping cookie name to cookie value.
+   */
   cookies: Record<string, string>;
+  /**
+   * Use to set a cookie `name` with `value`.
+   */
   setCookie: (name: string, value: string) => void;
 }
 

--- a/packages/toolpad-core/src/types.ts
+++ b/packages/toolpad-core/src/types.ts
@@ -392,7 +392,7 @@ export type RuntimeEvent = {
 export interface ComponentConfig<P extends object = {}> {
   /**
    * A short explanatory text that'll be shown in the editor UI when this component is referenced.
-   * May contain Markdown
+   * May contain Markdown.
    */
   helperText?: string;
   /**
@@ -410,7 +410,7 @@ export interface ComponentConfig<P extends object = {}> {
   loadingPropSource?: (keyof P & string)[];
   /**
    * Designates a property as "the loading property". If Toolpad detects any of the
-   * inputs is still loading it will set this property to `true`
+   * inputs is still loading it will set this property to `true`.
    */
   loadingProp?: keyof P & string;
   /**
@@ -423,7 +423,7 @@ export interface ComponentConfig<P extends object = {}> {
    */
   resizableHeightProp?: keyof P & string;
   /**
-   * Describes the individual properties for this component
+   * Describes the individual properties for this component.
    */
   argTypes?: ArgTypeDefinitions<P>;
 }


### PR DESCRIPTION
Docs created in #2491 but not bound to the URL:

1. Open https://mui.com/toolpad/reference/api/
2. Click on "getContext"

<img width="315" alt="Screenshot 2023-09-09 at 23 25 30" src="https://github.com/mui/mui-toolpad/assets/3165635/c67f2499-6267-4ea0-a39a-b1f660eb6b41">

3. 404

Preview: https://deploy-preview-2656--mui-toolpad-docs.netlify.app/toolpad/reference/api/get-context/