### PR TITLE
Fix createDataProvider imports in the integration tests

### DIFF
--- a/test/integration/backend-basic/fixture/toolpad/resources/myCursorData.ts
+++ b/test/integration/backend-basic/fixture/toolpad/resources/myCursorData.ts
@@ -1,4 +1,4 @@
-import { createDataProvider } from '@mui/toolpad-core/server';
+import { createDataProvider } from '@mui/toolpad/server';
 
 const DATA = Array.from({ length: 1_000 }, (_, id) => ({ id, name: `Cursor item ${id}` }));
 

--- a/test/integration/backend-basic/fixture/toolpad/resources/myIndexData.ts
+++ b/test/integration/backend-basic/fixture/toolpad/resources/myIndexData.ts
@@ -1,4 +1,4 @@
-import { createDataProvider } from '@mui/toolpad-core/server';
+import { createDataProvider } from '@mui/toolpad/server';
 
 const DATA = Array.from({ length: 100_000 }, (_, id) => ({ id, name: `Index item ${id}` }));
 


### PR DESCRIPTION
Noticed this while working on the pnpm [PR](https://github.com/mui/mui-toolpad/pull/2546)