### PR TITLE
Remove babel-plugin-transform-rename-import

### DIFF
--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -4,6 +4,11 @@ const { version: transformRuntimeVersion } = fse.readJSONSync(
   require.resolve('@babel/runtime-corejs2/package.json'),
 );
 
+const errorCodesPath = require.resolve('@mui/monorepo/docs/public/static/error-codes.json');
+const missingError = process.env.MUI_EXTRACT_ERROR_CODES === 'true' ? 'write' : 'annotate';
+
+const muiErrorMacro = require.resolve('@mui/monorepo/packages/mui-utils/macros/MuiError.macro');
+
 module.exports = {
   presets: [
     // backport of https://github.com/zeit/next.js/pull/9511
@@ -11,9 +16,14 @@ module.exports = {
   ],
   plugins: [
     [
-      'babel-plugin-transform-rename-import',
+      'babel-plugin-macros',
       {
-        replacements: [{ original: '@mui/utils/macros/MuiError.macro', replacement: 'react' }],
+        muiError: {
+          errorCodesPath,
+          missingError,
+        },
+        // TODO: Figure out dependency resolution for macros so this hack isn't needed.
+        resolvePath: () => muiErrorMacro,
       },
     ],
     'babel-plugin-optimize-clsx',

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -52,7 +52,6 @@ export default withDocsInfra(
           alias: {
             ...config.resolve.alias,
             docs: path.resolve(MONOREPO_PATH, './docs'),
-            'babel-plugin-macros': require.resolve('babel-plugin-macros'),
             ...MONOREPO_PACKAGES,
           },
         },

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -52,7 +52,7 @@ export default withDocsInfra(
           alias: {
             ...config.resolve.alias,
             docs: path.resolve(MONOREPO_PATH, './docs'),
-            [path.resolve(MONOREPO_PATH, './packages/mui-utils/macros/MuiError.macro')]: 'react',
+            'babel-plugin-macros': require.resolve('babel-plugin-macros'),
             ...MONOREPO_PACKAGES,
           },
         },

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,6 +39,7 @@
     "accept-language": "3.0.18",
     "ast-types": "0.14.2",
     "autoprefixer": "10.4.16",
+    "babel-plugin-macros": "3.1.0",
     "babel-plugin-module-resolver": "5.0.0",
     "babel-plugin-optimize-clsx": "2.6.2",
     "babel-plugin-preval": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/rimraf": "3.0.2",
     "@typescript-eslint/eslint-plugin": "6.7.4",
     "@typescript-eslint/parser": "6.7.4",
-    "babel-plugin-transform-rename-import": "2.3.0",
     "chalk": "5.3.0",
     "eslint": "8.51.0",
     "eslint-config-airbnb": "19.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4133,7 +4133,7 @@ b4a@^1.6.4:
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.4.tgz#ef1c1422cae5ce6535ec191baeed7567443f36c9"
   integrity sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==
 
-babel-plugin-macros@^3.0.1, babel-plugin-macros@^3.1.0:
+babel-plugin-macros@3.1.0, babel-plugin-macros@^3.0.1, babel-plugin-macros@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
   integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4209,11 +4209,6 @@ babel-plugin-transform-react-remove-prop-types@0.4.24:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
-babel-plugin-transform-rename-import@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz#5d9d645f937b0ca5c26a24b2510a06277b6ffd9b"
-  integrity sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-toolpad/pull/2546

Still have no idea what this construction with `babel-plugin-transform-rename-import` is supposed to do. But it's failing under https://github.com/mui/mui-toolpad/pull/2546 as not all import identifiers are to `@mui/monorepo/packages/mui-utils/macros/MuiError.macro` are writtent hat way. I'm replacing it with the babel macros setup from the front. Until we remove that altogether.

babel operates on individual modules, it doesn't do anything around module resolution. We should leave aliasing to the tools that are concerned with linking modules together. i.e. bundlers