### PR TITLE
Fix project loading several times

### DIFF
--- a/packages/toolpad-app/src/project.tsx
+++ b/packages/toolpad-app/src/project.tsx
@@ -84,18 +84,21 @@ export function ProjectProvider({ url, children }: ProjectProps) {
 
   const queryClient = useQueryClient();
 
-  const project = React.useMemo(
-    () => createProject(url, manifest, queryClient),
-    [url, manifest, queryClient],
-  );
+  const [project, setProject] = React.useState<Project | undefined>();
 
   React.useEffect(() => {
+    const newProject = createProject(url, manifest, queryClient);
+    setProject(newProject);
     return () => {
-      project.dispose();
+      newProject.dispose();
     };
-  }, [project]);
+  }, [url, manifest, queryClient]);
 
-  return <ProjectContext.Provider value={project}>{children}</ProjectContext.Provider>;
+  return (
+    <ProjectContext.Provider value={project}>
+      {project ? children : 'loading'}
+    </ProjectContext.Provider>
+  );
 }
 
 export function useProject() {

--- a/packages/toolpad-app/src/project.tsx
+++ b/packages/toolpad-app/src/project.tsx
@@ -51,7 +51,13 @@ function createProject(url: string, serializedManifest: string, queryClient: Que
   });
 
   const dispose = () => {
-    ws.close();
+    if (ws.readyState === ws.OPEN) {
+      ws.close();
+    } else {
+      ws.onopen = () => {
+        ws.close();
+      };
+    }
     unsubExternalChange();
     unsubFunctionsChanged();
   };

--- a/packages/toolpad-app/src/project.tsx
+++ b/packages/toolpad-app/src/project.tsx
@@ -69,12 +69,13 @@ type Project = Awaited<ReturnType<typeof createProject>>;
 
 const ProjectContext = React.createContext<Project | undefined>(undefined);
 
-export interface ProjectProps {
+export interface ProjectProviderProps {
   url: string;
   children: React.ReactNode;
+  fallback: React.ReactNode;
 }
 
-export function ProjectProvider({ url, children }: ProjectProps) {
+export function ProjectProvider({ url, children, fallback }: ProjectProviderProps) {
   const { data: manifest } = useSuspenseQuery({
     queryKey: ['app-dev-manifest', url],
     queryFn: () => fetchAppDevManifest(url),
@@ -96,7 +97,7 @@ export function ProjectProvider({ url, children }: ProjectProps) {
 
   return (
     <ProjectContext.Provider value={project}>
-      {project ? children : 'loading'}
+      {project ? children : fallback}
     </ProjectContext.Provider>
   );
 }

--- a/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHostInline.tsx
+++ b/packages/toolpad-app/src/toolpad/AppEditor/PageEditor/EditorCanvasHostInline.tsx
@@ -172,7 +172,7 @@ export default function EditorCanvasHost({
       );
 
       projectEventSubscriptionRef.current = project.events.subscribe('queriesInvalidated', () => {
-        bridge.canvasCommands.invalidateQueries();
+        queryClient.invalidateQueries();
       });
 
       const mutationObserver = new MutationObserver(handleScreenUpdate);

--- a/packages/toolpad-app/src/toolpad/Toolpad.tsx
+++ b/packages/toolpad-app/src/toolpad/Toolpad.tsx
@@ -160,7 +160,7 @@ function ToolpadEditorContent({ appUrl }: ToolpadEditorContentProps) {
         <ErrorBoundary fallbackRender={ErrorFallback}>
           <React.Suspense fallback={<FullPageLoader />}>
             <QueryClientProvider client={queryClient}>
-              <ProjectProvider url={appUrl}>
+              <ProjectProvider url={appUrl} fallback={<FullPageLoader />}>
                 <AppProvider appUrl={appUrl}>
                   <EditorShell>
                     <Routes>


### PR DESCRIPTION
The editor project is loading several times due to suspense. This leads to event handlers created multiple times. This change creates the project in an effect instead.

Fix needed for EXPERIMENTAL_INLINE_CANVAS