### PR TITLE
[core] Lower the frequency of no-response action runs

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -8,8 +8,8 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # Schedule for 6am and 6pm UTC
+    - cron: '0 6,18 * * *'
 
 permissions: {}
 

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -8,7 +8,9 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # Schedule for 6am and 6pm UTC
+    # These runs in our repos are spread evenly throughout the day to avoid hitting rate limits.
+    # If you change this schedule, consider changing the remaining repositories as well.
+    # Runs at 6 am, 6 pm
     - cron: '0 6,18 * * *'
 
 permissions: {}


### PR DESCRIPTION
Change the frequency of the no-response action runs to 2 per day.

The action runs on the following schedule:

- Material UI: 12 am, 12 pm
- MUI X: 3 am, 3 pm
- Toolpad: 6 am, 6 pm
- Base UI: 9 am, 9 pm