### PR TITLE
Fix editor failing to open

### DIFF
--- a/docs/data/toolpad/how-to-guides/editor-path.md
+++ b/docs/data/toolpad/how-to-guides/editor-path.md
@@ -24,7 +24,7 @@ Toolpad understands the `$EDITOR` environment variable. Make sure you can open y
 
 e.g. for webstorm, make sure to [install the CLI command](https://www.jetbrains.com/help/webstorm/working-with-the-ide-features-from-command-line.html#standalone) in the `PATH` variable, then declare the webstorm command:
 
-```
+```bash
 # ./.env
 
 EDITOR=webstorm

--- a/docs/data/toolpad/how-to-guides/editor-path.md
+++ b/docs/data/toolpad/how-to-guides/editor-path.md
@@ -17,3 +17,15 @@
 4. Type `code` to find the `Install 'code' command in PATH` option, and press enter to select it:
 
 {{"component": "modules/components/DocsImage.tsx", "src": "/static/toolpad/docs/how-to-guides/editor-path/code-install.png", "alt": "VS Code add 'code' to PATH", "caption": "Install 'code' option", "aspectRatio": 2, "width": 600, "zoom": false }}
+
+## When using another editor
+
+Toolpad understands the `$EDITOR` environment variable. Make sure you can open your editor of choice from the command line. Then provide the command in the `$EDITOR` environment variable. You can use a `.env` file in the root of your project to set the variable.
+
+e.g. for webstorm, make sure to [install the CLI command](https://www.jetbrains.com/help/webstorm/working-with-the-ide-features-from-command-line.html#standalone) in the `PATH` variable, then declare the webstorm command:
+
+```yml
+# ./.env
+
+EDITOR=webstorm
+```

--- a/docs/data/toolpad/how-to-guides/editor-path.md
+++ b/docs/data/toolpad/how-to-guides/editor-path.md
@@ -24,7 +24,7 @@ Toolpad understands the `$EDITOR` environment variable. Make sure you can open y
 
 e.g. for webstorm, make sure to [install the CLI command](https://www.jetbrains.com/help/webstorm/working-with-the-ide-features-from-command-line.html#standalone) in the `PATH` variable, then declare the webstorm command:
 
-```yml
+```
 # ./.env
 
 EDITOR=webstorm

--- a/packages/toolpad-app/src/components/OpenCodeEditor.tsx
+++ b/packages/toolpad-app/src/components/OpenCodeEditor.tsx
@@ -41,12 +41,14 @@ function MissingEditorDialog({ open, onClose }: MissingEditorDialogProps) {
       onClose={handleMissingEditorDialogClose}
       aria-labelledby={`${id}-title`}
       aria-describedby="alert-dialog-description"
+      onClick={(event) => event.stopPropagation()}
     >
       <DialogTitle id={`${id}-title`}>{'Editor not found'}</DialogTitle>
       <DialogContent>
         <DialogContentText id="alert-dialog-description">
-          No editor was detected on your system. If using Visual Studio Code, this may be due to a
-          missing &quot;code&quot; command in your PATH. <br />
+          No editor was detected on your system. If you use Visual Studio Code, this may be due to a
+          missing &quot;code&quot; command in your PATH. Otherwise you can set the{' '}
+          <code>$EDITOR</code> environment variable. <br />
           Check the{' '}
           <Link
             href="https://mui.com/toolpad/how-to-guides/editor-path/"

--- a/packages/toolpad-app/src/server/localMode.ts
+++ b/packages/toolpad-app/src/server/localMode.ts
@@ -830,18 +830,15 @@ async function writeDomToDisk(root: string, dom: appDom.AppDom): Promise<void> {
   ]);
 }
 
-const DEFAULT_EDITOR = 'code';
-
-export async function findSupportedEditor(): Promise<string | null> {
-  const maybeEditor = process.env.EDITOR ?? DEFAULT_EDITOR;
-  if (!maybeEditor) {
-    return null;
+export async function findSupportedEditor(): Promise<string | undefined> {
+  if (process.env.EDITOR) {
+    return undefined;
   }
   try {
-    await execa(maybeEditor, ['-v']);
-    return maybeEditor;
+    await execa('code', ['-v']);
+    return 'code';
   } catch (err) {
-    return null;
+    return undefined;
   }
 }
 
@@ -1156,9 +1153,6 @@ class ToolpadProject {
 
   async openCodeEditor(fileName: string, fileType: string) {
     const supportedEditor = await findSupportedEditor();
-    if (!supportedEditor) {
-      throw new Error(`No code editor found`);
-    }
     const root = this.getRoot();
     let resolvedPath = fileName;
 
@@ -1170,8 +1164,8 @@ class ToolpadProject {
       resolvedPath = getComponentFilePath(componentsFolder, fileName);
     }
     const fullResolvedPath = path.resolve(root, resolvedPath);
-    openEditor([fullResolvedPath, root], {
-      editor: process.env.EDITOR ? undefined : DEFAULT_EDITOR,
+    await openEditor([fullResolvedPath, root], {
+      editor: supportedEditor,
     });
   }
 


### PR DESCRIPTION
I've seen this fail on most of the recent interviews we did. "Open editor" button fails with endlessly spinning loading indicator. This should improve on it.

* Avoid calling `execa` with unknown input
* If there is an `$EDITOR` variable defined, let it take precedence and delegate handling to `openEditor`
* Check whether `code` exists in the path and override with it in this case
* Document the use of `.env` file to specify the code editor