### PR TITLE
Fix editable tree item bugs

### DIFF
--- a/packages/toolpad-app/src/components/EditableTreeItem.tsx
+++ b/packages/toolpad-app/src/components/EditableTreeItem.tsx
@@ -12,7 +12,7 @@ import {
 
 export interface EditableTreeItemProps extends Omit<TreeItemProps, 'label'> {
   labelText?: string;
-  renderLabel?: (children: React.ReactNode, isEditing: boolean) => React.ReactNode;
+  renderLabel?: (children: React.ReactNode) => React.ReactNode;
   suggestedNewItemName?: string;
   isEditing?: boolean;
   onEdit?: (newItemName: string) => void | Promise<void>;
@@ -125,58 +125,53 @@ export default function EditableTreeItem({
     <TreeItem
       {...rest}
       onClick={handleClick}
-      label={
-        <React.Fragment>
-          {renderLabel(
-            isEditing ? (
-              <React.Fragment>
-                <InputBase
-                  {...inputProps}
-                  ref={inputRef}
-                  value={itemNameInput}
-                  onChange={handleChange}
-                  autoFocus
-                  onFocus={handleFocus}
-                  onBlur={handleBlur}
-                  onKeyDown={handleKeyDown}
-                  fullWidth
-                  sx={{
-                    ...(inputProps?.sx || {}),
-                    ...labelTextSx,
-                    padding: 0,
-                  }}
-                />
-                {inputErrorPopoverAnchorEl ? (
-                  <Popover
-                    open={!!validationErrorMessage}
-                    anchorEl={inputErrorPopoverAnchorEl}
-                    disableAutoFocus
-                    anchorOrigin={{
-                      vertical: 'bottom',
-                      horizontal: 'left',
-                    }}
-                  >
-                    {validationErrorMessage ? (
-                      <Alert severity="error" variant="outlined">
-                        {validationErrorMessage}
-                      </Alert>
-                    ) : null}
-                  </Popover>
-                ) : null}
-              </React.Fragment>
-            ) : (
-              <Typography
-                variant="body2"
-                sx={{ fontWeight: 'inherit', flexGrow: 1, ...labelTextSx }}
-                noWrap
+      label={renderLabel(
+        isEditing ? (
+          <React.Fragment>
+            <InputBase
+              {...inputProps}
+              ref={inputRef}
+              value={itemNameInput}
+              onChange={handleChange}
+              autoFocus
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              fullWidth
+              sx={{
+                ...(inputProps?.sx || {}),
+                ...labelTextSx,
+                padding: 0,
+              }}
+            />
+            {inputErrorPopoverAnchorEl ? (
+              <Popover
+                open={!!validationErrorMessage}
+                anchorEl={inputErrorPopoverAnchorEl}
+                disableAutoFocus
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                }}
               >
-                {labelText}
-              </Typography>
-            ),
-            isEditing,
-          )}
-        </React.Fragment>
-      }
+                {validationErrorMessage ? (
+                  <Alert severity="error" variant="outlined">
+                    {validationErrorMessage}
+                  </Alert>
+                ) : null}
+              </Popover>
+            ) : null}
+          </React.Fragment>
+        ) : (
+          <Typography
+            variant="body2"
+            sx={{ fontWeight: 'inherit', flexGrow: 1, ...labelTextSx }}
+            noWrap
+          >
+            {labelText}
+          </Typography>
+        ),
+      )}
       sx={
         isEditing
           ? {

--- a/packages/toolpad-app/src/components/EditableTreeItem.tsx
+++ b/packages/toolpad-app/src/components/EditableTreeItem.tsx
@@ -45,8 +45,6 @@ export default function EditableTreeItem({
   const [itemNameInput, setItemNameInput] = React.useState(suggestedNewItemName);
   const [isInternalEditing, setIsInternalEditing] = React.useState(false);
 
-  console.log(itemNameInput);
-
   const isEditing = isExternalEditing || isInternalEditing;
 
   const newItemValidationResult = React.useMemo(

--- a/packages/toolpad-app/src/components/EditableTreeItem.tsx
+++ b/packages/toolpad-app/src/components/EditableTreeItem.tsx
@@ -45,6 +45,8 @@ export default function EditableTreeItem({
   const [itemNameInput, setItemNameInput] = React.useState(suggestedNewItemName);
   const [isInternalEditing, setIsInternalEditing] = React.useState(false);
 
+  console.log(itemNameInput);
+
   const isEditing = isExternalEditing || isInternalEditing;
 
   const newItemValidationResult = React.useMemo(
@@ -81,10 +83,10 @@ export default function EditableTreeItem({
       handleCancel();
       return;
     }
+
     if (onEdit) {
       onEdit(itemNameInput);
     }
-    setItemNameInput('');
     setIsInternalEditing(false);
   }, [handleCancel, itemNameInput, newItemValidationResult.isValid, onEdit]);
 

--- a/packages/toolpad-app/src/components/EditableTreeItem.tsx
+++ b/packages/toolpad-app/src/components/EditableTreeItem.tsx
@@ -12,7 +12,7 @@ import {
 
 export interface EditableTreeItemProps extends Omit<TreeItemProps, 'label'> {
   labelText?: string;
-  renderLabel?: (children: React.ReactNode) => React.ReactNode;
+  renderLabel?: (children: React.ReactNode, isEditing: boolean) => React.ReactNode;
   suggestedNewItemName?: string;
   isEditing?: boolean;
   onEdit?: (newItemName: string) => void | Promise<void>;
@@ -125,53 +125,58 @@ export default function EditableTreeItem({
     <TreeItem
       {...rest}
       onClick={handleClick}
-      label={renderLabel(
-        isEditing ? (
-          <React.Fragment>
-            <InputBase
-              {...inputProps}
-              ref={inputRef}
-              value={itemNameInput}
-              onChange={handleChange}
-              autoFocus
-              onFocus={handleFocus}
-              onBlur={handleBlur}
-              onKeyDown={handleKeyDown}
-              fullWidth
-              sx={{
-                ...(inputProps?.sx || {}),
-                ...labelTextSx,
-                padding: 0,
-              }}
-            />
-            {inputErrorPopoverAnchorEl ? (
-              <Popover
-                open={!!validationErrorMessage}
-                anchorEl={inputErrorPopoverAnchorEl}
-                disableAutoFocus
-                anchorOrigin={{
-                  vertical: 'bottom',
-                  horizontal: 'left',
-                }}
-              >
-                {validationErrorMessage ? (
-                  <Alert severity="error" variant="outlined">
-                    {validationErrorMessage}
-                  </Alert>
+      label={
+        <React.Fragment>
+          {renderLabel(
+            isEditing ? (
+              <React.Fragment>
+                <InputBase
+                  {...inputProps}
+                  ref={inputRef}
+                  value={itemNameInput}
+                  onChange={handleChange}
+                  autoFocus
+                  onFocus={handleFocus}
+                  onBlur={handleBlur}
+                  onKeyDown={handleKeyDown}
+                  fullWidth
+                  sx={{
+                    ...(inputProps?.sx || {}),
+                    ...labelTextSx,
+                    padding: 0,
+                  }}
+                />
+                {inputErrorPopoverAnchorEl ? (
+                  <Popover
+                    open={!!validationErrorMessage}
+                    anchorEl={inputErrorPopoverAnchorEl}
+                    disableAutoFocus
+                    anchorOrigin={{
+                      vertical: 'bottom',
+                      horizontal: 'left',
+                    }}
+                  >
+                    {validationErrorMessage ? (
+                      <Alert severity="error" variant="outlined">
+                        {validationErrorMessage}
+                      </Alert>
+                    ) : null}
+                  </Popover>
                 ) : null}
-              </Popover>
-            ) : null}
-          </React.Fragment>
-        ) : (
-          <Typography
-            variant="body2"
-            sx={{ fontWeight: 'inherit', flexGrow: 1, ...labelTextSx }}
-            noWrap
-          >
-            {labelText}
-          </Typography>
-        ),
-      )}
+              </React.Fragment>
+            ) : (
+              <Typography
+                variant="body2"
+                sx={{ fontWeight: 'inherit', flexGrow: 1, ...labelTextSx }}
+                noWrap
+              >
+                {labelText}
+              </Typography>
+            ),
+            isEditing,
+          )}
+        </React.Fragment>
+      }
       sx={
         isEditing
           ? {

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled, Box, IconButton, Stack, Typography } from '@mui/material';
+import { styled, Box, IconButton, Stack, Tooltip } from '@mui/material';
 import { TreeView, treeItemClasses } from '@mui/x-tree-view';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
@@ -61,7 +61,6 @@ function PagesExplorerTreeItem(props: StyledTreeItemProps) {
     nodeId,
     labelIcon,
     labelText,
-    title,
     onRenameNode,
     onDeleteNode,
     onDuplicateNode,
@@ -70,6 +69,7 @@ function PagesExplorerTreeItem(props: StyledTreeItemProps) {
     duplicateLabelText = 'Duplicate',
     toolpadNodeId,
     validateItemName,
+    title,
     ...other
   } = props;
 
@@ -100,45 +100,35 @@ function PagesExplorerTreeItem(props: StyledTreeItemProps) {
       nodeId={nodeId}
       labelText={labelText}
       renderLabel={(children) => (
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          {labelIcon}
-          {children}
-          <Typography
-            variant="caption"
-            sx={{
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
-              maxWidth: '40%',
-              overflow: 'hidden',
-              marginLeft: '2px',
-            }}
-          >
-            {title}
-          </Typography>
-          {toolpadNodeId ? (
-            <NodeMenu
-              renderButton={({ buttonProps, menuProps }) => (
-                <IconButton
-                  className={clsx(classes.treeItemMenuButton, {
-                    [classes.treeItemMenuOpen]: menuProps.open,
-                  })}
-                  aria-label="Open page explorer menu"
-                  size="small"
-                  {...buttonProps}
-                >
-                  <MoreVertIcon fontSize="inherit" />
-                </IconButton>
-              )}
-              nodeId={toolpadNodeId}
-              renameLabelText={renameLabelText}
-              deleteLabelText={deleteLabelText}
-              duplicateLabelText={duplicateLabelText}
-              onRenameNode={startEditing}
-              onDeleteNode={onDeleteNode}
-              onDuplicateNode={onDuplicateNode}
-            />
-          ) : null}
-        </Box>
+        <Tooltip title={title} placement="right" disableInteractive>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            {labelIcon}
+            {children}
+            {toolpadNodeId ? (
+              <NodeMenu
+                renderButton={({ buttonProps, menuProps }) => (
+                  <IconButton
+                    className={clsx(classes.treeItemMenuButton, {
+                      [classes.treeItemMenuOpen]: menuProps.open,
+                    })}
+                    aria-label="Open page explorer menu"
+                    size="small"
+                    {...buttonProps}
+                  >
+                    <MoreVertIcon fontSize="inherit" />
+                  </IconButton>
+                )}
+                nodeId={toolpadNodeId}
+                renameLabelText={renameLabelText}
+                deleteLabelText={deleteLabelText}
+                duplicateLabelText={duplicateLabelText}
+                onRenameNode={startEditing}
+                onDeleteNode={onDeleteNode}
+                onDuplicateNode={onDuplicateNode}
+              />
+            ) : null}
+          </Box>
+        </Tooltip>
       )}
       suggestedNewItemName={labelText}
       onCancel={stopEditing}

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -61,6 +61,7 @@ function PagesExplorerTreeItem(props: StyledTreeItemProps) {
     nodeId,
     labelIcon,
     labelText,
+    title,
     onRenameNode,
     onDeleteNode,
     onDuplicateNode,
@@ -69,7 +70,6 @@ function PagesExplorerTreeItem(props: StyledTreeItemProps) {
     duplicateLabelText = 'Duplicate',
     toolpadNodeId,
     validateItemName,
-    title,
     ...other
   } = props;
 

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -278,7 +278,9 @@ export default function PagesExplorer({ className }: PagesExplorerProps) {
       if (nodeId === activePage?.id) {
         const siblings = appDom.getSiblings(dom, deletedNode);
         const firstSiblingOfType = siblings.find((sibling) => sibling.type === deletedNode.type);
-        domViewAfterDelete = firstSiblingOfType && getNodeEditorDomView(firstSiblingOfType);
+        domViewAfterDelete = firstSiblingOfType
+          ? getNodeEditorDomView(firstSiblingOfType)
+          : { kind: 'page' };
       }
 
       await projectApi.methods.deletePage(deletedNode.name);

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -110,6 +110,7 @@ function PagesExplorerTreeItem(props: StyledTreeItemProps) {
               textOverflow: 'ellipsis',
               maxWidth: '40%',
               overflow: 'hidden',
+              marginLeft: '2px',
             }}
           >
             {title}

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -10,7 +10,7 @@ import invariant from 'invariant';
 import { alphabeticComparator, createPropComparator } from '@mui/toolpad-utils/comparators';
 import useBoolean from '@mui/toolpad-utils/hooks/useBoolean';
 import * as appDom from '@mui/toolpad-core/appDom';
-import { useAppStateApi, useAppState, useDomApi } from '../../AppState';
+import { useAppStateApi, useAppState } from '../../AppState';
 import useLocalStorageState from '../../../utils/useLocalStorageState';
 import NodeMenu from '../NodeMenu';
 import { DomView } from '../../../utils/domView';

--- a/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PagesExplorer/index.tsx
@@ -291,17 +291,12 @@ export default function PagesExplorer({ className }: PagesExplorerProps) {
 
   const handleRenameNode = React.useCallback(
     (nodeId: NodeId, updatedName: string) => {
-      domApi.setNodeName(nodeId, updatedName);
-      appStateApi.setView({ kind: 'page', name: updatedName });
-
-      const oldNameNode = dom.nodes[nodeId];
-      if (oldNameNode.type === 'page' && updatedName !== oldNameNode.name) {
-        setTimeout(async () => {
-          await projectApi.methods.deletePage(oldNameNode.name);
-        }, 300);
-      }
+      domApi.update((draft) => {
+        const page = appDom.getNode(draft, nodeId, 'page');
+        return appDom.setNodeNamespacedProp(draft, page, 'attributes', 'displayName', updatedName);
+      });
     },
-    [projectApi, dom.nodes, domApi, appStateApi],
+    [domApi],
   );
 
   const handleDuplicateNode = React.useCallback(
@@ -373,7 +368,6 @@ export default function PagesExplorer({ className }: PagesExplorerProps) {
             onRenameNode={handleRenameNode}
             onDuplicateNode={handleDuplicateNode}
             onDeleteNode={handleDeletePage}
-            validateItemName={validatePageName}
           />
         ))}
       </TreeView>

--- a/test/integration/duplication/index.spec.ts
+++ b/test/integration/duplication/index.spec.ts
@@ -19,7 +19,7 @@ test('duplication', async ({ page }) => {
   await editorModel.goto();
 
   {
-    await editorModel.openPageExplorerMenu('Page 1');
+    await editorModel.openPageExplorerMenu('page1');
     const duplicateMenuItem = page.getByRole('menuitem', { name: 'Duplicate' });
     await duplicateMenuItem.click();
 
@@ -28,12 +28,12 @@ test('duplication', async ({ page }) => {
     const button = editorModel.appCanvas.getByRole('button', { name: 'hello world' });
     await expect(button).toBeVisible();
 
-    await editorModel.openPageExplorerMenu('Page 2');
+    await editorModel.openPageExplorerMenu('page2');
     const deleteMenuItem = page.getByRole('menuitem', { name: 'Delete' });
     await deleteMenuItem.click();
     const deleteButton = editorModel.confirmationDialog.getByRole('button', { name: 'Delete' });
     await deleteButton.click();
 
-    await expect(editorModel.getExplorerItem('Page 2')).toBeHidden();
+    await expect(editorModel.getExplorerItem('page2')).toBeHidden();
   }
 });

--- a/test/integration/editor/new.spec.ts
+++ b/test/integration/editor/new.spec.ts
@@ -87,7 +87,7 @@ test('can create/delete page', async ({ page, localApp }) => {
   // Delete current page
 
   const currentPageMenuItem = editorModel.getExplorerItem('andOneMorePage');
-  const pageFolder = path.resolve(localApp.dir, './toolpad/pages/someOtherPage');
+  const pageFolder = path.resolve(localApp.dir, './toolpad/pages/andOneMorePage');
   const pageFile = path.resolve(pageFolder, './page.yml');
 
   await expect(currentPageMenuItem).toBeVisible();

--- a/test/integration/editor/new.spec.ts
+++ b/test/integration/editor/new.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import invariant from 'invariant';
 import { fileExists, folderExists } from '@mui/toolpad-utils/fs';
-import { test, expect } from '../../playwright/localTest';
+import { test, expect, Locator } from '../../playwright/localTest';
 import { ToolpadEditor } from '../../models/ToolpadEditor';
 
 test.use({
@@ -63,27 +63,39 @@ test('can create/delete page', async ({ page, localApp }) => {
   await editorModel.goto();
 
   await editorModel.createPage('someOtherPage');
+  await editorModel.createPage('andOneMorePage');
 
-  const pageMenuItem = editorModel.getExplorerItem('Some Other Page');
+  const deletePageFromExplorer = async (pageMenuItem: Locator) => {
+    await pageMenuItem.hover();
+
+    await pageMenuItem.getByRole('button', { name: 'Open page explorer menu' }).click();
+
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+
+    await page
+      .getByRole('dialog', { name: 'Confirm' })
+      .getByRole('button', { name: 'Delete' })
+      .click();
+  };
+
+  // Delete another page
+
+  const anotherPageMenuItem = editorModel.getExplorerItem('someOtherPage');
+  await deletePageFromExplorer(anotherPageMenuItem);
+  await expect(anotherPageMenuItem).toBeHidden();
+
+  // Delete current page
+
+  const currentPageMenuItem = editorModel.getExplorerItem('andOneMorePage');
   const pageFolder = path.resolve(localApp.dir, './toolpad/pages/someOtherPage');
   const pageFile = path.resolve(pageFolder, './page.yml');
 
-  await expect(pageMenuItem).toBeVisible();
+  await expect(currentPageMenuItem).toBeVisible();
   await expect.poll(async () => folderExists(pageFolder)).toBe(true);
   await expect.poll(async () => fileExists(pageFile)).toBe(true);
 
-  await pageMenuItem.hover();
-
-  await pageMenuItem.getByRole('button', { name: 'Open page explorer menu' }).click();
-
-  await page.getByRole('menuitem', { name: 'Delete' }).click();
-
-  await page
-    .getByRole('dialog', { name: 'Confirm' })
-    .getByRole('button', { name: 'Delete' })
-    .click();
-
-  await expect(pageMenuItem).toBeHidden();
+  await deletePageFromExplorer(currentPageMenuItem);
+  await expect(currentPageMenuItem).toBeHidden();
 
   await expect.poll(async () => folderExists(pageFolder)).toBe(false);
 });

--- a/test/integration/pages/index.spec.ts
+++ b/test/integration/pages/index.spec.ts
@@ -56,7 +56,7 @@ test('can rename page', async ({ page, localApp }) => {
   const oldPageFolder = path.resolve(localApp.dir, './toolpad/pages/page2');
   await expect.poll(async () => folderExists(oldPageFolder)).toBe(true);
 
-  await editorModel.explorer.getByText('Page 2').dblclick();
+  await editorModel.explorer.getByText('page2').dblclick();
   await page.keyboard.type('renamedpage');
   await page.keyboard.press('Enter');
 

--- a/test/integration/undo-redo/multiple-pages.spec.ts
+++ b/test/integration/undo-redo/multiple-pages.spec.ts
@@ -25,7 +25,7 @@ test('test undo and redo through different pages', async ({ page }) => {
   });
   await expect(pageButton1).toBeVisible();
 
-  await editorModel.explorer.getByText('Page 2').click();
+  await editorModel.explorer.getByText('page2').click();
 
   const pageButton2 = editorModel.appCanvas.getByRole('button', {
     name: 'page2Button',


### PR DESCRIPTION
Fix some bugs seen in editable tree items:

- In pages explorer, since the items were changed to show page display names instead of node names, the renaming feature was confusing and could even cause pages to be deleted unintentionally. Fix: Changed the renaming to update display name instead of node name.
- In page hierarchy explorer, somehow clicking near the outside of an item triggered a blur event that cleared the editable input. Fix: I removed a state update to the value of this input that didn't seem like it was doing anything.
- When deleting a page that is not the active page from the explorer, Toolpad changed to an empty app screen.

**Before:**

https://github.com/mui/mui-toolpad/assets/10789765/c9071693-1158-460b-8827-18282908496b

**After:**

https://github.com/mui/mui-toolpad/assets/10789765/ef648dc0-29aa-458e-a6cd-6393fa6d5ab9


