### PR TITLE
Simplify component loading

### DIFF
--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -1039,15 +1039,7 @@ export function duplicateNode(
   return addFragment(dom, fragment, parent.id, parentProp);
 }
 
-const RENDERTREE_NODES = [
-  'app',
-  'page',
-  'element',
-  'query',
-  'mutation',
-  'theme',
-  'codeComponent',
-] as const;
+const RENDERTREE_NODES = ['app', 'page', 'element', 'query', 'mutation', 'theme'] as const;
 
 export type RenderTreeNodeType = (typeof RENDERTREE_NODES)[number];
 export type RenderTreeNode = { [K in RenderTreeNodeType]: AppDomNodeOfType<K> }[RenderTreeNodeType];

--- a/packages/toolpad-app/src/canvas/index.tsx
+++ b/packages/toolpad-app/src/canvas/index.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import invariant from 'invariant';
 import { throttle } from 'lodash-es';
 import { CanvasEventsContext } from '@mui/toolpad-core/runtime';
-import ToolpadApp, { LoadComponents } from '../runtime/ToolpadApp';
+import { ToolpadComponents } from '@mui/toolpad-core';
+import ToolpadApp from '../runtime/ToolpadApp';
 import { queryClient } from '../runtime/api';
 import { AppCanvasState } from '../types';
 import getPageViewState from './getPageViewState';
@@ -22,11 +23,11 @@ const handleScreenUpdate = throttle(
 export interface AppCanvasProps {
   initialState?: AppCanvasState | null;
   basename: string;
-  loadComponents: LoadComponents;
+  extraComponents: ToolpadComponents;
 }
 
 export default function AppCanvas({
-  loadComponents,
+  extraComponents,
   basename,
   initialState = null,
 }: AppCanvasProps) {
@@ -150,7 +151,7 @@ export default function AppCanvas({
         <CanvasEventsContext.Provider value={bridge.canvasEvents}>
           <ToolpadApp
             rootRef={onAppRoot}
-            loadComponents={loadComponents}
+            extraComponents={extraComponents}
             hasShell={false}
             basename={basename}
             state={state}

--- a/packages/toolpad-app/src/runtime/ToolpadApp.spec.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.spec.tsx
@@ -13,9 +13,7 @@ import ToolpadApp from './ToolpadApp';
 import * as appDom from '../appDom';
 import createRuntimeState from './createRuntimeState';
 
-async function loadComponents() {
-  return {};
-}
+const COMPONENTS = {};
 
 // More sensible default for these tests
 const waitFor: typeof waitForOrig = (waiter, options) =>
@@ -43,7 +41,7 @@ function renderPage(
 
   return render(
     <CanvasEventsContext.Provider value={canvasEvents}>
-      <ToolpadApp loadComponents={loadComponents} state={state} basename="toolpad" />
+      <ToolpadApp extraComponents={COMPONENTS} state={state} basename="toolpad" />
     </CanvasEventsContext.Provider>,
   );
 }

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -1536,7 +1536,6 @@ export default function ToolpadApp({
     () => ({ ...internalComponents, ...extraComponents }),
     [extraComponents],
   );
-  console.log('components', extraComponents, components);
 
   const [resetNodeErrorsKey, setResetNodeErrorsKey] = React.useState(0);
 

--- a/packages/toolpad-app/src/runtime/index.tsx
+++ b/packages/toolpad-app/src/runtime/index.tsx
@@ -43,13 +43,12 @@ export interface RootProps {
 
 function Root({ ToolpadApp, initialState, base }: RootProps) {
   const components = useComponents();
-  const loadComponents = React.useMemo(() => async () => components, [components]);
   return (
     <React.StrictMode>
       <CacheProvider value={cache}>
         {/* For some reason this helps with https://github.com/vitejs/vite/issues/12423 */}
         <Button sx={{ display: 'none' }} />
-        <ToolpadApp basename={base} state={initialState} loadComponents={loadComponents} />
+        <ToolpadApp basename={base} state={initialState} extraComponents={components} />
         <Box data-testid="page-ready-marker" sx={{ display: 'none' }} />
       </CacheProvider>
     </React.StrictMode>


### PR DESCRIPTION
Simplify the way we load custom components on the page. Realized this was possible while working on the [data providers](https://github.com/mui/mui-toolpad/pull/2644) as I needed a similar mechanism to initialize the available data providers on the frontend.

- We don't need `loadComponents` anymore. This is a remnant of how we hacked it in in under Next.js. Components are now always initialized through the sync external store
- Don't pass custom components in the render tree. They are now fully initialized in the generated entrypoint
