### PR TITLE
Fix flaky authentication test: Wait for network idle in tests again

### DIFF
--- a/test/integration/auth/domain.spec.ts
+++ b/test/integration/auth/domain.spec.ts
@@ -60,8 +60,8 @@ test('Must be authenticated with valid domain to access app', async ({ page, req
 
   await page.waitForURL(/\/prod\/signin/);
 
-  // Wait for page content to render so that next CSRF request does not collide with ongoing auth requests
-  await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+  // Must wait for network to be idle or next CSRF request fails with "Failed to fetch", somehow due to the ongoing requests
+  await page.waitForLoadState('networkidle');
 
   // Is redirected when unauthenticated
   await page.goto('/prod/pages/mypage');


### PR DESCRIPTION
Last flaky test fix attempt with waiting for elements to render did not work in 100% of cases, seems like we really need to wait for network idle. Reverting back to that fix.
