### PR TITLE
Fix test for code components under new editor runtime

### DIFF
--- a/test/integration/codeComponents/index.spec.ts
+++ b/test/integration/codeComponents/index.spec.ts
@@ -35,7 +35,7 @@ test('can create new custom components', async ({ page, localApp }) => {
 
   await editorModel.goto();
 
-  await editorModel.pageRoot.waitFor();
+  await editorModel.waitForOverlay();
 
   const newComponentPath = path.resolve(localApp.dir, './toolpad/components/MyInspector.tsx');
   await fs.writeFile(
@@ -60,6 +60,13 @@ export default createComponent(MyInspector, {
     `,
     { encoding: 'utf-8' },
   );
+
+  if (process.env.EXPERIMENTAL_INLINE_CANVAS) {
+    // vite causes a reload when we're creating new custom components
+    // See https://github.com/vitejs/vite/issues/12912
+    await page.locator('[data-testid="page-ready-marker"]').isHidden();
+    await editorModel.waitForOverlay();
+  }
 
   await editorModel.componentCatalog.hover();
   await expect(editorModel.getComponentCatalogItem('MyInspector')).toBeVisible();

--- a/test/models/ToolpadRuntime.ts
+++ b/test/models/ToolpadRuntime.ts
@@ -29,7 +29,6 @@ export class ToolpadRuntime {
   }
 
   async waitForPageReady() {
-    await this.page.waitForTimeout(1000);
     await this.page.waitForSelector('[data-testid="page-ready-marker"]', {
       state: 'attached',
     });


### PR DESCRIPTION
The new editor that runs side by side with the app runtime now reloads when a component is added. This is caused by https://github.com/vitejs/vite/issues/12912. Before only the app runtime reloaded, but now the editor and app are one single react tree. This PR teaches the tests to anticipate this reload.

I suppose we can live with this for now, the whole editor became more responsive at the cost of a single reload whenc reating a new component. The ways to fix it are either
* fix https://github.com/vitejs/vite/issues/12912
* change Toolpad custom components to require a barrel file that collects all of them so that Toolpad doesn't have to create a virtual module to import them. We will likely require you to do this in Next.js.