### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ This will use the local version of Toolpad as built in the monorepo. This is rec
 1. Run Toolpad
 
    ```bash
-   yarn toolpad dev test/integration/backend-basic/fixture --dev
+   yarn toolpad dev test/integration/backend-basic/fixture/toolpad --dev
    ```
 
    **Note:** It's important to note the difference between `yarn toolpad dev` and the `--dev` parameter. The first instruction runs Toolpad in dev mode. The `--dev` parameter is one for contributors only and runs the underlying next.js app that powers the editor in dev mode. The latter makes sure the development build of React is being used and the editor frontend application runs in watch mode.


### PR DESCRIPTION
Recently the CLI was changed to point to the actual toolpad folder instead of the root project folder. This allows for running multiple Toolpad projects in one project. But the contributing docs needed to be updated with the change.