### PR TITLE
Correct types of component labels

### DIFF
--- a/packages/toolpad-components/src/Autocomplete.tsx
+++ b/packages/toolpad-components/src/Autocomplete.tsx
@@ -45,6 +45,7 @@ function Autocomplete({
 
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string | null>({
     name: rest.name,
+    label,
     value,
     onChange,
     emptyValue: null,

--- a/packages/toolpad-components/src/Autocomplete.tsx
+++ b/packages/toolpad-components/src/Autocomplete.tsx
@@ -45,7 +45,6 @@ function Autocomplete({
 
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string | null>({
     name: rest.name,
-    label,
     value,
     onChange,
     emptyValue: null,

--- a/packages/toolpad-components/src/Autocomplete.tsx
+++ b/packages/toolpad-components/src/Autocomplete.tsx
@@ -25,8 +25,8 @@ interface AutocompleteProps
     Pick<FormInputComponentProps, 'name' | 'isRequired' | 'minLength' | 'maxLength' | 'isInvalid'> {
   value: AutocompleteValue;
   onChange: (newValue: AutocompleteValue) => void;
-  options: AutocompleteOption[];
   label: string;
+  options: AutocompleteOption[];
 }
 
 function Autocomplete({

--- a/packages/toolpad-components/src/Autocomplete.tsx
+++ b/packages/toolpad-components/src/Autocomplete.tsx
@@ -25,7 +25,7 @@ interface AutocompleteProps
     Pick<FormInputComponentProps, 'name' | 'isRequired' | 'minLength' | 'maxLength' | 'isInvalid'> {
   value: AutocompleteValue;
   onChange: (newValue: AutocompleteValue) => void;
-  label: string;
+  label?: string;
   options: AutocompleteOption[];
 }
 

--- a/packages/toolpad-components/src/Checkbox.tsx
+++ b/packages/toolpad-components/src/Checkbox.tsx
@@ -19,6 +19,7 @@ import {
 
 export type FormControlLabelOptions = {
   onChange: (newValue: boolean) => void;
+  label: string;
   defaultValue: string;
   fullWidth: boolean;
 } & Omit<FormControlLabelProps, 'control' | 'onChange'> &
@@ -29,7 +30,7 @@ function Checkbox({ ...rest }: FormControlLabelOptions) {
   rest.checked = rest.checked ?? false;
   const { onFormInputChange, renderFormInput, formInputError } = useFormInput<boolean>({
     name: rest.name,
-    label: rest.label as string,
+    label: rest.label,
     onChange: rest.onChange,
     validationProps: { isRequired: rest.isRequired, isInvalid: rest.isInvalid },
   });

--- a/packages/toolpad-components/src/Checkbox.tsx
+++ b/packages/toolpad-components/src/Checkbox.tsx
@@ -7,7 +7,7 @@ import {
   FormHelperText,
   FormControl,
 } from '@mui/material';
-import type { CheckboxProps } from '@mui/material/Checkbox';
+import type { CheckboxProps as MuiCheckBocProps } from '@mui/material/Checkbox';
 import type { FormControlLabelProps } from '@mui/material/FormControlLabel';
 import { SX_PROP_HELPER_TEXT } from './constants';
 import {
@@ -17,16 +17,15 @@ import {
   FORM_INPUT_ARG_TYPES,
 } from './Form';
 
-export type FormControlLabelOptions = {
-  onChange: (newValue: boolean) => void;
-  label: string;
-  defaultValue: string;
-  fullWidth: boolean;
-} & Omit<FormControlLabelProps, 'control' | 'onChange'> &
-  Omit<CheckboxProps, 'onChange'> &
-  Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'>;
+export type CheckboxProps = Omit<FormControlLabelProps, 'control' | 'onChange'> &
+  Omit<MuiCheckBocProps, 'onChange'> & {
+    onChange: (newValue: boolean) => void;
+    label?: string;
+    defaultValue: string;
+    fullWidth: boolean;
+  } & Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'>;
 
-function Checkbox({ ...rest }: FormControlLabelOptions) {
+function Checkbox({ ...rest }: CheckboxProps) {
   rest.checked = rest.checked ?? false;
   const { onFormInputChange, renderFormInput, formInputError } = useFormInput<boolean>({
     name: rest.name,

--- a/packages/toolpad-components/src/Checkbox.tsx
+++ b/packages/toolpad-components/src/Checkbox.tsx
@@ -7,7 +7,7 @@ import {
   FormHelperText,
   FormControl,
 } from '@mui/material';
-import type { CheckboxProps as MuiCheckBocProps } from '@mui/material/Checkbox';
+import type { CheckboxProps as MuiCheckBoxProps } from '@mui/material/Checkbox';
 import type { FormControlLabelProps } from '@mui/material/FormControlLabel';
 import { SX_PROP_HELPER_TEXT } from './constants';
 import {
@@ -18,7 +18,7 @@ import {
 } from './Form';
 
 export type CheckboxProps = Omit<FormControlLabelProps, 'control' | 'onChange'> &
-  Omit<MuiCheckBocProps, 'onChange'> & {
+  Omit<MuiCheckBoxProps, 'onChange'> & {
     onChange: (newValue: boolean) => void;
     label?: string;
     defaultValue: string;

--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -91,7 +91,6 @@ function DatePicker({
 }: DatePickerProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string | null>({
     name: rest.name,
-    label: rest.label as string,
     value: valueProp,
     onChange,
     defaultValue: defaultValueProp,

--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -72,7 +72,7 @@ export interface DatePickerProps
     Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'> {
   value?: string;
   onChange: (newValue: string | null) => void;
-  label: string;
+  label?: string;
   format: string;
   fullWidth: boolean;
   variant: 'outlined' | 'filled' | 'standard';

--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -72,6 +72,7 @@ export interface DatePickerProps
     Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'> {
   value?: string;
   onChange: (newValue: string | null) => void;
+  label: string;
   format: string;
   fullWidth: boolean;
   variant: 'outlined' | 'filled' | 'standard';
@@ -91,7 +92,7 @@ function DatePicker({
 }: DatePickerProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string | null>({
     name: rest.name,
-    label: rest.label as string,
+    label: rest.label,
     value: valueProp,
     onChange,
     defaultValue: defaultValueProp,

--- a/packages/toolpad-components/src/DatePicker.tsx
+++ b/packages/toolpad-components/src/DatePicker.tsx
@@ -91,6 +91,7 @@ function DatePicker({
 }: DatePickerProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string | null>({
     name: rest.name,
+    label: rest.label as string,
     value: valueProp,
     onChange,
     defaultValue: defaultValueProp,

--- a/packages/toolpad-components/src/FilePicker.tsx
+++ b/packages/toolpad-components/src/FilePicker.tsx
@@ -49,7 +49,6 @@ function FilePicker({
 }: FilePickerProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<FullFile[]>({
     name: rest.name,
-    label: rest.label as string,
     value,
     onChange,
     validationProps: { isRequired, isInvalid },

--- a/packages/toolpad-components/src/FilePicker.tsx
+++ b/packages/toolpad-components/src/FilePicker.tsx
@@ -49,6 +49,7 @@ function FilePicker({
 }: FilePickerProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<FullFile[]>({
     name: rest.name,
+    label: rest.label as string,
     value,
     onChange,
     validationProps: { isRequired, isInvalid },

--- a/packages/toolpad-components/src/FilePicker.tsx
+++ b/packages/toolpad-components/src/FilePicker.tsx
@@ -20,6 +20,7 @@ export type FilePickerProps = MuiTextFieldProps & {
   multiple: boolean;
   value: FullFile[];
   onChange: (files: FullFile[]) => void;
+  label: string;
 } & Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'>;
 
 const readFile = async (file: Blob): Promise<string> => {
@@ -49,7 +50,7 @@ function FilePicker({
 }: FilePickerProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<FullFile[]>({
     name: rest.name,
-    label: rest.label as string,
+    label: rest.label,
     value,
     onChange,
     validationProps: { isRequired, isInvalid },

--- a/packages/toolpad-components/src/FilePicker.tsx
+++ b/packages/toolpad-components/src/FilePicker.tsx
@@ -20,7 +20,7 @@ export type FilePickerProps = MuiTextFieldProps & {
   multiple: boolean;
   value: FullFile[];
   onChange: (files: FullFile[]) => void;
-  label: string;
+  label?: string;
 } & Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'>;
 
 const readFile = async (file: Blob): Promise<string> => {

--- a/packages/toolpad-components/src/Form.tsx
+++ b/packages/toolpad-components/src/Form.tsx
@@ -184,7 +184,6 @@ export interface FormInputComponentProps {
 
 interface UseFormInputInput<V> {
   name: string;
-  label?: string;
   value?: V;
   onChange: (newValue: V) => void;
   emptyValue?: V;
@@ -202,7 +201,6 @@ interface UseFormInputPayload<V> {
 
 export function useFormInput<V>({
   name,
-  label,
   value,
   onChange,
   emptyValue,
@@ -219,7 +217,7 @@ export function useFormInput<V>({
 
   const formInputName = fieldName || fallbackName;
 
-  const formInputDisplayName = label || name || 'Field';
+  const formInputDisplayName: string = name || 'Field';
 
   const formInputError = formInputName
     ? (form?.formState.errors[formInputName] as FieldError)

--- a/packages/toolpad-components/src/Form.tsx
+++ b/packages/toolpad-components/src/Form.tsx
@@ -184,6 +184,7 @@ export interface FormInputComponentProps {
 
 interface UseFormInputInput<V> {
   name: string;
+  label?: string;
   value?: V;
   onChange: (newValue: V) => void;
   emptyValue?: V;
@@ -201,6 +202,7 @@ interface UseFormInputPayload<V> {
 
 export function useFormInput<V>({
   name,
+  label,
   value,
   onChange,
   emptyValue,
@@ -217,7 +219,7 @@ export function useFormInput<V>({
 
   const formInputName = fieldName || fallbackName;
 
-  const formInputDisplayName: string = name || 'Field';
+  const formInputDisplayName = label || name || 'Field';
 
   const formInputError = formInputName
     ? (form?.formState.errors[formInputName] as FieldError)

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -34,6 +34,7 @@ function Select({
 }: SelectProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string>({
     name: rest.name,
+    label: rest.label as string,
     value,
     onChange,
     defaultValue,

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -17,7 +17,7 @@ export interface SelectOption {
 export type SelectProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
   value: string;
   onChange: (newValue: string) => void;
-  label: string;
+  label?: string;
   defaultValue: string;
   options: (string | SelectOption)[];
 } & Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'>;

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -17,6 +17,7 @@ export interface SelectOption {
 export type SelectProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
   value: string;
   onChange: (newValue: string) => void;
+  label: string;
   defaultValue: string;
   options: (string | SelectOption)[];
 } & Pick<FormInputComponentProps, 'name' | 'isRequired' | 'isInvalid'>;
@@ -34,7 +35,7 @@ function Select({
 }: SelectProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string>({
     name: rest.name,
-    label: rest.label as string,
+    label: rest.label,
     value,
     onChange,
     defaultValue,

--- a/packages/toolpad-components/src/Select.tsx
+++ b/packages/toolpad-components/src/Select.tsx
@@ -34,7 +34,6 @@ function Select({
 }: SelectProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string>({
     name: rest.name,
-    label: rest.label as string,
     value,
     onChange,
     defaultValue,

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -17,7 +17,7 @@ import { SX_PROP_HELPER_TEXT } from './constants';
 export type TextFieldProps = Omit<MuiTextFieldProps, 'value' | 'onChange'> & {
   value: string;
   onChange: (newValue: string) => void;
-  label: string;
+  label?: string;
   defaultValue: string;
   alignItems?: BoxProps['alignItems'];
   justifyContent?: BoxProps['justifyContent'];

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -34,7 +34,6 @@ function TextField({
 }: TextFieldProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string>({
     name: rest.name,
-    label: rest.label as string,
     value,
     onChange,
     emptyValue: '',

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -17,6 +17,7 @@ import { SX_PROP_HELPER_TEXT } from './constants';
 export type TextFieldProps = Omit<MuiTextFieldProps, 'value' | 'onChange'> & {
   value: string;
   onChange: (newValue: string) => void;
+  label: string;
   defaultValue: string;
   alignItems?: BoxProps['alignItems'];
   justifyContent?: BoxProps['justifyContent'];
@@ -34,7 +35,7 @@ function TextField({
 }: TextFieldProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string>({
     name: rest.name,
-    label: rest.label as string,
+    label: rest.label,
     value,
     onChange,
     emptyValue: '',

--- a/packages/toolpad-components/src/TextField.tsx
+++ b/packages/toolpad-components/src/TextField.tsx
@@ -34,6 +34,7 @@ function TextField({
 }: TextFieldProps) {
   const { onFormInputChange, formInputError, renderFormInput } = useFormInput<string>({
     name: rest.name,
+    label: rest.label as string,
     value,
     onChange,
     emptyValue: '',


### PR DESCRIPTION
Avoid using `as string`, it's reducing type safety, we can just narrow down the type.