### PR TITLE
Move server files to the src folder

### DIFF
--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import yargs from 'yargs';
 import chalk from 'chalk';
 import { execaNode } from 'execa';
-import { runApp } from './server';
+import { runApp } from '../src/server/server';
 
 export type Command = 'dev' | 'start' | 'build';
 export interface RunOptions {

--- a/packages/toolpad-app/cli/index.ts
+++ b/packages/toolpad-app/cli/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import yargs from 'yargs';
 import chalk from 'chalk';
 import { execaNode } from 'execa';
-import { runApp } from '../src/server/server';
+import { runApp } from '../src/server';
 
 export type Command = 'dev' | 'start' | 'build';
 export interface RunOptions {

--- a/packages/toolpad-app/src/server/appBuilder.ts
+++ b/packages/toolpad-app/src/server/appBuilder.ts
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
-import { buildApp } from '../src/server/toolpadAppBuilder';
-import { initProject } from '../src/server/localMode';
+import { buildApp } from './toolpadAppBuilder';
+import { initProject } from './localMode';
 
 async function main() {
   invariant(

--- a/packages/toolpad-app/src/server/appServer.ts
+++ b/packages/toolpad-app/src/server/appServer.ts
@@ -2,15 +2,11 @@ import { parentPort, workerData, MessagePort } from 'worker_threads';
 import invariant from 'invariant';
 import { createServer, Plugin } from 'vite';
 import { createRpcClient } from '@mui/toolpad-utils/workerRpc';
-import {
-  getHtmlContent,
-  createViteConfig,
-  resolvedComponentsId,
-} from '../src/server/toolpadAppBuilder';
-import type { RuntimeConfig } from '../src/config';
-import type * as appDom from '../src/appDom';
-import type { ComponentEntry } from '../src/server/localMode';
-import { postProcessHtml } from '../src/server/toolpadAppServer';
+import { getHtmlContent, createViteConfig, resolvedComponentsId } from './toolpadAppBuilder';
+import type { RuntimeConfig } from '../config';
+import type * as appDom from '../appDom';
+import type { ComponentEntry } from './localMode';
+import { postProcessHtml } from './toolpadAppServer';
 
 export type Command = { kind: 'reload-components' } | { kind: 'exit' };
 

--- a/packages/toolpad-app/src/server/index.ts
+++ b/packages/toolpad-app/src/server/index.ts
@@ -15,15 +15,15 @@ import openBrowser from 'react-dev-utils/openBrowser';
 import { folderExists } from '@mui/toolpad-utils/fs';
 import chalk from 'chalk';
 import { serveRpc } from '@mui/toolpad-utils/workerRpc';
-import { asyncHandler } from '../src/utils/express';
-import { createProdHandler } from '../src/server/toolpadAppServer';
-import { ToolpadProject, initProject } from '../src/server/localMode';
+import { asyncHandler } from '../utils/express';
+import { createProdHandler } from './toolpadAppServer';
+import { ToolpadProject, initProject } from './localMode';
 import type { Command as AppDevServerCommand, AppViteServerConfig, WorkerRpc } from './appServer';
-import { createRpcHandler } from '../src/server/rpc';
-import { RUNTIME_CONFIG_WINDOW_PROPERTY } from '../src/constants';
-import type { RuntimeConfig } from '../src/config';
-import { createRpcServer } from '../src/server/rpcServer';
-import { createRpcRuntimeServer } from '../src/server/rpcRuntimeServer';
+import { createRpcHandler } from './rpc';
+import { RUNTIME_CONFIG_WINDOW_PROPERTY } from '../constants';
+import type { RuntimeConfig } from '../config';
+import { createRpcServer } from './rpcServer';
+import { createRpcRuntimeServer } from './rpcRuntimeServer';
 
 const DEFAULT_PORT = 3000;
 

--- a/packages/toolpad-app/tsup.config.ts
+++ b/packages/toolpad-app/tsup.config.ts
@@ -21,8 +21,10 @@ export default defineConfig((options) => [
   {
     entry: {
       index: './cli/index.ts',
-      appServer: './cli/appServer.ts',
-      appBuilder: './cli/appBuilder.ts',
+
+      // Worker entry points
+      appServer: './src/server/appServer.ts',
+      appBuilder: './src/server/appBuilder.ts',
       functionsDevWorker: './src/server/functionsDevWorker.ts',
       functionsTypesWorker: './src/server/functionsTypesWorker.ts',
     },


### PR DESCRIPTION
So that we have a single logical place to import them in the CLI and also to export them as library. This also colocates them more with related files and harmonizes the location of worker entrypoints