### PR TITLE
[docs] Fix incorrect nomenclature

### DIFF
--- a/docs/data/toolpad/reference/components/select.md
+++ b/docs/data/toolpad/reference/components/select.md
@@ -4,7 +4,7 @@
 
 <p class="description">API docs for the Toolpad Select component.</p>
 
-The MUI [Select](https://mui.com/material-ui/react-select/) component lets you select a value from a set of options.
+The Material UI [Select](https://mui.com/material-ui/react-select/) component lets you select a value from a set of options.
 
 ## Properties
 


### PR DESCRIPTION
 https://mui.com/toolpad/reference/components/select/
> The MUI [Select](https://mui.com/material-ui/react-select/) component 

- Change "MUI" to "Material UI"
