### PR TITLE
Update release instructions smoke test

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,9 +38,10 @@
    1. Run
 
    ```bash
-   npx https://pkg.csb.dev/mui/mui-toolpad/commit/<build>/create-toolpad-app
-   cd test-app
-   yarn dev
+   npx https://pkg.csb.dev/mui/mui-toolpad/commit/<build>/create-toolpad-app smoke
+   cd smoke
+   yarn add https://pkg.csb.dev/mui/mui-toolpad/commit/<build>/@mui/toolpad -S
+   yarn && yarn dev
    ```
 
    And verify the editor works


### PR DESCRIPTION
Make sure we not only test the `create-toolpad-app`, but also `@mui/toolpad`