### PR TITLE
Image error overlay fixes

### DIFF
--- a/packages/toolpad-components/src/components/ErrorOverlay.tsx
+++ b/packages/toolpad-components/src/components/ErrorOverlay.tsx
@@ -1,4 +1,4 @@
-import { SxProps, Typography, styled } from '@mui/material';
+import { SxProps, Typography, styled, Tooltip } from '@mui/material';
 import * as React from 'react';
 import { errorFrom } from '@mui/toolpad-utils/errors';
 import ErrorIcon from '@mui/icons-material/Error';
@@ -9,6 +9,9 @@ const OverlayRoot = styled('div')(({ theme }) => ({
   alignItems: 'center',
   justifyContent: 'center',
   padding: theme.spacing(2),
+  maxWidth: '100%',
+  maxHeight: '100%',
+  overflow: 'hidden',
 }));
 
 interface ErrorContentProps {
@@ -24,7 +27,11 @@ export function ErrorContent({ sx, error }: ErrorContentProps) {
         <ErrorIcon fontSize="small" color="error" />
         Error
       </Typography>
-      <Typography variant="body2">{errMessage}</Typography>
+      <Tooltip title={errMessage}>
+        <Typography variant="body2" align="center">
+          {errMessage}
+        </Typography>
+      </Tooltip>
     </OverlayRoot>
   );
 }

--- a/test/visual/components/fixture/toolpad/pages/components/page.yml
+++ b/test/visual/components/fixture/toolpad/pages/components/page.yml
@@ -117,5 +117,12 @@ spec:
       props:
         mode: switch
         label: Switch
+    - component: Image
+      name: image1
+      props:
+        width: 100
+        height: 100
+        src:
+          $$jsExpression: veryLongIdentifierThatResultsInLongErrorMessage.nonExisting
   alias:
     - f703ps3


### PR DESCRIPTION
Fix some overflow errors, make sure the text doesn't overflow outside of the image area, add a tooltip for when it does