### PR TITLE
Add instructions to start the editor for custom servers

### DIFF
--- a/packages/toolpad-app/src/runtime/PreviewHeader.tsx
+++ b/packages/toolpad-app/src/runtime/PreviewHeader.tsx
@@ -149,11 +149,14 @@ function CustomServerInstructions({ basename }: CustomServerInstructionsProps) {
           vertical: 'top',
           horizontal: 'right',
         }}
+        sx={{
+          maxWidth: 1000,
+        }}
       >
         <Box sx={{ p: 2 }}>
           <Typography>
             This application is running under a custom server. Run the standalone Toolpad editor to
-            edit this application.
+            make changes to this application.
           </Typography>
           <CodeView>{`npx @mui/toolpad editor ${appUrl}`}</CodeView>
         </Box>

--- a/packages/toolpad-app/src/runtime/PreviewHeader.tsx
+++ b/packages/toolpad-app/src/runtime/PreviewHeader.tsx
@@ -1,10 +1,172 @@
 import * as React from 'react';
-import { Button, Typography, Box, useTheme, Alert } from '@mui/material';
+import {
+  Button,
+  Typography,
+  Box,
+  useTheme,
+  Alert,
+  ButtonProps,
+  Popover,
+  styled,
+  IconButton,
+  Tooltip,
+  Snackbar,
+  IconButtonProps,
+} from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import { useMatch } from 'react-router-dom';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { IS_CUSTOM_SERVER, PREVIEW_HEADER_HEIGHT } from './constants';
 
