### PR TITLE
Fix ESM charts issues in production

### DIFF
--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -175,8 +175,6 @@ export interface CreateViteConfigResult {
   viteConfig: InlineConfig;
 }
 
-console.log('temp');
-
 export function createViteConfig({
   outDir,
   root,
@@ -257,6 +255,7 @@ export function createViteConfig({
           'lodash-es',
           'markdown-to-jsx',
           'nanoid/non-secure',
+          'prop-types',
           'react',
           'react-dom/client',
           'react-error-boundary',

--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -258,6 +258,7 @@ export function createViteConfig({
           'prop-types',
           'react',
           'react-dom',
+          'react-dom/client',
           'react-error-boundary',
           'react-hook-form',
           'react-is',

--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -257,7 +257,7 @@ export function createViteConfig({
           'nanoid/non-secure',
           'prop-types',
           'react',
-          'react-dom/client',
+          'react-dom',
           'react-error-boundary',
           'react-hook-form',
           'react-is',

--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -175,6 +175,8 @@ export interface CreateViteConfigResult {
   viteConfig: InlineConfig;
 }
 
+console.log('temp');
+
 export function createViteConfig({
   outDir,
   root,


### PR DESCRIPTION
Adding `prop-types` and `react-dom` to `optimizeDeps` seems to fix it indeed. Thanks @Janpot !