### PR TITLE
Avoid reloading queries twice on changes

### DIFF
--- a/packages/toolpad-app/cli/appBuilder.ts
+++ b/packages/toolpad-app/cli/appBuilder.ts
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 import { buildApp } from '../src/server/toolpadAppBuilder';
-import { initProject, getAppOutputFolder, getComponents } from '../src/server/localMode';
+import { initProject } from '../src/server/localMode';
 
 async function main() {
   invariant(
@@ -18,8 +18,8 @@ async function main() {
   await buildApp({
     root: projectDir,
     base: '/prod',
-    getComponents,
-    outDir: getAppOutputFolder(projectDir),
+    getComponents: () => project.getComponents(),
+    outDir: project.getAppOutputFolder(),
   });
 
   await project.dispose();

--- a/packages/toolpad-app/cli/appServer.ts
+++ b/packages/toolpad-app/cli/appServer.ts
@@ -66,7 +66,7 @@ export interface ToolpadAppDevServerParams {
   base: string;
 }
 
-export async function createDevServer({ outDir, config, root, base }: ToolpadAppDevServerParams) {
+async function createDevServer({ outDir, config, root, base }: ToolpadAppDevServerParams) {
   const { viteConfig } = createViteConfig({
     outDir,
     dev: true,

--- a/packages/toolpad-app/cli/server.ts
+++ b/packages/toolpad-app/cli/server.ts
@@ -18,12 +18,7 @@ import chalk from 'chalk';
 import { serveRpc } from '@mui/toolpad-utils/workerRpc';
 import { asyncHandler } from '../src/utils/express';
 import { createProdHandler } from '../src/server/toolpadAppServer';
-import {
-  ToolpadProject,
-  getAppOutputFolder,
-  getComponents,
-  initProject,
-} from '../src/server/localMode';
+import { ToolpadProject, initProject } from '../src/server/localMode';
 import type { Command as AppDevServerCommand, AppViteServerConfig, WorkerRpc } from './appServer';
 import { createRpcHandler } from '../src/server/rpc';
 import { RUNTIME_CONFIG_WINDOW_PROPERTY } from '../src/constants';
@@ -58,7 +53,7 @@ async function createDevHandler(
 
   const worker = new Worker(appServerPath, {
     workerData: {
-      outDir: getAppOutputFolder(project.getRoot()),
+      outDir: project.getAppOutputFolder(),
       base,
       config: runtimeConfig,
       root: project.getRoot(),
@@ -85,7 +80,7 @@ async function createDevHandler(
   serveRpc<WorkerRpc>(mainThreadRpcChannel.port2, {
     notifyReady: async () => resolveReadyPromise?.(),
     loadDom: async () => project.loadDom(),
-    getComponents: async () => getComponents(project.getRoot()),
+    getComponents: async () => project.getComponents(),
   });
 
   project.events.on('componentsListChanged', () => {

--- a/packages/toolpad-app/src/runtime/useDataQuery.ts
+++ b/packages/toolpad-app/src/runtime/useDataQuery.ts
@@ -40,8 +40,6 @@ export function useDataQuery(
   const queryName = node.name;
   const pageName = page.name;
 
-  // These are only used by the editor to invalidate caches whenever the query changes during editing
-  const nodeHash: number | undefined = savedNodes ? savedNodes[node.id] : undefined;
   const isNodeAvailableOnServer: boolean = savedNodes ? !!savedNodes[node.id] : true;
 
   const {
@@ -51,7 +49,7 @@ export function useDataQuery(
     data: responseData = EMPTY_OBJECT,
     refetch,
   } = useQuery(
-    [nodeHash, pageName, queryName, params],
+    [pageName, queryName, params],
     () => api.mutation.execQuery(pageName, queryName, params),
     {
       ...options,

--- a/packages/toolpad-app/src/server/localMode.ts
+++ b/packages/toolpad-app/src/server/localMode.ts
@@ -95,15 +95,15 @@ function getComponentFilePath(componentsFolder: string, componentName: string): 
   return path.join(componentsFolder, `${componentName}.tsx`);
 }
 
-export function getOutputFolder(root: string) {
+function getOutputFolder(root: string) {
   return path.join(getToolpadFolder(root), '.generated');
 }
 
-export function getAppOutputFolder(root: string) {
+function getAppOutputFolder(root: string) {
   return path.join(getOutputFolder(root), 'app');
 }
 
-export async function legacyConfigFileExists(root: string): Promise<boolean> {
+async function legacyConfigFileExists(root: string): Promise<boolean> {
   const [yamlFileExists, ymlFileExists] = await Promise.all([
     fileExists(path.join(root, './toolpad.yaml')),
     fileExists(path.join(root, './toolpad.yml')),
@@ -118,7 +118,7 @@ export interface ComponentEntry {
   path: string;
 }
 
-export async function getComponents(root: string): Promise<ComponentEntry[]> {
+async function getComponents(root: string): Promise<ComponentEntry[]> {
   const componentsFolder = getComponentsFolder(root);
   const entries = (await readMaybeDir(componentsFolder)) || [];
   const result = entries.map((entry) => {
@@ -1075,6 +1075,10 @@ class ToolpadProject {
     return getOutputFolder(this.getRoot());
   }
 
+  getAppOutputFolder() {
+    return getAppOutputFolder(this.getRoot());
+  }
+
   alertOnMissingVariablesInDom(dom: appDom.AppDom) {
     const requiredVars = appDom.getRequiredEnvVars(dom);
     const missingVars = Array.from(requiredVars).filter(
@@ -1119,6 +1123,10 @@ class ToolpadProject {
     const [dom] = await this.loadDomAndFingerprint();
     this.alertOnMissingVariablesInDom(dom);
     return dom;
+  }
+
+  async getComponents(): Promise<ComponentEntry[]> {
+    return getComponents(this.getRoot());
   }
 
   async writeDomToDisk(newDom: appDom.AppDom) {

--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -84,7 +84,7 @@ export function postProcessHtml(html: string, { config, dom }: PostProcessHtmlPa
 interface ToolpadVitePluginParams {
   root: string;
   base: string;
-  getComponents: (root: string) => Promise<ComponentEntry[]>;
+  getComponents: () => Promise<ComponentEntry[]>;
 }
 
 function toolpadVitePlugin({ root, base, getComponents }: ToolpadVitePluginParams): Plugin {
@@ -158,7 +158,7 @@ function toolpadVitePlugin({ root, base, getComponents }: ToolpadVitePluginParam
         };
       }
       if (id === resolvedComponentsId) {
-        const components = await getComponents(root);
+        const components = await getComponents();
 
         const imports = components.map(({ name }) => `import ${name} from './components/${name}';`);
 
@@ -190,7 +190,7 @@ export interface CreateViteConfigParams {
   dev: boolean;
   base: string;
   plugins?: Plugin[];
-  getComponents: (root: string) => Promise<ComponentEntry[]>;
+  getComponents: () => Promise<ComponentEntry[]>;
 }
 
 export interface CreateViteConfigResult {
@@ -309,7 +309,7 @@ export function createViteConfig({
 
 export interface ToolpadBuilderParams {
   outDir: string;
-  getComponents: (root: string) => Promise<ComponentEntry[]>;
+  getComponents: () => Promise<ComponentEntry[]>;
   root: string;
   base: string;
 }

--- a/packages/toolpad-app/src/server/toolpadAppServer.ts
+++ b/packages/toolpad-app/src/server/toolpadAppServer.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs/promises';
 import { Server } from 'http';
 import * as express from 'express';
 import { postProcessHtml } from './toolpadAppBuilder';
-import { ToolpadProject, getAppOutputFolder } from './localMode';
+import { ToolpadProject } from './localMode';
 import { asyncHandler } from '../utils/express';
 import { basicAuthUnauthorized, checkBasicAuthHeader } from './basicAuth';
 import { createRpcRuntimeServer } from './rpcRuntimeServer';
@@ -23,7 +23,7 @@ export interface ToolpadAppHandlerParams {
 export async function createProdHandler(project: ToolpadProject) {
   const handler = express.Router();
 
-  handler.use(express.static(getAppOutputFolder(project.getRoot()), { index: false }));
+  handler.use(express.static(project.getAppOutputFolder(), { index: false }));
 
   // Allow static assets, block everything else
   handler.use((req, res, next) => {
@@ -43,7 +43,7 @@ export async function createProdHandler(project: ToolpadProject) {
     asyncHandler(async (req, res) => {
       const dom = await project.loadDom();
 
-      const htmlFilePath = path.resolve(getAppOutputFolder(project.getRoot()), './index.html');
+      const htmlFilePath = path.resolve(project.getAppOutputFolder(), './index.html');
       let html = await fs.readFile(htmlFilePath, { encoding: 'utf-8' });
 
       html = postProcessHtml(html, { config: project.getRuntimeConfig(), dom });


### PR DESCRIPTION
- Remove node hashes mechanism to reload queries on changes. We're taking care of this through the project event system already. This avoids reloading the queries twice

Also in this PR, some cleanup that I ran into:
- Use the same `project.getComponents()` everywhere
- Remove reliance on global functions to get application folders
