### PR TITLE
Fix crash when a query name is the same as a page name

### DIFF
--- a/packages/toolpad-app/src/appDom/index.ts
+++ b/packages/toolpad-app/src/appDom/index.ts
@@ -877,21 +877,6 @@ export function fromConstPropValues<P>(props: BindableAttrValues<P>): Partial<P>
   return result;
 }
 
-const nodeByNameCache = new WeakMap<AppDom, Map<string, NodeId>>();
-function getNodeIdByNameIndex(dom: AppDom): Map<string, NodeId> {
-  let cached = nodeByNameCache.get(dom);
-  if (!cached) {
-    cached = new Map(Array.from(Object.values(dom.nodes), (node) => [node.name, node.id]));
-    nodeByNameCache.set(dom, cached);
-  }
-  return cached;
-}
-
-export function getNodeIdByName(dom: AppDom, name: string): NodeId | null {
-  const index = getNodeIdByNameIndex(dom);
-  return index.get(name) ?? null;
-}
-
 export function getNodeFirstChild(dom: AppDom, node: ElementNode | PageNode, parentProp: string) {
   const nodeChildren = (getChildNodes(dom, node) as NodeChildren<ElementNode>)[parentProp] || [];
   return nodeChildren.length > 0 ? nodeChildren[0] : null;

--- a/packages/toolpad-app/src/toolpad/AppEditor/BindingEditor.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/BindingEditor.tsx
@@ -365,8 +365,7 @@ function NavigationActionEditor({ value, onChange }: NavigationActionEditorProps
   const handlePageChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const pageName = event.target.value;
-      const pageId = appDom.getNodeIdByName(dom, pageName);
-      const page = pageId ? appDom.getNode(dom, pageId) : null;
+      const page = appDom.getPageByName(dom, pageName);
 
       const defaultActionParameters =
         page && appDom.isPage(page) ? getDefaultActionParameters(page) : {};

--- a/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/HierarchyExplorer/index.tsx
@@ -136,8 +136,7 @@ export default function HierarchyExplorer() {
   const appStateApi = useAppStateApi();
   const [expandedDomNodeIds, setExpandedDomNodeIds] = React.useState<string[]>([]);
 
-  const currentPageId = currentView?.name ? appDom.getNodeIdByName(dom, currentView?.name) : null;
-  const currentPageNode = currentPageId ? appDom.getNode(dom, currentPageId, 'page') : null;
+  const currentPageNode = currentView?.name ? appDom.getPageByName(dom, currentView.name) : null;
   const selectedDomNodeId = currentView?.selectedNodeId;
 
   const selectedNodeAncestorIds = React.useMemo(() => {

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { styled } from '@mui/material';
-import { NodeId } from '@mui/toolpad-core';
 import usePageTitle from '@mui/toolpad-utils/hooks/usePageTitle';
 import { Panel, PanelGroup, PanelResizeHandle } from '../../../components/resizablePanels';
 import RenderPanel from './RenderPanel';
@@ -58,14 +57,13 @@ interface PageEditorProps {
 
 export default function PageEditor({ name }: PageEditorProps) {
   const { dom } = useAppState();
-  const nodeId = React.useMemo(() => appDom.getNodeIdByName(dom, name), [dom, name]);
-  const pageNode = appDom.getMaybeNode(dom, nodeId as NodeId, 'page');
+  const pageNode = React.useMemo(() => appDom.getPageByName(dom, name), [dom, name]);
 
   useUndoRedo();
 
   return pageNode ? (
     <PageEditorContent node={pageNode} />
   ) : (
-    <NotFoundEditor message={`Non-existing Page "${nodeId}"`} />
+    <NotFoundEditor message={`Non-existing Page "${name}"`} />
   );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagePanel.tsx
@@ -22,8 +22,7 @@ export default function PagePanel({ className, sx }: ComponentPanelProps) {
   const project = useProject();
   const { dom, currentView } = useAppState();
 
-  const currentPageId = currentView?.name ? appDom.getNodeIdByName(dom, currentView?.name) : null;
-  const currentPageNode = currentPageId ? appDom.getNode(dom, currentPageId, 'page') : null;
+  const currentPageNode = currentView?.name ? appDom.getPageByName(dom, currentView.name) : null;
 
   return (
     <PagePanelRoot className={className} sx={sx}>

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -171,7 +171,7 @@ export default function PagesExplorer({ className }: PagesExplorerProps) {
     [':pages'],
   );
 
-  const activeNodeId = currentView.name ? appDom.getNodeIdByName(dom, currentView.name) : null;
+  const activePage = currentView.name ? appDom.getPageByName(dom, currentView.name) : null;
 
   const handleToggle = (event: React.SyntheticEvent, nodeIds: string[]) => {
     setExpanded(nodeIds as NodeId[]);
@@ -270,7 +270,7 @@ export default function PagesExplorer({ className }: PagesExplorerProps) {
       const deletedNode = appDom.getNode(dom, nodeId);
 
       let domViewAfterDelete: DomView | undefined;
-      if (nodeId === activeNodeId) {
+      if (nodeId === activePage?.id) {
         const siblings = appDom.getSiblings(dom, deletedNode);
         const firstSiblingOfType = siblings.find((sibling) => sibling.type === deletedNode.type);
         domViewAfterDelete = firstSiblingOfType && getNodeEditorDomView(firstSiblingOfType);
@@ -283,7 +283,7 @@ export default function PagesExplorer({ className }: PagesExplorerProps) {
         domViewAfterDelete || { kind: 'page' },
       );
     },
-    [projectApi, activeNodeId, appStateApi, dom],
+    [projectApi, activePage?.id, appStateApi, dom],
   );
 
   const handleRenameNode = React.useCallback(
@@ -338,7 +338,7 @@ export default function PagesExplorer({ className }: PagesExplorerProps) {
       <TreeView
         ref={pagesTreeRef}
         aria-label="Pages explorer"
-        selected={activeNodeId ? [activeNodeId] : []}
+        selected={activePage ? [activePage.id] : []}
         onNodeSelect={handleSelect}
         expanded={expanded}
         onNodeToggle={handleToggle}

--- a/test/integration/backend-basic/fixture/toolpad/pages/dataProviders/page.yml
+++ b/test/integration/backend-basic/fixture/toolpad/pages/dataProviders/page.yml
@@ -24,3 +24,8 @@ spec:
         height: 244
         rowsSource: dataProvider
   display: shell
+  queries:
+    - name: dataProviders
+      query:
+        function: hello
+        kind: local


### PR DESCRIPTION
Fixes https://github.com/mui/mui-public/pull/135

Toolpad name based navigation was relying on a function that still treats node names as unique, but that constraint has already been dropped a while ago. I'm removing the `getNodeIdByName` function altogether to avoid this confusion in the future.

replicating the behavior in an existing fixture breaks some tests. That will suffice for now as a test
