### PR TITLE
Unify useDom, useDomLoader and useAppState

### DIFF
--- a/packages/toolpad-app/src/toolpad/AppEditor/AppEditorShell.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/AppEditorShell.tsx
@@ -5,13 +5,13 @@ import SyncProblemIcon from '@mui/icons-material/SyncProblem';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
-import { DomLoader, useDomLoader } from '../AppState';
+import { AppState, useAppState } from '../AppState';
 import ToolpadShell from '../ToolpadShell';
 import PagePanel from './PagePanel';
 import { getViewFromPathname } from '../../utils/domView';
 
-function getSaveState(domLoader: DomLoader): React.ReactNode {
-  if (domLoader.saveDomError) {
+function getSaveState(appState: AppState): React.ReactNode {
+  if (appState.saveDomError) {
     return (
       <Tooltip title="Error while saving">
         <SyncProblemIcon color="primary" />
@@ -19,7 +19,7 @@ function getSaveState(domLoader: DomLoader): React.ReactNode {
     );
   }
 
-  const isSaving = domLoader.unsavedDomChanges > 0;
+  const isSaving = appState.unsavedDomChanges > 0;
 
   if (isSaving) {
     return (
@@ -42,7 +42,7 @@ export interface ToolpadShellProps {
 }
 
 export default function AppEditorShell({ children, ...props }: ToolpadShellProps) {
-  const domLoader = useDomLoader();
+  const appState = useAppState();
 
   const location = useLocation();
 
@@ -67,7 +67,7 @@ export default function AppEditorShell({ children, ...props }: ToolpadShellProps
           </Button>
         </Stack>
       }
-      status={getSaveState(domLoader)}
+      status={getSaveState(appState)}
       {...props}
     >
       <Box

--- a/packages/toolpad-app/src/toolpad/AppEditor/BindingEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/BindingEditor.tsx
@@ -50,7 +50,7 @@ import useUnsavedChangesConfirm from '../hooks/useUnsavedChangesConfirm';
 
 import TabPanel from '../../components/TabPanel';
 
-import { useDom } from '../AppState';
+import { useAppState } from '../AppState';
 import * as appDom from '../../appDom';
 import { getBindingType, getBindingValue } from '../../bindings';
 
@@ -338,7 +338,7 @@ function NavigationActionParameterEditor({
 export interface NavigationActionEditorProps extends WithControlledProp<NavigationAction | null> {}
 
 function NavigationActionEditor({ value, onChange }: NavigationActionEditorProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const root = appDom.getApp(dom);
   const { pages = [] } = appDom.getChildNodes(dom, root);
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/ConnectionEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/ConnectionEditor/index.tsx
@@ -3,7 +3,7 @@ import { Box, Container, Stack, Typography } from '@mui/material';
 import { NodeId } from '@mui/toolpad-core';
 import invariant from 'invariant';
 import { ConnectionEditorProps, ClientDataSource } from '../../../types';
-import { useDom, useDomApi } from '../../AppState';
+import { useAppState, useDomApi } from '../../AppState';
 import * as appDom from '../../../appDom';
 import dataSources from '../../../toolpadDataSources/client';
 import { ConnectionContextProvider } from '../../../toolpadDataSources/context';
@@ -100,7 +100,7 @@ export interface ConnectionProps {
 }
 
 export default function ConnectionEditor({ nodeId }: ConnectionProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const connectionNode = appDom.getMaybeNode(dom, nodeId as NodeId, 'connection');
 
   useUndoRedo();

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -5,7 +5,7 @@ import { TreeView, TreeItem, TreeItemProps } from '@mui/x-tree-view';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import * as appDom from '../../../appDom';
-import { useDom, useDomApi, useAppState, useAppStateApi } from '../../AppState';
+import { useAppState, useDomApi, useAppStateApi } from '../../AppState';
 import EditableText from '../../../components/EditableText';
 import { ComponentIcon } from '../PageEditor/ComponentCatalog/ComponentCatalogItem';
 import { useNodeNameValidation } from '../PagesExplorer/validation';
@@ -19,7 +19,7 @@ export interface CustomTreeItemProps extends TreeItemProps {
 
 function CustomTreeItem(props: CustomTreeItemProps) {
   const domApi = useDomApi();
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const appStateApi = useAppStateApi();
 
   const [domNodeEditable, setDomNodeEditable] = React.useState(false);
@@ -132,7 +132,7 @@ function RecursiveSubTree({ dom, root }: { dom: appDom.AppDom; root: appDom.Elem
 }
 
 export default function HierarchyExplorer() {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { currentView } = useAppState();
   const appStateApi = useAppStateApi();
   const [expandedDomNodeIds, setExpandedDomNodeIds] = React.useState<string[]>([]);

--- a/packages/toolpad-app/src/toolpad/AppEditor/NodeMenu.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/NodeMenu.tsx
@@ -4,7 +4,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { NodeId } from '@mui/toolpad-core';
 import * as appDom from '../../appDom';
-import { useDom } from '../AppState';
+import { useAppState } from '../AppState';
 import useLatest from '../../utils/useLatest';
 import { ConfirmDialog } from '../../components/SystemDialogs';
 import useMenu from '../../utils/useMenu';
@@ -26,7 +26,7 @@ export default function NodeMenu({
   onDeleteNode,
   onDuplicateNode,
 }: NodeMenuProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
 
   const { menuProps, buttonProps, onMenuClose } = useMenu();
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/NodeNameEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/NodeNameEditor.tsx
@@ -1,7 +1,7 @@
 import { SxProps, TextField } from '@mui/material';
 import * as React from 'react';
 import * as appDom from '../../appDom';
-import { useDom, useDomApi } from '../AppState';
+import { useAppState, useDomApi } from '../AppState';
 import { useNodeNameValidation } from './PagesExplorer/validation';
 import client from '../../api';
 
@@ -12,7 +12,7 @@ interface NodeNameEditorProps {
 
 export default function NodeNameEditor({ node, sx }: NodeNameEditorProps) {
   const domApi = useDomApi();
-  const { dom } = useDom();
+  const { dom } = useAppState();
 
   const [nameInput, setNameInput] = React.useState(node.name);
   React.useEffect(() => setNameInput(node.name), [node.name]);

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
@@ -7,7 +7,7 @@ import invariant from 'invariant';
 import ComponentCatalogItem from './ComponentCatalogItem';
 import CreateCodeComponentNodeDialog from '../../PagesExplorer/CreateCodeComponentNodeDialog';
 import * as appDom from '../../../../appDom';
-import { useDom } from '../../../AppState';
+import { useAppState } from '../../../AppState';
 import { usePageEditorApi } from '../PageEditorProvider';
 import { useToolpadComponents } from '../../toolpadComponents';
 import useLocalStorageState from '../../../../utils/useLocalStorageState';
@@ -46,7 +46,7 @@ export interface ComponentCatalogProps {
 
 export default function ComponentCatalog({ className }: ComponentCatalogProps) {
   const api = usePageEditorApi();
-  const { dom } = useDom();
+  const { dom } = useAppState();
 
   const [openStart, setOpenStart] = React.useState(0);
   const [openCustomComponents, setOpenCustomComponents] = useLocalStorageState(

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentEditor.tsx
@@ -12,7 +12,7 @@ import {
 import { ExactEntriesOf } from '../../../utils/types';
 import * as appDom from '../../../appDom';
 import NodeAttributeEditor from './NodeAttributeEditor';
-import { useDom } from '../../AppState';
+import { useAppState } from '../../AppState';
 import { usePageEditorState } from './PageEditorProvider';
 import ErrorAlert from './ErrorAlert';
 import NodeNameEditor from '../NodeNameEditor';
@@ -167,7 +167,7 @@ interface SelectedNodeEditorProps {
 }
 
 function SelectedNodeEditor({ node }: SelectedNodeEditorProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { bindings, viewState } = usePageEditorState();
 
   const nodeError = viewState.nodes[node.id]?.error;

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentPanel.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import PageOptionsPanel from './PageOptionsPanel';
 import ComponentEditor from './ComponentEditor';
 import ThemeEditor from './ThemeEditor';
-import { useAppState, useAppStateApi, useDom } from '../../AppState';
+import { useAppState, useAppStateApi } from '../../AppState';
 import { PageViewTab } from '../../../utils/domView';
 import * as appDom from '../../../appDom';
 
@@ -67,7 +67,7 @@ export interface ComponentPanelProps {
 }
 
 export default function ComponentPanel({ className }: ComponentPanelProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { currentView } = useAppState();
   const appStateApi = useAppStateApi();
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ConnectionSelect.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ConnectionSelect.tsx
@@ -4,7 +4,7 @@ import { NodeId } from '@mui/toolpad-core';
 import { asArray } from '@mui/toolpad-utils/collections';
 import * as appDom from '../../../appDom';
 import { Maybe, WithControlledProp } from '../../../utils/types';
-import { useDom } from '../../AppState';
+import { useAppState } from '../../AppState';
 import dataSources from '../../../toolpadDataSources/client';
 
 export type ConnectionOption = {
@@ -23,7 +23,7 @@ export default function ConnectionSelect({
   value,
   onChange,
 }: ConnectionSelectProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
 
   const app = appDom.getApp(dom);
   const { connections = [] } = appDom.getChildNodes(dom, app);

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageOptionsPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageOptionsPanel.tsx
@@ -1,6 +1,6 @@
 import { Stack, Typography, Divider, MenuItem, TextField, Tooltip, Link } from '@mui/material';
 import * as React from 'react';
-import { useDom, useDomApi } from '../../AppState';
+import { useAppState, useDomApi } from '../../AppState';
 import { usePageEditorState } from './PageEditorProvider';
 import QueryEditor from './QueryEditor';
 import UrlQueryEditor from './UrlQueryEditor';
@@ -15,7 +15,7 @@ const PAGE_DISPLAY_OPTIONS: { value: appDom.PageDisplayMode; label: string }[] =
 
 export default function PageOptionsPanel() {
   const { nodeId: pageNodeId } = usePageEditorState();
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const domApi = useDomApi();
 
   const page = appDom.getNode(dom, pageNodeId, 'page');

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor/QueryEditorDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor/QueryEditorDialog.tsx
@@ -22,7 +22,7 @@ import * as appDom from '../../../../appDom';
 import dataSources from '../../../../toolpadDataSources/client';
 import { omit, update } from '../../../../utils/immutability';
 import { useEvaluateLiveBinding } from '../../useEvaluateLiveBinding';
-import { useDom } from '../../../AppState';
+import { useAppState } from '../../../AppState';
 import { ConnectionContextProvider } from '../../../../toolpadDataSources/context';
 import ConnectionSelect, { ConnectionOption } from '../ConnectionSelect';
 import BindableEditor from '../BindableEditor';
@@ -107,7 +107,7 @@ export default function QueryNodeEditorDialog<Q>({
   onSave,
   isDraft,
 }: QueryNodeEditorProps<Q>) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
 
   // To keep it around during closing animation
   const node = useLatest(nodeProp);

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/QueryEditor/index.tsx
@@ -25,7 +25,7 @@ import clsx from 'clsx';
 import { usePageEditorState } from '../PageEditorProvider';
 import * as appDom from '../../../../appDom';
 import dataSources from '../../../../toolpadDataSources/client';
-import { useAppStateApi, useDom, useDomApi, useAppState } from '../../../AppState';
+import { useAppStateApi, useAppState, useDomApi } from '../../../AppState';
 import NodeMenu from '../../NodeMenu';
 import QueryNodeEditorDialog from './QueryEditorDialog';
 
@@ -51,7 +51,7 @@ interface DataSourceSelectorProps<Q> {
 }
 
 function ConnectionSelectorDialog<Q>({ open, onCreated, onClose }: DataSourceSelectorProps<Q>) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
 
   const handleCreateClick = React.useCallback(
     (dataSourceId: string) => () => {
@@ -117,7 +117,7 @@ type DialogState =
     };
 
 export default function QueryEditor() {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { currentView } = useAppState();
   const state = usePageEditorState();
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeDropArea.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/NodeDropArea.tsx
@@ -12,7 +12,7 @@ import {
   Rectangle,
 } from '../../../../utils/geometry';
 
-import { useDom } from '../../../AppState';
+import { useAppState } from '../../../AppState';
 
 import {
   DROP_ZONE_CENTER,
@@ -156,7 +156,7 @@ export default function NodeDropArea({
   dropAreaRect,
   availableDropZones,
 }: NodeDropAreaProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { dragOverNodeId, dragOverSlotParentProp, dragOverZone, viewState } = usePageEditorState();
 
   const { nodes: nodesInfo } = viewState;

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/OverlayGrid.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/OverlayGrid.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Grid, styled } from '@mui/material';
 import invariant from 'invariant';
 import { usePageEditorState } from '../PageEditorProvider';
-import { useDom } from '../../../AppState';
+import { useAppState } from '../../../AppState';
 import { createToolpadAppTheme } from '../../../../runtime/AppThemeProvider';
 import { absolutePositionCss } from '../../../../utils/geometry';
 
@@ -38,7 +38,7 @@ export const OverlayGrid = React.forwardRef<OverlayGridHandle>(function OverlayG
 ) {
   const gridRef = React.useRef<HTMLDivElement | null>(null);
 
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { viewState, nodeId: pageNodeId } = usePageEditorState();
 
   const { nodes: nodesInfo } = viewState;

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderOverlay.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import invariant from 'invariant';
 
 import * as appDom from '../../../../appDom';
-import { useAppStateApi, useDom, useDomApi, useAppState } from '../../../AppState';
+import { useAppStateApi, useAppState, useDomApi } from '../../../AppState';
 import {
   DropZone,
   DROP_ZONE_BOTTOM,
@@ -143,7 +143,7 @@ interface RenderOverlayProps {
 }
 
 export default function RenderOverlay({ bridge }: RenderOverlayProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { currentView } = useAppState();
   const selectedNodeId = currentView.kind === 'page' ? currentView.selectedNodeId : null;
   const hoveredNodeId = currentView.kind === 'page' ? currentView.hoveredNodeId : null;

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderPanel.tsx
@@ -3,7 +3,7 @@ import { styled } from '@mui/material';
 import { NodeId } from '@mui/toolpad-core';
 import * as appDom from '../../../../appDom';
 import EditorCanvasHost from '../EditorCanvasHost';
-import { getNodeHashes, useDom, useAppStateApi, useDomLoader, useDomApi } from '../../../AppState';
+import { getNodeHashes, useAppState, useAppStateApi, useDomApi } from '../../../AppState';
 import { usePageEditorApi, usePageEditorState } from '../PageEditorProvider';
 import RenderOverlay from './RenderOverlay';
 import { NodeHashes } from '../../../../types';
@@ -29,8 +29,8 @@ export interface RenderPanelProps {
 }
 
 export default function RenderPanel({ className }: RenderPanelProps) {
-  const domLoader = useDomLoader();
-  const { dom } = useDom();
+  const domLoader = useAppState();
+  const { dom } = useAppState();
   const domApi = useDomApi();
   const appStateApi = useAppStateApi();
   const pageEditorApi = usePageEditorApi();

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ThemeEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ThemeEditor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as appDom from '../../../appDom';
-import { useDom, useDomApi } from '../../AppState';
+import { useAppState, useDomApi } from '../../AppState';
 import MuiThemeEditor from '../../../components/MuiThemeEditor';
 
 export interface ComponentEditorProps {
@@ -8,7 +8,7 @@ export interface ComponentEditorProps {
 }
 
 export default function ComponentEditor({ className }: ComponentEditorProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const domApi = useDomApi();
 
   const app = appDom.getApp(dom);

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/UrlQueryEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/UrlQueryEditor.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import { NodeId } from '@mui/toolpad-core';
 import * as appDom from '../../../appDom';
-import { useDom, useDomApi, useAppState, useAppStateApi } from '../../AppState';
+import { useAppState, useDomApi, useAppStateApi } from '../../AppState';
 import MapEntriesEditor from '../../../components/MapEntriesEditor';
 import useBoolean from '../../../utils/useBoolean';
 import useUnsavedChangesConfirm from '../../hooks/useUnsavedChangesConfirm';
@@ -43,7 +43,7 @@ function UrlQueryString({ input }: UrlQueryStringProps) {
 }
 
 export default function UrlQueryEditor({ pageNodeId }: UrlQueryEditorProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { currentView } = useAppState();
 
   const domApi = useDomApi();

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
@@ -5,7 +5,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from '../../../components/resiza
 import RenderPanel from './RenderPanel';
 import ComponentPanel from './ComponentPanel';
 import { PageEditorProvider } from './PageEditorProvider';
-import { useDom } from '../../AppState';
+import { useAppState } from '../../AppState';
 import * as appDom from '../../../appDom';
 import ComponentCatalog from './ComponentCatalog';
 import NotFoundEditor from '../NotFoundEditor';
@@ -57,7 +57,7 @@ interface PageEditorProps {
 }
 
 export default function PageEditor({ nodeId }: PageEditorProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const pageNode = appDom.getMaybeNode(dom, nodeId as NodeId, 'page');
 
   useUndoRedo();

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -3,7 +3,7 @@ import { styled, SxProps, Box, Divider, Typography } from '@mui/material';
 import { Panel, PanelGroup, PanelResizeHandle } from '../../components/resizablePanels';
 import PagesExplorer from './PagesExplorer';
 import PageHierarchyExplorer from './HierarchyExplorer';
-import { useDom } from '../AppState';
+import { useAppState } from '../AppState';
 import AppOptions from '../AppOptions';
 import config from '../../config';
 
@@ -18,7 +18,7 @@ export interface ComponentPanelProps {
 }
 
 export default function PagePanel({ className, sx }: ComponentPanelProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
 
   return (
     <PagePanelRoot className={className} sx={sx}>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/CreateCodeComponentNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/CreateCodeComponentNodeDialog.tsx
@@ -13,7 +13,7 @@ import * as React from 'react';
 import invariant from 'invariant';
 import CloseIcon from '@mui/icons-material/Close';
 import * as appDom from '../../../appDom';
-import { useDom } from '../../AppState';
+import { useAppState } from '../../AppState';
 import DialogForm from '../../../components/DialogForm';
 import useEvent from '../../../utils/useEvent';
 import { useNodeNameValidation } from './validation';
@@ -33,7 +33,7 @@ export default function CreateCodeComponentDialog({
   onClose,
   ...props
 }: CreateCodeComponentDialogProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
 
   const existingNames = React.useMemo(
     () => appDom.getExistingNamesForChildren(dom, appDom.getApp(dom), 'codeComponents'),

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/CreatePageNodeDialog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/CreatePageNodeDialog.tsx
@@ -11,7 +11,7 @@ import invariant from 'invariant';
 import * as appDom from '../../../appDom';
 import DialogForm from '../../../components/DialogForm';
 import useEvent from '../../../utils/useEvent';
-import { useAppStateApi, useDom } from '../../AppState';
+import { useAppStateApi, useAppState } from '../../AppState';
 import { useNodeNameValidation } from './validation';
 
 const DEFAULT_NAME = 'page';
@@ -22,7 +22,7 @@ export interface CreatePageDialogProps {
 }
 
 export default function CreatePageDialog({ open, onClose, ...props }: CreatePageDialogProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const appStateApi = useAppStateApi();
 
   const existingNames = React.useMemo(

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -9,7 +9,7 @@ import { NodeId } from '@mui/toolpad-core';
 import clsx from 'clsx';
 import invariant from 'invariant';
 import * as appDom from '../../../appDom';
-import { useAppStateApi, useDom, useAppState } from '../../AppState';
+import { useAppStateApi, useAppState } from '../../AppState';
 import CreatePageNodeDialog from './CreatePageNodeDialog';
 import useLocalStorageState from '../../../utils/useLocalStorageState';
 import NodeMenu from '../NodeMenu';
@@ -124,7 +124,7 @@ export interface PagesExplorerProps {
 }
 
 export default function PagesExplorer({ className }: PagesExplorerProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const { currentView } = useAppState();
 
   const appStateApi = useAppStateApi();

--- a/packages/toolpad-app/src/toolpad/AppState.tsx
+++ b/packages/toolpad-app/src/toolpad/AppState.tsx
@@ -96,15 +96,27 @@ export function domReducer(dom: appDom.AppDom, action: AppStateAction): appDom.A
   }
 }
 
-export interface DomLoader {
+export interface AppState {
   dom: appDom.AppDom;
   savedDom: appDom.AppDom;
   savingDom: boolean;
   unsavedDomChanges: number;
   saveDomError: string | null;
+  currentView: DomView;
+  undoStack: UndoRedoStackEntry[];
+  redoStack: UndoRedoStackEntry[];
+  hasUnsavedChanges: boolean;
 }
 
-export function domLoaderReducer(state: DomLoader, action: AppStateAction): DomLoader {
+export interface UndoRedoStackEntry {
+  dom: appDom.AppDom;
+  view: DomView;
+  timestamp: number;
+}
+
+const UNDO_HISTORY_LIMIT = 100;
+
+export function appStateReducer(state: AppState, action: AppStateAction): AppState {
   if (state.dom) {
     const newDom = domReducer(state.dom, action);
     const hasUnsavedDomChanges = newDom !== state.dom;
@@ -146,33 +158,6 @@ export function domLoaderReducer(state: DomLoader, action: AppStateAction): DomL
 
       return update(state, { dom: action.dom, savedDom: action.dom });
     }
-    default:
-      return state;
-  }
-}
-
-export interface AppState extends DomLoader {
-  currentView: DomView;
-  undoStack: UndoRedoStackEntry[];
-  redoStack: UndoRedoStackEntry[];
-  hasUnsavedChanges: boolean;
-}
-
-export type PublicAppState = Pick<AppState, 'dom' | 'currentView' | 'hasUnsavedChanges'>;
-
-interface UndoRedoStackEntry extends Omit<PublicAppState, 'currentView' | 'hasUnsavedChanges'> {
-  view: DomView;
-  timestamp: number;
-}
-
-const UNDO_HISTORY_LIMIT = 100;
-
-export function appStateReducer(state: AppState, action: AppStateAction): AppState {
-  const domLoaderState = domLoaderReducer(state, action);
-
-  state = { ...state, ...domLoaderState };
-
-  switch (action.type) {
     case 'UPDATE_HISTORY': {
       const updatedUndoStack = [
         ...state.undoStack,
@@ -410,34 +395,14 @@ function createAppStateApi(
 
 const [useAppStateContext, AppStateProvider] = createProvidedContext<AppState>('AppState');
 
-export function useDom(): Pick<AppState, 'dom'> {
-  const { dom } = useAppStateContext();
+export function useAppState(): AppState {
+  const appState = useAppStateContext();
 
-  if (!dom) {
+  if (!appState.dom) {
     throw new Error("Trying to access the DOM before it's loaded");
   }
 
-  return { dom };
-}
-
-export function useDomLoader(): DomLoader {
-  const { dom, savedDom, savingDom, unsavedDomChanges, saveDomError } = useAppStateContext();
-
-  if (!dom) {
-    throw new Error("Trying to access the DOM before it's loaded");
-  }
-
-  return { dom, savedDom, savingDom, unsavedDomChanges, saveDomError };
-}
-
-export function useAppState(): PublicAppState {
-  const { dom, currentView, hasUnsavedChanges } = useAppStateContext();
-
-  if (!dom) {
-    throw new Error("Trying to access the DOM before it's loaded");
-  }
-
-  return { dom, currentView, hasUnsavedChanges };
+  return appState;
 }
 
 const DomApiContext = React.createContext<DomApi>(createDomApi(() => undefined));

--- a/packages/toolpad-app/src/toolpad/propertyControls/ChartData.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/ChartData.tsx
@@ -29,7 +29,7 @@ import * as appDom from '../../appDom';
 import type { EditorProps } from '../../types';
 import PropertyControl from '../../components/PropertyControl';
 import { usePageEditorState } from '../AppEditor/PageEditor/PageEditorProvider';
-import { useDom, useDomApi } from '../AppState';
+import { useAppState, useDomApi } from '../AppState';
 import BindableEditor from '../AppEditor/PageEditor/BindableEditor';
 import { updateArray, remove } from '../../utils/immutability';
 import { createToolpadAppTheme } from '../../runtime/AppThemeProvider';
@@ -51,7 +51,7 @@ function ChartDataPropEditor({
   value = [],
   onChange,
 }: EditorProps<ChartDataSeries[]>) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const domApi = useDomApi();
   const { pageState, bindings, globalScopeMeta } = usePageEditorState();
   const jsBrowserRuntime = useBrowserJsRuntime();

--- a/packages/toolpad-app/src/toolpad/propertyControls/GridColumns.tsx
+++ b/packages/toolpad-app/src/toolpad/propertyControls/GridColumns.tsx
@@ -31,7 +31,7 @@ import { DateFormatEditor } from '@mui/toolpad-core/dateFormat';
 import type { EditorProps } from '../../types';
 import { useToolpadComponents } from '../AppEditor/toolpadComponents';
 import { ToolpadComponentDefinition } from '../../runtime/toolpadComponents';
-import { useDom } from '../AppState';
+import { useAppState } from '../AppState';
 import PropertyControl from '../../components/PropertyControl';
 
 // TODO: this import suggests leaky abstraction
@@ -115,7 +115,7 @@ function GridColumnEditor({
   value: editedColumn,
   onChange: handleColumnChange,
 }: GridColumnEditorProps) {
-  const { dom } = useDom();
+  const { dom } = useAppState();
   const toolpadComponents = useToolpadComponents(dom);
   const codeComponents: ToolpadComponentDefinition[] = React.useMemo(() => {
     return Object.values(toolpadComponents)


### PR DESCRIPTION
Unify the three reducers into a single one `AppState`. Having separate `useDom`, `useDomLoader` and `useAppState`, each with a different subset of the same state feels a bit complicated. We can leave the selection to consumers of the state instead. I'm also trying to add more than just the dom in this app state and the nomenclature gets all messed up.