### PR TITLE
Hosted 5 more examples on railway and linked them to docs

### DIFF
--- a/examples/charts/README.md
+++ b/examples/charts/README.md
@@ -2,9 +2,13 @@
 
 <p class="description">A Toolpad app that shows how to use charts to build an analytics dashboard.</p>
 
-<a target="_blank">
+<a href="https://mui-toolpad-charts-production.up.railway.app/prod/pages/page" target="_blank">
   <img src="https://mui.com/static/toolpad/marketing/charts.png" alt="Charts in Toolpad" style="aspect-ratio: 575/317;" width="1433">
 </a>
+
+## Check out the live app
+
+[Open example](https://mui-toolpad-charts-production.up.railway.app/prod/pages/page)
 
 ## How to run
 
@@ -27,5 +31,7 @@ pnpm create toolpad-app --example charts
 This app demonstrates the following capabilities of Toolpad:
 
 1. Usage of the four types of charts.
+
+## The source
 
 [Check out the source code](https://github.com/mui/mui-toolpad/tree/master/examples/charts)

--- a/examples/dog-app/README.md
+++ b/examples/dog-app/README.md
@@ -2,13 +2,13 @@
 
 <p class="description">An app that shows dog images based on selected breeds or sub-breeds.</p>
 
-<a target="_blank">
+<a href="https://mui-toolpad-dog-app-production.up.railway.app/prod/pages/page" target="_blank">
   <img src="https://mui.com/static/toolpad/docs/getting-started/first-app/step-13.png" alt="An app that shows dog images based on selected breeds or sub-breeds." style="aspect-ratio: 360/199;" width="1440">
 </a>
 
-A basic Toolpad app that shows how to call an API and work with data grid and image component.
+## Check out the live app
 
-To build this app step-by-step, visit the [docs](https://mui.com/toolpad/getting-started/first-app/#building-your-first-application).
+[Open example](https://mui-toolpad-dog-app-production.up.railway.app/prod/pages/page)
 
 ## How to run
 
@@ -29,3 +29,13 @@ pnpm create toolpad-app --example dog-app
 or:
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/mui/mui-toolpad/tree/master/examples/dog-app)
+
+## What's inside
+
+A basic Toolpad app that shows how to call an API and work with data grid and image component.
+
+To build this app step-by-step, visit the [docs](https://mui.com/toolpad/getting-started/first-app/#building-your-first-application).
+
+## The source
+
+[Check out the source code](https://github.com/mui/mui-toolpad/tree/master/examples/dog-app)

--- a/examples/graphql/README.md
+++ b/examples/graphql/README.md
@@ -2,15 +2,13 @@
 
 <p class="description">An app that shows latest 100 stargezers' info for any GitHub repository.</p>
 
-<a target="_blank">
+<a href="https://mui-toolpad-graphql-production.up.railway.app/prod/pages/page" target="_blank">
   <img src="https://mui.com/static/toolpad/marketing/graphql.png" alt="Toolpad example app using graphQL API" style="aspect-ratio: 687/376;" width="1434">
 </a>
 
-A Toolpad app that shows how to:
+## Check out the live app
 
-- call a graphQL API using custom functions
-- use data grid, metric and textField components
-- work with secrets in Toolpad
+[Open example](https://mui-toolpad-graphql-production.up.railway.app/prod/pages/page)
 
 ## How to run
 
@@ -31,3 +29,15 @@ pnpm create toolpad-app --example graphql
 or:
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/mui/mui-toolpad/tree/master/examples/graphql)
+
+## What's inside
+
+A Toolpad app that shows how to:
+
+- call a graphQL API using custom functions
+- use data grid, metric and textField components
+- work with secrets in Toolpad
+
+## The source
+
+[Check out the source code](https://github.com/mui/mui-toolpad/tree/master/examples/graphql)

--- a/examples/supabase/README.md
+++ b/examples/supabase/README.md
@@ -2,9 +2,13 @@
 
 <p class="description">A Toolpad app that fetches data from Supabase and shows it in a list component.</p>
 
-<a target="_blank">
+<a href="https://mui-toolpad-supabase-production.up.railway.app/prod/pages/page" target="_blank">
   <img src="https://mui.com/static/toolpad/marketing/supabase.png" alt="Supabase integration" style="aspect-ratio: 575/318;" width="1469">
 </a>
+
+## Check out the live app
+
+[Open example](https://mui-toolpad-supabase-production.up.railway.app/prod/pages/page)
 
 ## How to run
 
@@ -28,5 +32,7 @@ This app demonstrates the following capabilities of Toolpad:
 
 1. Connecting to Supabase database using custom functions.
 2. Using the list component to create a basic product catalogue manager.
+
+## The source
 
 [Check out the source code](https://github.com/mui/mui-toolpad/tree/master/examples/supabase)

--- a/examples/with-prisma-data-provider/README.md
+++ b/examples/with-prisma-data-provider/README.md
@@ -2,9 +2,13 @@
 
 <p class="description">A basic Toolpad application that demonstrates how to use data providers with Prisma.</p>
 
-<a target="_blank">
+<a href="https://mui-toolpad-with-prisma-data-provider-production.up.railway.app/prod/pages/crud" target="_blank">
   <img src="https://mui.com/static/toolpad/marketing/with-prisma-data-provider.png" alt="Data provider example with Prisma ORM" style="aspect-ratio: 25/13;" width="1435">
 </a>
+
+## Check out the live app
+
+[Open example](https://mui-toolpad-with-prisma-data-provider-production.up.railway.app/prod/pages/crud)
 
 ## How to run
 
@@ -29,5 +33,7 @@ This app demonstrates the following capabilities of Toolpad:
 1. Reusing your models in Toolpad UI.
 2. Using a Data Grid, Button and a text input component.
 3. Leveraging data providers to support pagination.
+
+## The source
 
 [Check out the source code](https://github.com/mui/mui-toolpad/tree/master/examples/with-prisma-data-provider)


### PR DESCRIPTION
While I was checking other examples, I found that https://mui.com/toolpad/examples/npm-stats/ leads to a wrong link (the one with page ID) even though the README has page_name in the URL. Not sure how can I fix it?