### PR TITLE
[core] Remove engine please-use-pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "zod-to-json-schema": "3.22.5"
   },
   "engines": {
-    "npm": "please-use-pnpm",
     "node": ">=18",
     "pnpm": "8.15.6"
   },


### PR DESCRIPTION
This seems to duplicate with:
https://github.com/mui/mui-toolpad/blob/d21b49eeae89228cccf316aa578c13f4fe24208a/package.json#L12 but only catch npm, not yarn, seems better to remove this, it will match with the other repositories too.