### PR TITLE
Fix typo : use npm instead of pnpm in instruction

### DIFF
--- a/docs/data/toolpad/studio/getting-started/installation.md
+++ b/docs/data/toolpad/studio/getting-started/installation.md
@@ -60,7 +60,7 @@ Start by installing the required dependencies:
 <codeblock storageKey="package-manager">
 
 ```bash npm
-pnpm install -S @toolpad/studio
+npm install -S @toolpad/studio
 ```
 
 ```bash yarn


### PR DESCRIPTION
The tab is selected for `npm` but the command is being shown is for `pnpm`

![image](https://github.com/mui/mui-toolpad/assets/29161993/63095f70-db06-4b9d-b4ab-f0f70b7718ae)


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I've read and followed the [contributing guide](https://github.com/mui/mui-toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [ ] I've updated the relevant documentation for any new or updated feature.
- [ ] I've linked relevant GitHub issue with "Closes #<issue id>".
- [x] I've added a visual demonstration in the form of a screenshot or video.
