### PR TITLE
Don't create private packages with create-toolpad-app

### DIFF
--- a/packages/create-toolpad-app/src/index.ts
+++ b/packages/create-toolpad-app/src/index.ts
@@ -118,7 +118,6 @@ const scaffoldProject = async (absolutePath: string, installFlag: boolean): Prom
   const packageJson: PackageJson = {
     name: path.basename(absolutePath),
     version: '0.1.0',
-    private: true,
     scripts: {
       dev: 'toolpad dev',
       build: 'toolpad build',


### PR DESCRIPTION
I believe this should be up to the user to decide