### PR TITLE
Add documentation about installing Toolpad in an existing project

### DIFF
--- a/docs/data/toolpad/concepts/custom-server.md
+++ b/docs/data/toolpad/concepts/custom-server.md
@@ -2,6 +2,10 @@
 
 <p class="description">Run Toolpad applications programmatically in existing node.js servers.</p>
 
+:::warning
+We're working on an improved integration method. You'll be able to run Toolpad applications as React server components. If this interests you, please upvote the [feature request](https://github.com/mui/mui-toolpad/issues/3012).
+:::
+
 The Toolpad `dev` command comes with its own built-in server. However, sometimes you'd want more control over the way Toolpad applications are hosted within your application. The Toolpad custom server integration API allows you to run a Toolpad application programmatically within an existing node.js server.
 
 :::info

--- a/docs/data/toolpad/getting-started/installation.md
+++ b/docs/data/toolpad/getting-started/installation.md
@@ -104,6 +104,8 @@ pnpm run toolpad:dev
 
 </codeblock>
 
+When you run this command, Toolpad will automatically initialize a new application in the **./my-toolpad-app** folder.
+
 :::info
-To integrate Toolpad in an existing server, you can follow the custom server [integration guide](/toolpad/concepts/custom-server/).
+To integrate a Toolpad application in an existing server, you can follow the custom server [integration guide](/toolpad/concepts/custom-server/).
 :::

--- a/docs/data/toolpad/getting-started/installation.md
+++ b/docs/data/toolpad/getting-started/installation.md
@@ -52,3 +52,58 @@ pnpm run dev
 </codeblock>
 
 This starts the development server on port `3000` or the first available port after that and opens the browser to the Toolpad editor.
+
+## Install Toolpad in an existing project
+
+Start by installing the required dependencies:
+
+<codeblock storageKey="package-manager">
+
+```bash npm
+pnpm install -S @mui/toolpad
+```
+
+```bash yarn
+yarn add @mui/toolpad
+```
+
+```bash pnpm
+pnpm add @mui/toolpad
+```
+
+</codeblock>
+
+Then you'll have to add the toolpad scripts to yur `package.json`:
+
+```json
+// ./package.json
+...
+  "scripts": {
+    "toolpad:dev": "toolpad dev ./my-toolpad-app",
+    "toolpad:build": "toolpad build ./my-toolpad-app",
+    "toolpad:start": "toolpad start ./my-toolpad-app"
+  }
+...
+```
+
+Now you can start your toolpad application using one of the commands:
+
+<codeblock storageKey="package-manager">
+
+```bash npm
+npm run toolpad:dev
+```
+
+```bash yarn
+yarn toolpad:dev
+```
+
+```bash pnpm
+pnpm run toolpad:dev
+```
+
+</codeblock>
+
+:::info
+To integrate Toolpad in an existing server, you can follow the custom server [integration guide](/toolpad/concepts/custom-server/).
+:::


### PR DESCRIPTION
Closes https://github.com/mui/mui-toolpad/issues/3180

https://deploy-preview-3214--mui-toolpad-docs.netlify.app/toolpad/getting-started/installation/#install-toolpad-in-an-existing-project