### PR TITLE
Tweak titles to improve SERP results

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -147,7 +147,7 @@ const pages: MuiPage[] = [
           },
           {
             pathname: '/toolpad/how-to-guides/embed-pages',
-            title: 'Embed a Toolpad page',
+            title: 'Embedding Toolpad pages',
           },
           {
             pathname: '/toolpad/how-to-guides/basic-auth',

--- a/docs/data/toolpad/getting-started/examples-overview.md
+++ b/docs/data/toolpad/getting-started/examples-overview.md
@@ -1,6 +1,6 @@
 ---
 productId: toolpad
-title: Toolpad examples
+title: Examples
 ---
 
 # Overview

--- a/docs/data/toolpad/how-to-guides/embed-pages.md
+++ b/docs/data/toolpad/how-to-guides/embed-pages.md
@@ -1,4 +1,4 @@
-# Embed a Toolpad page
+# Embedding Toolpad pages
 
 <p class="description">Toolpad pages can be embedded anywhere you want to use them.</p>
 


### PR DESCRIPTION
See https://app.ahrefs.com/site-audit/3833384/76/data-explorer?columns=pageRating%2Curl%2Ctraffic%2Ctitle%2Cserp_title%2Cis_page_title_used_in_serp%2Ctop_keyword%2Ctop_keyword_position&filterId=207cf10d892e807e0aaeafdf8fc70712&issueId=d69246c2-225a-11ec-8456-06d2f2f613d8

Google deduplicates the "Toolpad" from "Toolpad examples - MUI Toolpad" into "Toolpad examples". By just using the title "Examples" we can keep it "Examples - MUI Toolpad".

The "Toolpad" in "Why Toolpad" and "Embedding Toolpad pages" is probably justified.