### PR TITLE
Handle errors during data provider introspection

### DIFF
--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -626,7 +626,11 @@ function useDataProviderDataGridProps(
   setActionResult: (result: ActionResult) => void,
 ): DataProviderDataGridProps {
   const useDataProvider = useNonNullableContext(UseDataProviderContext);
-  const { dataProvider } = useDataProvider(dataProviderId || null);
+  const {
+    dataProvider,
+    error: dataProviderLoadError,
+    isLoading: dataProviderLoading,
+  } = useDataProvider(dataProviderId || null);
 
   const [rawPaginationModel, setRawPaginationModel] = React.useState<GridPaginationModel>({
     page: 0,
@@ -886,9 +890,19 @@ function useDataProviderDataGridProps(
     return rowData;
   }, [data?.records, draftRow]);
 
-  if (!dataProvider) {
-    return {};
+  if (dataProviderLoadError) {
+    return {
+      rowLoadingError: dataProviderLoadError,
+    };
   }
+
+  if (dataProviderLoading) {
+    return {
+      loading: true,
+    };
+  }
+
+  invariant(dataProvider, "dataProvider must be defined if it's loaded without error");
 
   return {
     loading: isLoading || (isPlaceholderData && isFetching),

--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -890,6 +890,10 @@ function useDataProviderDataGridProps(
     return rowData;
   }, [data?.records, draftRow]);
 
+  if (!dataProviderId) {
+    return {};
+  }
+
   if (dataProviderLoadError) {
     return {
       rowLoadingError: dataProviderLoadError,


### PR DESCRIPTION
Make sure we give feedback when the data provider introspection fails. Currently it just shows as empty, this PR makes it show an error in the rows area. We can also render the grid as loading while introspecting.
