### PR TITLE
Unclutter UI for code pages

### DIFF
--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -1212,3 +1212,7 @@ export function getRequiredEnvVars(dom: AppDom): Set<string> {
 export function getPageTitle(node: PageNode): string {
   return node.attributes.title || node.name;
 }
+
+export function isCodePage(node: PageNode): boolean {
+  return !!node.attributes.codeFile;
+}

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -132,14 +132,13 @@ function RecursiveSubTree({ dom, root }: { dom: appDom.AppDom; root: appDom.Elem
 }
 
 export default function HierarchyExplorer() {
-  const { dom } = useAppState();
-  const { currentView } = useAppState();
+  const { dom, currentView } = useAppState();
   const appStateApi = useAppStateApi();
   const [expandedDomNodeIds, setExpandedDomNodeIds] = React.useState<string[]>([]);
 
   const currentPageId = currentView?.name ? appDom.getNodeIdByName(dom, currentView?.name) : null;
   const currentPageNode = currentPageId ? appDom.getNode(dom, currentPageId, 'page') : null;
-  const selectedDomNodeId = (currentView as Extract<DomView, { kind: 'page' }>)?.selectedNodeId;
+  const selectedDomNodeId = currentView?.selectedNodeId;
 
   const selectedNodeAncestorIds = React.useMemo(() => {
     if (!selectedDomNodeId) {

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/ComponentPanel.tsx
@@ -70,8 +70,7 @@ export interface ComponentPanelProps {
 }
 
 export default function ComponentPanel({ className }: ComponentPanelProps) {
-  const { dom } = useAppState();
-  const { currentView } = useAppState();
+  const { dom, currentView } = useAppState();
   const appStateApi = useAppStateApi();
 
   const currentTab = currentView.kind === 'page' ? currentView.tab : null;

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageOptionsPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/PageOptionsPanel.tsx
@@ -76,10 +76,14 @@ export default function PageOptionsPanel() {
           })}
         </ToggleButtonGroup>
       </Tooltip>
-      <Divider variant="middle" sx={{ alignSelf: 'stretch' }} />
-      <Typography variant="overline">Page State:</Typography>
-      <UrlQueryEditor pageNodeId={pageNodeId} />
-      <QueryEditor />
+      {appDom.isCodePage(page) ? null : (
+        <React.Fragment>
+          <Divider variant="middle" sx={{ alignSelf: 'stretch' }} />
+          <Typography variant="overline">Page State:</Typography>
+          <UrlQueryEditor pageNodeId={pageNodeId} />
+          <QueryEditor />
+        </React.Fragment>
+      )}
     </Stack>
   );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderPanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/RenderPanel/RenderPanel.tsx
@@ -110,7 +110,7 @@ export default function RenderPanel({ className }: RenderPanelProps) {
         base={appState.appUrl}
         savedNodes={savedNodes}
         pageName={page.name}
-        overlay={<RenderOverlay bridge={bridge} />}
+        overlay={appDom.isCodePage(page) ? null : <RenderOverlay bridge={bridge} />}
         onInit={handleInit}
       />
     </RenderPanelRoot>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
@@ -39,7 +39,7 @@ function PageEditorContent({ node }: PageEditorContentProps) {
       <PanelGroup autoSaveId="editor/component-panel-split" direction="horizontal">
         <Panel defaultSizePercentage={75} minSizePercentage={50} maxSizePercentage={80}>
           <PageEditorRoot>
-            <ComponentCatalog />
+            {appDom.isCodePage(node) ? null : <ComponentCatalog />}
             <RenderPanel className={classes.renderPanel} />
           </PageEditorRoot>
         </Panel>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -6,6 +6,7 @@ import PageHierarchyExplorer from './HierarchyExplorer';
 import { useAppState } from '../AppState';
 import AppOptions from '../AppOptions';
 import { useProject } from '../../project';
+import * as appDom from '../../appDom';
 
 const PagePanelRoot = styled('div')({
   display: 'flex',
@@ -19,7 +20,10 @@ export interface ComponentPanelProps {
 
 export default function PagePanel({ className, sx }: ComponentPanelProps) {
   const project = useProject();
-  const { dom } = useAppState();
+  const { dom, currentView } = useAppState();
+
+  const currentPageId = currentView?.name ? appDom.getNodeIdByName(dom, currentView?.name) : null;
+  const currentPageNode = currentPageId ? appDom.getNode(dom, currentPageId, 'page') : null;
 
   return (
     <PagePanelRoot className={className} sx={sx}>
@@ -44,10 +48,14 @@ export default function PagePanel({ className, sx }: ComponentPanelProps) {
         <Panel minSizePercentage={10} defaultSizePercentage={30} maxSizePercentage={75}>
           <PagesExplorer />
         </Panel>
-        <PanelResizeHandle />
-        <Panel minSizePercentage={25} maxSizePercentage={90}>
-          <PageHierarchyExplorer />
-        </Panel>
+        {currentPageNode && !appDom.isCodePage(currentPageNode) ? (
+          <React.Fragment>
+            <PanelResizeHandle />
+            <Panel minSizePercentage={25} maxSizePercentage={90}>
+              <PageHierarchyExplorer />
+            </Panel>
+          </React.Fragment>
+        ) : null}
       </PanelGroup>
     </PagePanelRoot>
   );


### PR DESCRIPTION
Remove page hierarchy, query editor, component drawer and page overlay when a code page is used