### PR TITLE
Remove fallback modules

### DIFF
--- a/docs/data/toolpad/studio/concepts/custom-components.md
+++ b/docs/data/toolpad/studio/concepts/custom-components.md
@@ -26,7 +26,6 @@ Toolpad Studio exposes a [`createComponent`](https://mui.com/toolpad/studio/refe
 
 ```jsx
 import * as React from 'react';
-import { Typography } from '@mui/material';
 import { createComponent } from '@toolpad/studio/browser';
 
 export interface HelloWorldProps {
@@ -34,7 +33,7 @@ export interface HelloWorldProps {
 }
 
 function HelloWorld({ msg }: HelloWorldProps) {
-  return <Typography>{msg}</Typography>;
+  return <div>{msg}</div>;
 }
 
 export default createComponent(HelloWorld, {

--- a/packages/toolpad-studio/src/server/localMode.ts
+++ b/packages/toolpad-studio/src/server/localMode.ts
@@ -233,7 +233,6 @@ async function createDefaultCodeComponent(name: string, filePath: string): Promi
   const result = await format(
     `
   import * as React from 'react';
-  import { Typography } from '@mui/material';
   import { createComponent } from '@toolpad/studio/browser';
   
   export interface ${propTypeId} {
@@ -242,7 +241,7 @@ async function createDefaultCodeComponent(name: string, filePath: string): Promi
   
   function ${componentId}({ msg }: ${propTypeId}) {
     return (
-      <Typography>{msg}</Typography>
+      <div>{msg}</div>
     );
   }
 

--- a/packages/toolpad-studio/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-studio/src/server/toolpadAppBuilder.ts
@@ -20,12 +20,6 @@ const TOOLPAD_BUILD = process.env.GIT_SHA1?.slice(0, 7) || 'dev';
 
 const MAIN_ENTRY = '/main.tsx';
 const EDITOR_ENTRY = '/editor.tsx';
-const FALLBACK_MODULES = [
-  '@mui/material',
-  '@mui/icons-material',
-  '@mui/x-data-grid',
-  '@mui/x-charts',
-];
 
 function getHtmlContent(entry: string) {
   return `
@@ -62,19 +56,9 @@ function toolpadStudioVitePlugin(): Plugin {
   return {
     name: 'toolpad-studio',
 
-    async resolveId(id, parent) {
+    async resolveId(id) {
       if (id.endsWith('.html')) {
         return id;
-      }
-      const hasFallback = FALLBACK_MODULES.some(
-        (moduleName) => moduleName === id || id.startsWith(`${moduleName}/`),
-      );
-      if (hasFallback) {
-        const [userMod, fallbackMod] = await Promise.all([
-          this.resolve(id, parent),
-          this.resolve(id, currentDirectory),
-        ]);
-        return userMod || fallbackMod;
       }
       return null;
     },
@@ -314,7 +298,6 @@ if (import.meta.hot) {
       },
       envFile: false,
       resolve: {
-        dedupe: FALLBACK_MODULES,
         alias: [
           {
             // FIXME(https://github.com/mui/material-ui/issues/35233)
@@ -364,7 +347,6 @@ if (import.meta.hot) {
       optimizeDeps: {
         force: !process.env.EXPERIMENTAL_INLINE_CANVAS && toolpadDevMode ? true : undefined,
         include: [
-          ...FALLBACK_MODULES.map((moduleName) => `@toolpad/studio > ${moduleName}`),
           ...(process.env.EXPERIMENTAL_INLINE_CANVAS && dev
             ? [
                 'perf-cascade',


### PR DESCRIPTION
This prevents users from installing `@mui/x-data-grid-pro@7` for custom components.

We'll avoid fallback modules altogether and users will have to explicitly install all dependencies they use in custom components. We'll change to default custom component to not use `@mui/material-ui`