-export default function PreviewHeader() {
+interface CopyToClipboardButtonProps extends IconButtonProps {
+  content: string;
+}
+
+function CopyToClipboardButton({ content, onClick, ...props }: CopyToClipboardButtonProps) {
+  const [confirmSnackbarOpen, setConfirmSnackbarOpen] = React.useState(false);
+
+  const handleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      window.navigator.clipboard.writeText(content);
+      setConfirmSnackbarOpen(true);
+      onClick?.(event);
+    },
+    [content, onClick],
+  );
+
+  const handleCopySnackbarClose = React.useCallback(() => setConfirmSnackbarOpen(false), []);
+
+  return (
+    <React.Fragment>
+      <Tooltip title="Copy to clipboard">
+        <IconButton {...props} onClick={handleClick}>
+          <ContentCopyIcon fontSize="inherit" />
+        </IconButton>
+      </Tooltip>
+
+      <Snackbar
+        open={confirmSnackbarOpen}
+        autoHideDuration={3000}
+        onClose={handleCopySnackbarClose}
+        message="Copied to clipboard"
+      />
+    </React.Fragment>
+  );
+}
+
+interface CodeViewProps {
+  children?: string;
+}
+
+const classes = {
+  copyToClipboardButton: 'Toolpad_CodeView_CopyToClipboardButton',
+  hasCopyToClipboardButton: 'Toolpad_CodeView_hasCopyToClipboardButton',
+};
+
+const CodeViewRoot = styled('pre')(({ theme }) => ({
+  position: 'relative',
+  border: `1px solid ${theme.palette.divider}`,
+  padding: theme.spacing(2),
+  paddingRight: theme.spacing(5),
+  borderRadius: theme.shape.borderRadius,
+
+  fontFamily: theme.fontFamilyMonospaced,
+
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+
+  [`& .${classes.copyToClipboardButton}`]: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    marginTop: theme.spacing(1),
+    marginRight: theme.spacing(1),
+  },
+}));
+
+function CodeView({ children }: CodeViewProps) {
+  return (
+    <CodeViewRoot>
+      <Typography noWrap component="code" fontFamily="inherit">
+        {children}
+      </Typography>
+
+      {children ? (
+        <CopyToClipboardButton
+          size="small"
+          content={children}
+          className={classes.copyToClipboardButton}
+        />
+      ) : null}
+    </CodeViewRoot>
+  );
+}
+
+function OpenInEditorButton({ children = 'Open in editor', ...props }: ButtonProps) {
+  return (
+    <Button color="inherit" size="small" startIcon={<EditIcon />} {...props}>
+      {children}
+    </Button>
+  );
+}
+
+interface CustomServerInstructionsProps {
+  basename: string;
+}
+
+function CustomServerInstructions({ basename }: CustomServerInstructionsProps) {
+  const id = React.useId();
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+
+  const appUrl = React.useMemo(() => {
+    return new URL(basename, window.location.origin).href;
+  }, [basename]);
+
+  return (
+    <React.Fragment>
+      <OpenInEditorButton aria-describedby={id} onClick={handleClick} />
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+      >
+        <Box sx={{ p: 2 }}>
+          <Typography>
+            This application is running under a custom server. Run the standalone Toolpad editor to
+            edit this application.
+          </Typography>
+          <CodeView>{`npx @mui/toolpad editor ${appUrl}`}</CodeView>
+        </Box>
+      </Popover>
+    </React.Fragment>
+  );
+}
+
+export interface PreviewHeaderProps {
+  basename: string;
+}
+
+export default function PreviewHeader({ basename }: PreviewHeaderProps) {
   const pageMatch = useMatch('/pages/:slug');
   const activePage = pageMatch?.params.slug;
 
@@ -21,21 +183,17 @@ export default function PreviewHeader() {
     >
       <Alert
         severity="warning"
-        // variant="filled"
         sx={{
           borderRadius: 0,
         }}
         action={
-          IS_CUSTOM_SERVER ? null : (
-            <Button
-              color="inherit"
-              size="small"
-              startIcon={<EditIcon />}
+          IS_CUSTOM_SERVER ? (
+            <CustomServerInstructions basename={basename} />
+          ) : (
+            <OpenInEditorButton
               component="a"
               href={activePage ? `/_toolpad/app/pages/${activePage}` : '/_toolpad/app'}
-            >
-              Open in editor
-            </Button>
+            />
           )
         }
       >

--- a/packages/toolpad-app/src/runtime/PreviewHeader.tsx
+++ b/packages/toolpad-app/src/runtime/PreviewHeader.tsx
@@ -12,6 +12,7 @@ import {
   Tooltip,
   Snackbar,
   IconButtonProps,
+  popoverClasses,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import { useMatch } from 'react-router-dom';
@@ -150,7 +151,9 @@ function CustomServerInstructions({ basename }: CustomServerInstructionsProps) {
           horizontal: 'right',
         }}
         sx={{
-          maxWidth: 1000,
+          [`& .${popoverClasses.paper}`]: {
+            maxWidth: 700,
+          },
         }}
       >
         <Box sx={{ p: 2 }}>

--- a/packages/toolpad-app/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-app/src/runtime/ToolpadApp.tsx
@@ -1541,7 +1541,7 @@ export default function ToolpadApp({ rootRef, extraComponents, basename, state }
       <UseDataProviderContext.Provider value={useDataProvider}>
         <AppThemeProvider dom={dom}>
           <CssBaseline enableColorScheme />
-          {SHOW_PREVIEW_HEADER ? <PreviewHeader /> : null}
+          {SHOW_PREVIEW_HEADER ? <PreviewHeader basename={basename} /> : null}
           <AppRoot ref={rootRef}>
             <ComponentsContextProvider value={components}>
               <DomContextProvider value={dom}>

--- a/test/models/ToolpadEditor.ts
+++ b/test/models/ToolpadEditor.ts
@@ -137,23 +137,22 @@ export class ToolpadEditor {
 
     await this.componentCatalog.hover();
 
-    let pageRootBoundingBox;
-    await expect(async () => {
-      pageRootBoundingBox = await this.pageRoot.boundingBox();
-      expect(pageRootBoundingBox).toBeTruthy();
-    }).toPass();
+    await expect.poll(() => this.pageRoot.boundingBox()).toBeTruthy();
+
+    const pageRootBoundingBox = (await this.pageRoot.boundingBox())!;
 
     if (!moveTargetX) {
-      moveTargetX = pageRootBoundingBox!.x + pageRootBoundingBox!.width / 2;
+      moveTargetX = pageRootBoundingBox.x + pageRootBoundingBox.width / 2;
     }
+
     if (!moveTargetY) {
-      moveTargetY = pageRootBoundingBox!.y + pageRootBoundingBox!.height / 2;
+      moveTargetY = pageRootBoundingBox.y + pageRootBoundingBox.height / 2;
     }
 
     const sourceLocator = this.getComponentCatalogItem(componentName);
     await expect(sourceLocator).toBeVisible();
 
-    await this.dragTo(sourceLocator, moveTargetX!, moveTargetY!, hasDrop);
+    await this.dragTo(sourceLocator, moveTargetX, moveTargetY, hasDrop);
 
     await style.evaluate((elm) => elm.parentNode?.removeChild(elm));
   }

--- a/test/models/ToolpadEditor.ts
+++ b/test/models/ToolpadEditor.ts
@@ -137,22 +137,23 @@ export class ToolpadEditor {
 
     await this.componentCatalog.hover();
 
-    await expect.poll(() => this.pageRoot.boundingBox()).toBeTruthy();
-
-    const pageRootBoundingBox = (await this.pageRoot.boundingBox())!;
+    let pageRootBoundingBox;
+    await expect(async () => {
+      pageRootBoundingBox = await this.pageRoot.boundingBox();
+      expect(pageRootBoundingBox).toBeTruthy();
+    }).toPass();
 
     if (!moveTargetX) {
-      moveTargetX = pageRootBoundingBox.x + pageRootBoundingBox.width / 2;
+      moveTargetX = pageRootBoundingBox!.x + pageRootBoundingBox!.width / 2;
     }
-
     if (!moveTargetY) {
-      moveTargetY = pageRootBoundingBox.y + pageRootBoundingBox.height / 2;
+      moveTargetY = pageRootBoundingBox!.y + pageRootBoundingBox!.height / 2;
     }
 
     const sourceLocator = this.getComponentCatalogItem(componentName);
     await expect(sourceLocator).toBeVisible();
 
-    await this.dragTo(sourceLocator, moveTargetX, moveTargetY, hasDrop);
+    await this.dragTo(sourceLocator, moveTargetX!, moveTargetY!, hasDrop);
 
     await style.evaluate((elm) => elm.parentNode?.removeChild(elm));
   }


### PR DESCRIPTION
Complements https://github.com/mui/mui-toolpad/pull/2800 with instructions in a popover on the application header, to start the standalone editor.  

![Screenshot 2023-11-07 at 17 22 56](https://github.com/mui/mui-toolpad/assets/2109932/b6f3d4f8-3c9a-418a-adbf-81176808835c)
