### PR TITLE
Use toggle buttons for text mode property

### DIFF
--- a/packages/toolpad-components/src/Text.tsx
+++ b/packages/toolpad-components/src/Text.tsx
@@ -293,8 +293,14 @@ export default createBuiltin(Text, {
         'Defines how the content is rendered. Either as plain text, markdown, or as a link.',
       type: 'string',
       enum: ['text', 'markdown', 'link'],
+      enumLabels: {
+        text: 'Text',
+        markdown: 'Markdown',
+        link: 'Link',
+      },
       default: 'text',
       label: 'Mode',
+      control: { type: 'ToggleButtons' },
     },
     value: {
       helperText: 'The text content.',


### PR DESCRIPTION
One less click to select mode and less confusion as textfield and select look a lot like each other


<img width="344" alt="Screenshot 2023-10-06 at 16 40 23" src="https://github.com/mui/mui-toolpad/assets/2109932/a276635a-226a-4d74-81d9-610948e23201">
