### PR TITLE
[docs] Fix dead link to live demo

### DIFF
--- a/examples/basic-crud-app/README.md
+++ b/examples/basic-crud-app/README.md
@@ -2,13 +2,13 @@
 
 <p class="description">An admin application to showcase how CRUD operations work in Toolpad.</p>
 
-<a href="https://basic-crud-app-production.up.railway.app/prod/" target="_blank">
+<a href="https://basic-crud-app-production.up.railway.app/prod/pages/AdminApp" target="_blank">
   <img src="https://mui.com/static/toolpad/docs/examples/basic-crud-app.png" alt="Basic CRUD app" style="aspect-ratio: 625/347;" width="1440">
 </a>
 
 ## Check out the live app
 
-[Open example](https://basic-crud-app-production.up.railway.app/prod/)
+[Open example](https://basic-crud-app-production.up.railway.app/prod/pages/AdminApp)
 
 ## How to run
 

--- a/examples/npm-stats/README.md
+++ b/examples/npm-stats/README.md
@@ -2,13 +2,13 @@
 
 <p class="description">This analytics dashboard shows how to track a KPI from a third-party data source.</p>
 
-<a href="https://mui-toolpad-npm-stats-production.up.railway.app/prod/pages/evZC-gp" target="_blank">
+<a href="https://mui-toolpad-npm-stats-production.up.railway.app/prod/pages/page" target="_blank">
   <img src="https://mui.com/static/toolpad/docs/examples/npm-stats.png" alt="npm stats app" style="aspect-ratio: 67/37;" width="1440">
 </a>
 
 ## Check out the live app
 
-[Open example](https://mui-toolpad-npm-stats-production.up.railway.app/prod/pages/evZC-gp)
+[Open example](https://mui-toolpad-npm-stats-production.up.railway.app/prod/pages/page)
 
 ## How to run
 

--- a/examples/qr-generator/README.md
+++ b/examples/qr-generator/README.md
@@ -2,13 +2,13 @@
 
 <p class="description">A basic Toolpad application that can be used to turn any text or URL into a QR code.</p>
 
-<a href="https://mui-toolpad-qr-generator-production.up.railway.app/prod/" target="_blank">
+<a href="https://mui-toolpad-qr-generator-production.up.railway.app/prod/pages/qrcode" target="_blank">
   <img src="https://mui.com/static/toolpad/docs/examples/qr-generator.png" alt="QR generator" style="aspect-ratio: 575/318;" width="1440">
 </a>
 
 ## Check out the live app
 
-[Open example](https://mui-toolpad-qr-generator-production.up.railway.app/prod/)
+[Open example](https://mui-toolpad-qr-generator-production.up.railway.app/prod/pages/qrcode)
 
 ## How to run
 


### PR DESCRIPTION
To reproduce the bug, go to https://mui.com/toolpad/examples/npm-stats/#check-out-the-live-app.

I used the opportunity to fix the redirection.

---

I landed here checking that I wouldn't break anything by deleting the example repo that is on Render, now that it moved to Railway:

![Screenshot 2024-01-01 at 17 43 23](https://github.com/mui/mui-toolpad/assets/3165635/5e73b7fb-87e7-45cb-8ffc-eb318da57b65)

https://dashboard.render.com/usage/inv-cm932juv3ddc7381bgi0/view

Deleted.

Are there any objections to deleting the rest? It doesn't seem that we need:

![Screenshot 2024-01-01 at 17 46 12](https://github.com/mui/mui-toolpad/assets/3165635/31057eec-7b2e-4033-aa92-0ab7abe2c3f3)

https://dashboard.render.com/

---

I looked a bit at moving completely out of Render.com, I have tried to move the MUI Toolpad apps to Railway, https://github.com/mui/mui-public/blob/master/tools-public/railway.toml, https://mui-publictools-public-production.up.railway.app. It looks ok, but there seems to be one main problem: https://docs.railway.app/guides/environments#how-come-my-github-pr-wont-deploy. 

> Railway will not deploy a PR branch from a user who is not in your team or invited to your project without their associated GitHub account.

It forces to add all the team members, so Render is likely still cheaper.