### PR TITLE
[website] Add star count fallback

### DIFF
--- a/docs/src/components/landing/GithubStars.js
+++ b/docs/src/components/landing/GithubStars.js
@@ -15,13 +15,12 @@ export default function GithubStars() {
   const fetchStars = React.useCallback(async () => {
     setFetching(true);
     const response = await fetch('https://api.github.com/repos/mui/mui-toolpad');
-    const data = await response.json();    
+    const data = await response.json();
     setFetching(false);
     if (typeof window !== 'undefined') {
-      localStorage.setItem('mui-toolpad-stars', `${Date.now()}_${data.stargazers_count}`);          
+      localStorage.setItem('mui-toolpad-stars', `${Date.now()}_${data.stargazers_count}`);
     }
     setStars(data.stargazers_count ?? FALLBACK_STAR_COUNT);
-    
   }, []);
 
   React.useEffect(() => {

--- a/docs/src/components/landing/GithubStars.js
+++ b/docs/src/components/landing/GithubStars.js
@@ -7,6 +7,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import ROUTES from '../../route';
 
 export default function GithubStars() {
+  const FALLBACK_STAR_COUNT = 700;
   const [fetching, setFetching] = React.useState(true);
   const [stars, setStars] = React.useState(0);
   const theme = useTheme();
@@ -15,11 +16,15 @@ export default function GithubStars() {
     setFetching(true);
     const response = await fetch('https://api.github.com/repos/mui/mui-toolpad');
     const data = await response.json();
+    console.log(data)
     setFetching(false);
-    if (typeof window !== 'undefined') {
+    if (typeof window !== 'undefined' && data.stargazers_count) {
       localStorage.setItem('mui-toolpad-stars', `${Date.now()}_${data.stargazers_count}`);
+      setStars(data.stargazers_count);
     }
-    setStars(data.stargazers_count);
+    else {
+      setStars(FALLBACK_STAR_COUNT);
+    }
   }, []);
 
   React.useEffect(() => {

--- a/docs/src/components/landing/GithubStars.js
+++ b/docs/src/components/landing/GithubStars.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import ROUTES from '../../route';
@@ -74,7 +75,7 @@ export default function GithubStars() {
           sx={{ mt: stars ? 0.1 : 0, mr: stars ? 0.5 : 0 }}
           fontSize="small"
         />
-        {fetching ? '...' : stars}
+        {fetching ? <CircularProgress size={16} sx={{ ml: 0.25, mt: 0.1 }} /> : stars}
       </Box>
     </Button>
   );

--- a/docs/src/components/landing/GithubStars.js
+++ b/docs/src/components/landing/GithubStars.js
@@ -15,8 +15,7 @@ export default function GithubStars() {
   const fetchStars = React.useCallback(async () => {
     setFetching(true);
     const response = await fetch('https://api.github.com/repos/mui/mui-toolpad');
-    const data = await response.json();
-    console.log(data)
+    const data = await response.json();    
     setFetching(false);
     if (typeof window !== 'undefined') {
       localStorage.setItem('mui-toolpad-stars', `${Date.now()}_${data.stargazers_count}`);          

--- a/docs/src/components/landing/GithubStars.js
+++ b/docs/src/components/landing/GithubStars.js
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import StarRateRoundedIcon from '@mui/icons-material/StarRateRounded';
+import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import ROUTES from '../../route';
 
 export default function GithubStars() {
-  const FALLBACK_STAR_COUNT = 700;
   const [fetching, setFetching] = React.useState(true);
   const [stars, setStars] = React.useState(0);
   const theme = useTheme();
@@ -17,16 +16,19 @@ export default function GithubStars() {
     const response = await fetch('https://api.github.com/repos/mui/mui-toolpad');
     const data = await response.json();
     setFetching(false);
-    if (typeof window !== 'undefined') {
+    if (response.status !== 200) {
+      console.error('Failed to fetch stars count', data);
+    }
+    if (typeof window !== 'undefined' && data.stargazers_count) {
       localStorage.setItem('mui-toolpad-stars', `${Date.now()}_${data.stargazers_count}`);
     }
-    setStars(data.stargazers_count ?? FALLBACK_STAR_COUNT);
+    setStars(data.stargazers_count ?? '');
   }, []);
 
   React.useEffect(() => {
     const cached = localStorage.getItem('mui-toolpad-stars');
-    if (cached && Date.now() - parseFloat(cached.split('_')[0]) < 1000 * 60 * 60) {
-      setStars(parseFloat(cached.split('_')[1]));
+    if (cached && Date.now() - parseFloat(cached.split('_')?.[0]) < 1000 * 60 * 60) {
+      setStars(cached.split('_')?.[1] ? parseFloat(cached.split('_')?.[1]) : '');
       setFetching(false);
     } else {
       fetchStars();
@@ -56,7 +58,7 @@ export default function GithubStars() {
       }}
       startIcon={<GitHubIcon />}
     >
-      Stars
+      Star
       <Box
         sx={{
           display: 'flex',
@@ -68,7 +70,10 @@ export default function GithubStars() {
           }),
         }}
       >
-        <StarRateRoundedIcon fontSize="small" />
+        <StarBorderOutlinedIcon
+          sx={{ mt: stars ? 0.1 : 0, mr: stars ? 0.5 : 0 }}
+          fontSize="small"
+        />
         {fetching ? '...' : stars}
       </Box>
     </Button>

--- a/docs/src/components/landing/GithubStars.js
+++ b/docs/src/components/landing/GithubStars.js
@@ -18,13 +18,11 @@ export default function GithubStars() {
     const data = await response.json();
     console.log(data)
     setFetching(false);
-    if (typeof window !== 'undefined' && data.stargazers_count) {
-      localStorage.setItem('mui-toolpad-stars', `${Date.now()}_${data.stargazers_count}`);
-      setStars(data.stargazers_count);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('mui-toolpad-stars', `${Date.now()}_${data.stargazers_count}`);          
     }
-    else {
-      setStars(FALLBACK_STAR_COUNT);
-    }
+    setStars(data.stargazers_count ?? FALLBACK_STAR_COUNT);
+    
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
- Seeing this on the landing page <img width="593" alt="Screenshot 2024-03-06 at 2 48 40 PM" src="https://github.com/mui/mui-toolpad/assets/19550456/57b98f56-d1fd-4230-b5fb-9813a9706ca7">

- With a rate limiting API error being the reason for it:

```json
{
    "message": "API rate limit exceeded for 49.228.103.47. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
    "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"    
}
```

- Tweak the Button UI to make the star count optional (empty if an error occurs):
<img width="602" alt="Screenshot 2024-03-07 at 10 26 38 PM" src="https://github.com/mui/mui-toolpad/assets/19550456/fb8fe29b-abe8-4c38-b96e-f0ad5512cd1c">

- Prevent a NaN on the star count

- Log to console and do not cache in case of error


Live: https://deploy-preview-3278--mui-toolpad-docs.netlify.app/toolpad/