### PR TITLE
Make toolpad-core and toopad-components ESM only

### DIFF
--- a/packages/toolpad-app/src/server/FunctionsManager.ts
+++ b/packages/toolpad-app/src/server/FunctionsManager.ts
@@ -222,6 +222,7 @@ export default class FunctionsManager {
       bundle: true,
       metafile: true,
       outdir: this.getFunctionsOutputFolder(),
+      outExtension: { '.js': '.mjs' },
       platform: 'node',
       format: 'esm',
       packages: 'external',
@@ -294,7 +295,7 @@ export default class FunctionsManager {
 
     const outputFilePath = path.resolve(
       this.getFunctionsOutputFolder(),
-      `${path.basename(fileName, '.ts')}.js`,
+      `${path.basename(fileName, '.ts')}.mjs`,
     );
 
     return outputFilePath;

--- a/packages/toolpad-app/src/server/FunctionsManager.ts
+++ b/packages/toolpad-app/src/server/FunctionsManager.ts
@@ -223,6 +223,7 @@ export default class FunctionsManager {
       metafile: true,
       outdir: this.getFunctionsOutputFolder(),
       platform: 'node',
+      format: 'esm',
       packages: 'external',
       target: 'es2022',
       tsconfigRaw: JSON.stringify({ compilerOptions }),

--- a/packages/toolpad-app/src/server/functionsRuntime.ts
+++ b/packages/toolpad-app/src/server/functionsRuntime.ts
@@ -1,56 +1,19 @@
 import * as path from 'path';
-import { createRequire } from 'node:module';
 import * as fs from 'fs/promises';
-import * as vm from 'vm';
 import * as url from 'node:url';
-import { initialContextStore } from '@mui/toolpad-core/serverRuntime';
 import { TOOLPAD_DATA_PROVIDER_MARKER, ToolpadDataProvider } from '@mui/toolpad-core/server';
 import * as z from 'zod';
 import { fromZodError } from 'zod-validation-error';
+import * as crypto from 'crypto';
 
 import.meta.url ??= url.pathToFileURL(__filename).toString();
-
-interface ModuleObject {
-  exports: Record<string, unknown>;
-}
-
-const fileContents = new Map<string, string>();
-const moduleCache = new Map<string, ModuleObject>();
-
-function loadModule(fullPath: string, content: string) {
-  const moduleRequire = createRequire(url.pathToFileURL(fullPath));
-  const moduleObject: ModuleObject = { exports: {} };
-
-  const serverRuntime = moduleRequire('@mui/toolpad/server');
-  // eslint-disable-next-line no-underscore-dangle
-  serverRuntime.__initContextStore(initialContextStore);
-
-  vm.runInThisContext(`((require, exports, module) => {\n${content}\n})`)(
-    moduleRequire,
-    moduleObject.exports,
-    moduleObject,
-  );
-
-  return moduleObject;
-}
 
 async function loadExports(filePath: string): Promise<Map<string, unknown>> {
   const fullPath = path.resolve(filePath);
   const content = await fs.readFile(fullPath, 'utf-8');
-
-  if (content !== fileContents.get(fullPath)) {
-    moduleCache.delete(fullPath);
-    fileContents.set(fullPath, content);
-  }
-
-  let cachedModule = moduleCache.get(fullPath);
-
-  if (!cachedModule) {
-    cachedModule = loadModule(fullPath, content);
-    moduleCache.set(fullPath, cachedModule);
-  }
-
-  return new Map(Object.entries(cachedModule.exports));
+  const hash = crypto.createHash('md5').update(content).digest('hex');
+  const exports = await import(`${fullPath}?${hash}`);
+  return new Map(Object.entries(exports));
 }
 
 const dataProviderSchema: z.ZodType<ToolpadDataProvider<any, any>> = z.object({

--- a/packages/toolpad-app/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-app/src/server/toolpadAppBuilder.ts
@@ -311,11 +311,7 @@ if (import.meta.hot) {
       },
       optimizeDeps: {
         force: toolpadDevMode ? true : undefined,
-        include: [
-          ...FALLBACK_MODULES.map((moduleName) => `@mui/toolpad > ${moduleName}`),
-          '@mui/toolpad/runtime',
-          '@mui/toolpad/canvas',
-        ],
+        include: [...FALLBACK_MODULES.map((moduleName) => `@mui/toolpad > ${moduleName}`)],
       },
       appType: 'custom',
       logLevel: 'info',

--- a/packages/toolpad-components/package.json
+++ b/packages/toolpad-components/package.json
@@ -5,7 +5,6 @@
   "author": "MUI Toolpad team",
   "homepage": "https://github.com/mui/mui-toolpad#readme",
   "license": "MIT",
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
@@ -13,13 +12,11 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",
-      "import": "./dist/*.js",
-      "require": "./dist/*.cjs"
+      "import": "./dist/*.js"
     }
   },
   "files": [

--- a/packages/toolpad-components/tsup.config.ts
+++ b/packages/toolpad-components/tsup.config.ts
@@ -23,7 +23,7 @@ function cleanFolderOnFailure(folder: string): EsbuildPlugin {
 
 export default defineConfig((options) => ({
   entry: ['src/*{.ts,.tsx}'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: false,
   silent: true,
   clean: !options.watch,

--- a/packages/toolpad-core/package.json
+++ b/packages/toolpad-core/package.json
@@ -5,7 +5,6 @@
   "author": "MUI Toolpad team",
   "homepage": "https://github.com/mui/mui-toolpad#readme",
   "license": "MIT",
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
@@ -13,13 +12,15 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",
-      "import": "./dist/*.js",
-      "require": "./dist/*.cjs"
+      "import": "./dist/*.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
     }
   },
   "files": [

--- a/packages/toolpad-core/src/server.ts
+++ b/packages/toolpad-core/src/server.ts
@@ -8,7 +8,7 @@ import {
   PropValueType,
   ToolpadDataProviderBase,
 } from './types';
-import { ServerContext, __initContextStore, getServerContext } from './serverRuntime';
+import { ServerContext, getServerContext } from './serverRuntime';
 
 /**
  * The runtime configuration for a Toolpad function. Describes the parameters it accepts and their
@@ -143,5 +143,3 @@ export function createDataProvider<
 >(input: ToolpadDataProviderBase<R, P>): ToolpadDataProvider<R, P> {
   return Object.assign(input, { [TOOLPAD_DATA_PROVIDER_MARKER]: true as const });
 }
-
-export { __initContextStore };

--- a/packages/toolpad-core/src/serverRuntime.ts
+++ b/packages/toolpad-core/src/serverRuntime.ts
@@ -14,17 +14,7 @@ export interface ServerContext {
   setCookie: (name: string, value: string) => void;
 }
 
-let contextStore = new AsyncLocalStorage<ServerContext>();
-
-export const initialContextStore = contextStore;
-
-/**
- * INTERNAL: Do not use
- */
-// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
-export function __initContextStore(store: AsyncLocalStorage<ServerContext>) {
-  contextStore = store;
-}
+const contextStore = new AsyncLocalStorage<ServerContext>();
 
 export function getServerContext(): ServerContext | undefined {
   return contextStore.getStore();

--- a/packages/toolpad-core/tsup.config.ts
+++ b/packages/toolpad-core/tsup.config.ts
@@ -20,7 +20,7 @@ function cleanFolderOnFailure(folder: string): EsbuildPlugin {
 
 export default defineConfig({
   entry: ['src/*{.ts,.tsx}'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: false,
   silent: true,
   sourcemap: true,


### PR DESCRIPTION
Both of these packages rely on being deduplicated in the runtimes as they contain singletons and contexts that guarantee proper working. Having the two versions can only lead to broken code. We were already hacking around this problem for server context. This PR forces only one output for each of these to minimize these issues.
This could be a breaking change for server-side code