### PR TITLE
Fix screenshot flakeyness

### DIFF
--- a/test/integration/rest-basic/index.spec.ts
+++ b/test/integration/rest-basic/index.spec.ts
@@ -79,7 +79,6 @@ test('rest editor basics', async ({ page, context, localApp, argosScreenshot }) 
   await expect(queryEditor).toBeVisible();
 
   const urlInput = queryEditor.getByLabel('url', { exact: true });
-  await urlInput.click();
   await urlInput.fill('http://foo.bar');
 
   await argosScreenshot('rest-editor', {


### PR DESCRIPTION
No sure why but removing the click seems to solve the flakeyness of the query editor