### PR TITLE
Block next.js from updating

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,12 @@
       "description": "prettier made breaking changes in v3, pretty-quick needs to catch up before we can upgrade. https://github.com/azz/pretty-quick/issues/164"
     },
     {
+      "groupName": "next",
+      "matchPackageNames": ["next"],
+      "allowedVersions": "<= 13.4.19",
+      "description": "https://github.com/mui/mui-toolpad/pull/2739"
+    },
+    {
       "matchDepTypes": ["action"],
       "pinDigests": true
     },


### PR DESCRIPTION
We upgrade dependencies in groups. If a package can't upgrade and it doesn't break a test, it needs to be excluded.