### PR TITLE
Add Markdown and Link components

### DIFF
--- a/packages/toolpad-app/src/runtime/toolpadComponents/index.tsx
+++ b/packages/toolpad-app/src/runtime/toolpadComponents/index.tsx
@@ -7,6 +7,7 @@ export interface ToolpadComponentDefinition {
   system?: boolean;
   codeComponentId?: NodeId;
   synonyms: string[];
+  initialProps?: Record<string, unknown>;
 }
 
 export type ToolpadComponentDefinitions = Record<string, ToolpadComponentDefinition | undefined>;
@@ -57,6 +58,28 @@ export const INTERNAL_COMPONENTS = new Map<string, ToolpadComponentDefinition>([
   ['DatePicker', { displayName: 'Date Picker', builtIn: 'DatePicker', synonyms: ['time'] }],
   ['FilePicker', { displayName: 'File Picker', builtIn: 'FilePicker', synonyms: [] }],
   ['Text', { displayName: 'Text', builtIn: 'Text', synonyms: ['markdown', 'link', 'output'] }],
+  [
+    'Markdown',
+    {
+      displayName: 'Markdown',
+      builtIn: 'Text',
+      initialProps: {
+        mode: 'markdown',
+      },
+      synonyms: [],
+    },
+  ],
+  [
+    'Link',
+    {
+      displayName: 'Link',
+      builtIn: 'Text',
+      initialProps: {
+        mode: 'link',
+      },
+      synonyms: [],
+    },
+  ],
   ['Select', { displayName: 'Select', builtIn: 'Select', synonyms: ['combobox', 'dropdown'] }],
   ['List', { displayName: 'List', builtIn: 'List', synonyms: ['repeat'] }],
   ['Paper', { displayName: 'Paper', builtIn: 'Paper', synonyms: ['surface'] }],

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
@@ -90,14 +90,17 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
     [openStart, setOpenStart],
   );
 
+  const toolpadComponents = useToolpadComponents(dom);
+
   const handleDragStart = (componentType: string) => (event: React.DragEvent<HTMLElement>) => {
+    const def = toolpadComponents[componentType];
+    invariant(def, `No component definition found for "${componentType}"`);
+
     event.dataTransfer.dropEffect = 'copy';
-    const newNode = appDom.createElement(dom, componentType, {});
+    const newNode = appDom.createElement(dom, def.builtIn || componentType, def.initialProps || {});
     api.newNodeDragStart(newNode);
     closeDrawer(0);
   };
-
-  const toolpadComponents = useToolpadComponents(dom);
 
   const handleMouseEnter = React.useCallback(() => openDrawer(), [openDrawer]);
   const handleMouseLeave = React.useCallback(() => closeDrawer(), [closeDrawer]);

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalog.tsx
@@ -15,6 +15,7 @@ import ArrowDropDownSharpIcon from '@mui/icons-material/ArrowDropDownSharp';
 import invariant from 'invariant';
 import InputAdornment from '@mui/material/InputAdornment';
 import AccountCircle from '@mui/icons-material/Search';
+import { uncapitalize } from '@mui/toolpad-utils/strings';
 import ComponentCatalogItem from './ComponentCatalogItem';
 import CreateCodeComponentNodeDialog from '../../PagesExplorer/CreateCodeComponentNodeDialog';
 import * as appDom from '../../../../appDom';
@@ -97,7 +98,13 @@ export default function ComponentCatalog({ className }: ComponentCatalogProps) {
     invariant(def, `No component definition found for "${componentType}"`);
 
     event.dataTransfer.dropEffect = 'copy';
-    const newNode = appDom.createElement(dom, def.builtIn || componentType, def.initialProps || {});
+    const newNode = appDom.createElement(
+      dom,
+      def.builtIn || componentType,
+      def.initialProps || {},
+      undefined,
+      uncapitalize(def.displayName),
+    );
     api.newNodeDragStart(newNode);
     closeDrawer(0);
   };

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalogItem.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentCatalog/ComponentCatalogItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
-
+import { ButtonBase, SxProps, Box } from '@mui/material';
 import SmartButtonIcon from '@mui/icons-material/SmartButton';
 import ImageIcon from '@mui/icons-material/Image';
 import GridOnIcon from '@mui/icons-material/GridOn';
@@ -31,13 +30,16 @@ import HtmlIcon from '@mui/icons-material/Html';
 import TableRowsIcon from '@mui/icons-material/TableRows';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import TagIcon from '@mui/icons-material/Tag';
-import { ButtonBase, SxProps } from '@mui/material';
 import PasswordIcon from '@mui/icons-material/Password';
+import LinkIcon from '@mui/icons-material/Link';
+import TextFormatIcon from '@mui/icons-material/TextFormat';
 
 const iconMap = new Map<string, React.ComponentType<SvgIconProps>>([
   ['Password', PasswordIcon],
   ['Autocomplete', ManageSearchIcon],
   ['Text', NotesIcon],
+  ['Link', LinkIcon],
+  ['Markdown', TextFormatIcon],
   ['Button', SmartButtonIcon],
   ['Image', ImageIcon],
   ['DataGrid', GridOnIcon],


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/1702

Proposing a new way of defining built-in components. As variants of existing components, but initialized with different properties. e.g. we can create a markdown component by inserting a text component with the mode set to 'markdown'. Same for link. This PR doesn't add new components, it just initializes existing components differently when dragging them to the canvas.


https://github.com/mui/mui-toolpad/assets/2109932/2baae9ae-6dd0-4fc2-88c5-bd16d5994c32


This could help us with the implementation of https://github.com/mui/mui-toolpad/issues/2737. Where we can have both a password component and a textfield component with password mode.

Also in this PR: initialize element names with their component's displayName. Which improves the default naming of custom components a lot