### PR TITLE
Remove id from examples

### DIFF
--- a/examples/basic-crud-app/package.json
+++ b/examples/basic-crud-app/package.json
@@ -8,6 +8,6 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38"
+    "@mui/toolpad": "0.1.39"
   }
 }

--- a/examples/basic-crud-app/toolpad/pages/AdminApp/page.yml
+++ b/examples/basic-crud-app/toolpad/pages/AdminApp/page.yml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: page
 spec:
-  id: I1VOdmU
   title: Employees
   content:
     - component: PageRow

--- a/examples/charts/package.json
+++ b/examples/charts/package.json
@@ -8,6 +8,6 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38"
+    "@mui/toolpad": "0.1.39"
   }
 }

--- a/examples/charts/toolpad/pages/page/page.yml
+++ b/examples/charts/toolpad/pages/page/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: tffH0lV
-  title: Default page
+  title: Charts
   content:
     - component: PageRow
       name: pageRow

--- a/examples/custom-datagrid-column/package.json
+++ b/examples/custom-datagrid-column/package.json
@@ -8,6 +8,6 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38"
+    "@mui/toolpad": "0.1.39"
   }
 }

--- a/examples/custom-datagrid-column/toolpad/pages/example/page.yml
+++ b/examples/custom-datagrid-column/toolpad/pages/example/page.yml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: page
 spec:
-  id: yq14d6o
   title: Page 1
   content:
     - component: PageRow

--- a/examples/custom-server-nextjs/package.json
+++ b/examples/custom-server-nextjs/package.json
@@ -9,7 +9,7 @@
     "edit": "toolpad editor http://localhost:3001/my-toolpad-app"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38",
+    "@mui/toolpad": "0.1.39",
     "next": "14.0.2"
   },
   "devDependencies": {}

--- a/examples/custom-server-nextjs/toolpad/pages/page/page.yml
+++ b/examples/custom-server-nextjs/toolpad/pages/page/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: HYZmpQV
-  title: Default page
+  title: Custom server
   content:
     - component: Text
       name: text

--- a/examples/custom-server/package.json
+++ b/examples/custom-server/package.json
@@ -9,7 +9,7 @@
     "edit": "toolpad editor http://localhost:3001/my-app"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38",
+    "@mui/toolpad": "0.1.39",
     "express": "4.18.2"
   },
   "devDependencies": {}

--- a/examples/custom-server/toolpad/pages/page/page.yml
+++ b/examples/custom-server/toolpad/pages/page/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: HYZmpQV
-  title: Default page
+  title: Custom server
   content:
     - component: Text
       name: text

--- a/examples/datagrid-columns/package.json
+++ b/examples/datagrid-columns/package.json
@@ -8,6 +8,6 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38"
+    "@mui/toolpad": "0.1.39"
   }
 }

--- a/examples/datagrid-columns/toolpad/pages/customers/page.yml
+++ b/examples/datagrid-columns/toolpad/pages/customers/page.yml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: page
 spec:
-  id: uVF80NP
   title: page2
   content:
     - component: PageRow

--- a/examples/dog-app/package.json
+++ b/examples/dog-app/package.json
@@ -8,6 +8,6 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38"
+    "@mui/toolpad": "0.1.39"
   }
 }

--- a/examples/dog-app/toolpad/pages/page/page.yml
+++ b/examples/dog-app/toolpad/pages/page/page.yml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: page
 spec:
-  id: PCYkw5V
   title: page1
   content:
     - component: PageRow

--- a/examples/google-sheet/package.json
+++ b/examples/google-sheet/package.json
@@ -8,7 +8,7 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38",
+    "@mui/toolpad": "0.1.39",
     "googleapis": "128.0.0"
   }
 }

--- a/examples/google-sheet/toolpad/pages/page/page.yml
+++ b/examples/google-sheet/toolpad/pages/page/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: mDJP5kU
-  title: Default page
+  title: Google sheets
   queries:
     - name: fetchSheet
       query:

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -8,7 +8,7 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38",
+    "@mui/toolpad": "0.1.39",
     "graphql": "16.8.1",
     "graphql-request": "6.1.0",
     "graphql-tag": "2.12.6"

