### PR TITLE
[website] Tweak a few elements on the landing page

### DIFF
--- a/docs/src/components/landing/CodeBlock.js
+++ b/docs/src/components/landing/CodeBlock.js
@@ -225,6 +225,7 @@ export default function CodeBlock({ appMode, fileIndex, setFrameIndex }) {
             TabIndicatorProps={{
               sx: {
                 left: `${indicatorLeft}px!important`,
+                backgroundColor: 'primary.400',
               },
             }}
             sx={{ minHeight: 'auto' }}
@@ -236,10 +237,20 @@ export default function CodeBlock({ appMode, fileIndex, setFrameIndex }) {
                 value={index.toString()}
                 ref={tabRef}
                 key={index}
-                sx={{
+                sx={(theme) => ({
                   minHeight: 0,
                   padding: '12px 14px',
-                }}
+                  color: (theme.vars || theme).palette.grey[500],
+                  '&.Mui-selected': {
+                    color: (theme.vars || theme).palette.primary[300],
+                  },
+                  '&:hover': {
+                    color: (theme.vars || theme).palette.grey[300],
+                    '&.Mui-selected': {
+                      color: (theme.vars || theme).palette.primary[300],
+                    },
+                  },
+                })}
               />
             ))}
           </TabList>

--- a/docs/src/components/landing/GithubStars.js
+++ b/docs/src/components/landing/GithubStars.js
@@ -61,7 +61,7 @@ export default function GithubStars() {
           display: 'flex',
           alignItem: 'center',
           ml: 0.5,
-          color: theme.palette.primary[700],
+          color: theme.palette.primary[500],
           ...theme.applyDarkStyles({
             color: theme.palette.primary[200],
           }),

--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -270,7 +270,7 @@ export default function Hero() {
                 sm: 'unset',
                 md: `rotateY(${heroAppMode ? '0' : '180'}deg)`,
               },
-              boxShadow: `0 0 16px ${alpha(theme.palette.grey[100], 0.9)}`,
+              boxShadow: `0 4px 8px ${alpha(theme.palette.grey[100], 0.9)}`,
             }),
             (theme) =>
               theme.applyDarkStyles({
@@ -278,7 +278,7 @@ export default function Hero() {
                   (theme.vars || theme).palette.primaryDark[500]
                 } 0%, ${alpha(theme.palette.primaryDark[800], 0.4)} 150%)`,
                 borderColor: `${alpha(theme.palette.primaryDark[300], 0.3)}`,
-                boxShadow: `0 4px 8px ${alpha(theme.palette.primaryDark[600], 0.5)}`,
+                boxShadow: `0 4px 8px ${alpha(theme.palette.common.black, 0.8)}`,
               }),
           ]}
         >

--- a/docs/src/components/landing/UseCases.js
+++ b/docs/src/components/landing/UseCases.js
@@ -29,14 +29,15 @@ const ImageContainer = styled(Link)(({ theme }) => [
     )} 150%)`,
     border: '1px solid',
     borderColor: (theme.vars || theme).palette.grey[100],
-    boxShadow: `0 4px 8px ${alpha(theme.palette.grey[100], 0.5)}`,
+    boxShadow: `0 2px 4px ${alpha(theme.palette.grey[100], 0.8)}`,
     overflow: 'hidden',
   },
   theme.applyDarkStyles({
-    background: `linear-gradient(120deg, ${(theme.vars || theme).palette.primaryDark[500]
-      } 0%, ${alpha(theme.palette.primaryDark[800], 0.4)} 150%)`,
+    background: `linear-gradient(120deg, ${
+      (theme.vars || theme).palette.primaryDark[500]
+    } 0%, ${alpha(theme.palette.primaryDark[800], 0.4)} 150%)`,
     borderColor: `${alpha(theme.palette.primaryDark[300], 0.3)}`,
-    boxShadow: `0 4px 8px ${alpha(theme.palette.primaryDark[600], 0.5)}`,
+    boxShadow: `0 2px 4px ${alpha(theme.palette.common.black, 0.8)}`,
   }),
 ]);
 


### PR DESCRIPTION
This PR adds some design tweaks and polish to some landing page elements, notably the hero section code block tabs contrast, which could use a bump in color there. Every other change is mostly tiny!

| Before | After |
|--------|--------|
| <img width="607" alt="Screen Shot 2023-09-12 at 17 02 19" src="https://github.com/mui/mui-toolpad/assets/67129314/205c86c0-3a60-43ca-8fe8-ae637f4deb28"> | <img width="607" alt="Screen Shot 2023-09-12 at 17 12 14" src="https://github.com/mui/mui-toolpad/assets/67129314/c7be0be3-9b2e-4934-a083-40a896e88563"> | 



