### PR TITLE
Fix Toolpad not picking a free port

### DIFF
--- a/packages/toolpad-app/src/server/index.ts
+++ b/packages/toolpad-app/src/server/index.ts
@@ -442,7 +442,7 @@ export async function runApp({
   dev = false,
   dir = '.',
   base = '/prod',
-  port = 3000,
+  port,
   toolpadDevMode = false,
 }: RunAppOptions) {
   const projectDir = resolveProjectDir(dir);


### PR DESCRIPTION
This broke during the custom server changes