### PR TITLE
Refactor cli interface

### DIFF
--- a/packages/toolpad-app/cli/appBuilder.ts
+++ b/packages/toolpad-app/cli/appBuilder.ts
@@ -11,7 +11,7 @@ async function main() {
 
   const projectDir = process.env.TOOLPAD_PROJECT_DIR;
 
-  const project = await initProject('build', projectDir);
+  const project = await initProject({ dir: projectDir });
 
   await project.build();
 

--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -12,13 +12,14 @@ export interface RunOptions {
   dev?: boolean;
 }
 
-async function runCommand(cmd: 'dev' | 'start', { dir, ...args }: Omit<RunOptions, 'cmd'>) {
+async function runCommand(cmd: 'dev' | 'start', { dir, dev, ...args }: Omit<RunOptions, 'cmd'>) {
   const projectDir = path.resolve(process.cwd(), dir);
 
   const app = await runApp({
     ...args,
-    projectDir,
+    dir: projectDir,
     cmd,
+    toolpadDevMode: dev,
   });
 
   process.once('SIGINT', () => {

--- a/packages/toolpad-app/src/config.ts
+++ b/packages/toolpad-app/src/config.ts
@@ -38,7 +38,6 @@ export type BuildEnvVars = Record<
 export interface RuntimeConfig {
   externalUrl: string;
   projectDir?: string;
-  cmd: 'dev' | 'start' | 'build';
 }
 
 declare global {

--- a/packages/toolpad-app/src/server/FunctionsManager.ts
+++ b/packages/toolpad-app/src/server/FunctionsManager.ts
@@ -7,7 +7,6 @@ import * as chokidar from 'chokidar';
 import chalk from 'chalk';
 import { glob } from 'glob';
 import { writeFileRecursive, fileExists, readJsonFile } from '@mui/toolpad-utils/fs';
-import invariant from 'invariant';
 import Piscina from 'piscina';
 import { ExecFetchResult } from '@mui/toolpad-core';
 import { errorFrom } from '@mui/toolpad-utils/errors';
@@ -81,15 +80,6 @@ export default class FunctionsManager {
   constructor(project: IToolpadProject) {
     this.project = project;
     this.devWorker = createDevWorker(process.env);
-    if (this.shouldExtractTypes()) {
-      this.extractTypesWorker = new Piscina({
-        filename: path.join(__dirname, 'functionsTypesWorker.js'),
-      });
-    }
-  }
-
-  shouldExtractTypes(): boolean {
-    return this.project.options.cmd !== 'start';
   }
 
   private getResourcesFolder(): string {
@@ -140,8 +130,12 @@ export default class FunctionsManager {
   }
 
   private async extractTypes() {
-    invariant(this.shouldExtractTypes(), 'extractTypes() can not be used in prod mode');
-    invariant(this.extractTypesWorker, 'this.extractTypesWorker should have been initialized');
+    if (!this.extractTypesWorker) {
+      this.extractTypesWorker = new Piscina({
+        filename: path.join(__dirname, 'functionsTypesWorker.js'),
+      });
+    }
+
     const extractedTypes: Promise<IntrospectionResult> = this.extractTypesWorker
       .run({ resourcesFolder: this.getResourcesFolder() } satisfies ExtractTypesParams, {})
       .catch((error: unknown) => ({
@@ -311,7 +305,7 @@ export default class FunctionsManager {
 
   async introspect(): Promise<IntrospectionResult> {
     if (!this.extractedTypes) {
-      if (this.shouldExtractTypes()) {
+      if (this.project.options.dev) {
         this.extractedTypes = this.extractTypes();
       } else {
         this.extractedTypes = readJsonFile(

--- a/packages/toolpad-app/src/server/localMode.ts
+++ b/packages/toolpad-app/src/server/localMode.ts
@@ -992,7 +992,6 @@ class ToolpadProject {
   constructor(root: string, options: Partial<ToolpadProjectOptions>) {
     this.root = root;
     this.options = {
-      // cmd: 'start',
       dev: false,
       externalUrl: 'http://localhost:3000',
       ...options,

--- a/packages/toolpad-app/src/server/localMode.ts
+++ b/packages/toolpad-app/src/server/localMode.ts
@@ -992,7 +992,7 @@ class ToolpadProject {
   constructor(root: string, options: Partial<ToolpadProjectOptions>) {
     this.root = root;
     this.options = {
-      cmd: 'start',
+      // cmd: 'start',
       dev: false,
       externalUrl: 'http://localhost:3000',
       ...options,
@@ -1203,7 +1203,6 @@ class ToolpadProject {
     return {
       externalUrl: this.options.externalUrl,
       projectDir: this.getRoot(),
-      cmd: this.options.dev ? 'dev' : 'start',
     };
   }
 }
@@ -1215,19 +1214,21 @@ declare global {
   var __toolpadProject: ToolpadProject | undefined;
 }
 
-export async function initProject(
-  cmd: 'dev' | 'start' | 'build',
-  root: string,
-  externalUrl?: string,
-) {
+export interface InitProjectOptions {
+  dev?: boolean;
+  dir: string;
+  externalUrl?: string;
+}
+
+export async function initProject({ dev, dir, externalUrl }: InitProjectOptions) {
   // eslint-disable-next-line no-underscore-dangle
   invariant(!global.__toolpadProject, 'A project is already running');
 
-  await migrateLegacyProject(root);
+  await migrateLegacyProject(dir);
 
-  await initToolpadFolder(root);
+  await initToolpadFolder(dir);
 
-  const project = new ToolpadProject(root, { cmd, dev: cmd === 'dev', externalUrl });
+  const project = new ToolpadProject(dir, { dev, externalUrl });
   // eslint-disable-next-line no-underscore-dangle
   globalThis.__toolpadProject = project;
 

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -210,7 +210,7 @@ export type ProjectEvents = {
 };
 
 export interface ToolpadProjectOptions {
-  cmd: 'dev' | 'start' | 'build';
+  // cmd: 'dev' | 'start' | 'build';
   dev: boolean;
   externalUrl: string;
 }

--- a/packages/toolpad-app/src/types.ts
+++ b/packages/toolpad-app/src/types.ts
@@ -210,7 +210,6 @@ export type ProjectEvents = {
 };
 
 export interface ToolpadProjectOptions {
-  // cmd: 'dev' | 'start' | 'build';
   dev: boolean;
   externalUrl: string;
 }


### PR DESCRIPTION
First in a set of refactors which aims at exposing toolpad as a library to be embedded in your node.js application
This is mostly renaming parameters and replacing `cmd` with `dev`
Working towards a single comprehensive interface that we can expose to users to create their own Toolpad http handler

```tsx
dev: boolean // Dev/prod mode
dir: string // Toolpad project directory
port: number // port under which to run
externalUrl: string // external url
```

Still contemplating how to expose `basePath` and `externalUrl`. Perhaps a `basePath` + `externalOrigin`?