### PR TITLE
hoist documentation dependencies again

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -11,7 +11,7 @@ const withDocsInfra = require('@mui/monorepo/docs/nextConfigDocsInfra');
 const pkg = require('../package.json');
 const { findPages } = require('./src/modules/utils/find');
 
-const MONOREPO_PATH = path.resolve(currentDirectory, './node_modules/@mui/monorepo');
+const MONOREPO_PATH = path.resolve(currentDirectory, '../node_modules/@mui/monorepo');
 const MONOREPO_PACKAGES = {
   '@mui/base': path.resolve(MONOREPO_PATH, './packages/mui-base/src'),
   '@mui/codemod': path.resolve(MONOREPO_PATH, './packages/mui-codemod/src'),

--- a/package.json
+++ b/package.json
@@ -9,10 +9,6 @@
     "packages": [
       "packages/*",
       "docs"
-    ],
-    "nohoist": [
-      "docs",
-      "docs/**"
     ]
   },
   "bin": {


### PR DESCRIPTION
Since adding `@mui/toolpad` as a dependency to the docs we're getting weird `yarn install` bugs. I suspect it's becasue of our exotic setup where we no-hoist the docs dependencies. Back when we were setting this up it was the only way we could get the docs to work and ran out of time to figure out what was really happening. The issues seem to be resolved now.

https://deploy-preview-2701--mui-toolpad-docs.netlify.app/toolpad

* The install step in CI seems to be about 2-3 times faster.
* This will fix the problem with https://github.com/mui/mui-toolpad/pull/2694
