### PR TITLE
[DataGrid] fix errors not showing up in the rows area

### DIFF
--- a/packages/toolpad-components/src/DataGrid.tsx
+++ b/packages/toolpad-components/src/DataGrid.tsx
@@ -1294,7 +1294,6 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
               {...dataProviderProps}
               sx={{
                 height: '100%',
-                visibility: errorProp ? 'hidden' : 'visible',
               }}
             />
           </SetActionResultContext.Provider>

--- a/test/visual/components/fixture/toolpad/pages/components/page.yml
+++ b/test/visual/components/fixture/toolpad/pages/components/page.yml
@@ -124,5 +124,12 @@ spec:
         height: 100
         src:
           $$jsExpression: veryLongIdentifierThatResultsInLongErrorMessage.nonExisting
+    - component: DataGrid
+      name: dataGrid2
+      layout:
+        height: 160
+      props:
+        rows:
+          $$jsExpression: nonExisting
   alias:
     - f703ps3


### PR DESCRIPTION
This used to be an overlay, but we've hijacked the NoRowsOverlay for this, so we need to make the grid visible

adding a vrt in https://app.argos-ci.com/mui/mui-toolpad/builds/2684/79662068