### PR TITLE
[docs] Fix images width overflow on Firefox

### DIFF
--- a/docs/src/modules/components/DocsImage.tsx
+++ b/docs/src/modules/components/DocsImage.tsx
@@ -40,7 +40,7 @@ const Img = styled('img')<DocsImageProps>(({ theme, zoom, indent, width, aspectR
   marginRight: indent ? 0 : undefined,
   zIndex: 5,
   borderRadius: 4,
-  maxWidth: zoom === false ? 'min(50vw, 500px)' : 'unset',
+  maxWidth: zoom === false ? 'min(50vw, 500px)' : '100%',
   cursor: zoom ? 'zoom-in' : 'initial',
   '&:hover': {
     '& ~ div': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I've read and followed the [contributing guide](https://github.com/mui/mui-toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [x] I've updated the relevant documentation for any new or updated feature.
- Closes #2860 

| Before | After |
|--------|-------|
|     <img width="1506" alt="Screenshot 2023-11-06 at 3 12 52 PM" src="https://github.com/mui/mui-toolpad/assets/19550456/a689ebf6-19ac-4a0c-9589-3608f31642f2">  |   <img width="1494" alt="Screenshot 2023-11-06 at 3 13 20 PM" src="https://github.com/mui/mui-toolpad/assets/19550456/802822f1-0605-4edb-b2f5-9f04bc3defc1">    |