--- a/examples/graphql/toolpad/pages/page/page.yml
+++ b/examples/graphql/toolpad/pages/page/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: WduAwgm
-  title: Default page
+  title: Graphql
   content:
     - component: PageRow
       name: pageRow

--- a/examples/npm-stats/package.json
+++ b/examples/npm-stats/package.json
@@ -8,6 +8,6 @@
     "start": "NODE_OPTIONS='--max-old-space-size=396' toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38"
+    "@mui/toolpad": "0.1.39"
   }
 }

--- a/examples/npm-stats/toolpad/pages/page/page.yml
+++ b/examples/npm-stats/toolpad/pages/page/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: evZC-gp
-  title: Default page
+  title: Npm stats
   queries:
     - name: versionLastWeek
       query:

--- a/examples/qr-generator/package.json
+++ b/examples/qr-generator/package.json
@@ -8,7 +8,7 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38",
+    "@mui/toolpad": "0.1.39",
     "qrcode": "^1.5.3"
   },
   "devDependencies": {

--- a/examples/qr-generator/toolpad/pages/qrcode/page.yml
+++ b/examples/qr-generator/toolpad/pages/qrcode/page.yml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: page
 spec:
-  id: sR_fqKE
-  title: Default page
   content:
     - component: PageRow
       name: pageRow

--- a/examples/stripe-script/toolpad/pages/page/page.yml
+++ b/examples/stripe-script/toolpad/pages/page/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: b4UWL4X
-  title: Default page
+  title: Stripe scripts
   content:
     - component: Text
       name: text

--- a/examples/supabase/package.json
+++ b/examples/supabase/package.json
@@ -8,7 +8,7 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38",
+    "@mui/toolpad": "0.1.39",
     "@supabase/supabase-js": "2.38.5"
   }
 }

--- a/examples/supabase/toolpad/pages/page/page.yml
+++ b/examples/supabase/toolpad/pages/page/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: BKAYeeK
-  title: Default page
+  title: Supabase example
   queries:
     - name: query
       query:

--- a/examples/with-prisma-data-provider/package.json
+++ b/examples/with-prisma-data-provider/package.json
@@ -9,7 +9,7 @@
     "prisma": "prisma"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38",
+    "@mui/toolpad": "0.1.39",
     "@prisma/client": "5.6.0",
     "qrcode": "^1.5.3"
   },

--- a/examples/with-prisma-data-provider/toolpad/pages/cursorBased/page.yml
+++ b/examples/with-prisma-data-provider/toolpad/pages/cursorBased/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: -vzMDF1
-  title: Default page
+  title: Prisma data source example with cursor
   content:
     - component: Text
       name: text

--- a/examples/with-prisma-data-provider/toolpad/pages/indexBased/page.yml
+++ b/examples/with-prisma-data-provider/toolpad/pages/indexBased/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: n5zz3LC
-  title: Default page
+  title: Prisma data source example
   content:
     - component: Text
       name: text

--- a/examples/with-prisma/package.json
+++ b/examples/with-prisma/package.json
@@ -9,7 +9,7 @@
     "prisma": "prisma"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38",
+    "@mui/toolpad": "0.1.39",
     "@prisma/client": "5.6.0",
     "qrcode": "^1.5.3"
   },

--- a/examples/with-prisma/toolpad/pages/users/page.yml
+++ b/examples/with-prisma/toolpad/pages/users/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: n5zz3LC
-  title: Default page
+  title: Prisma example
   content:
     - component: PageRow
       name: pageRow1

--- a/examples/with-wasm/package.json
+++ b/examples/with-wasm/package.json
@@ -8,7 +8,7 @@
     "start": "toolpad start"
   },
   "dependencies": {
-    "@mui/toolpad": "0.1.38"
+    "@mui/toolpad": "0.1.39"
   },
   "devDependencies": {
     "assemblyscript": "0.27.22"

--- a/examples/with-wasm/toolpad/pages/wasm/page.yml
+++ b/examples/with-wasm/toolpad/pages/wasm/page.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: page
 spec:
-  id: sR_fqKE
-  title: Default page
+  title: WASM example
   content:
     - component: TextField
       name: number1


### PR DESCRIPTION
Unnecessary property after the new routing in 0.1.39. This avoids creating an `alias` property in `page.yml` on startup.
Also fixes some titles
