### PR TITLE
Revert monorepo update

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,7 @@
     "@mui/lab": "5.0.0-alpha.170",
     "@mui/material": "5.15.15",
     "@mui/material-nextjs": "^5.15.11",
-    "@mui/monorepo": "github:mui/material-ui#9ef12dc81c54566eeceae16bcf026a75fbce504d",
+    "@mui/monorepo": "github:mui/material-ui#f3cb496c999acbc8f19533e38df20be12e56d059",
     "@mui/styles": "5.15.15",
     "@mui/utils": "5.15.14",
     "@mui/x-license": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@argos-ci/core": "1.5.5",
-    "@mui/monorepo": "github:mui/material-ui#9ef12dc81c54566eeceae16bcf026a75fbce504d",
+    "@mui/monorepo": "github:mui/material-ui#f3cb496c999acbc8f19533e38df20be12e56d059",
     "@mui/x-charts": "7.2.0",
     "@next/eslint-plugin-next": "14.2.1",
     "@playwright/test": "1.43.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: 1.5.5
         version: 1.5.5
       '@mui/monorepo':
-        specifier: github:mui/material-ui#9ef12dc81c54566eeceae16bcf026a75fbce504d
-        version: github.com/mui/material-ui/9ef12dc81c54566eeceae16bcf026a75fbce504d
+        specifier: github:mui/material-ui#f3cb496c999acbc8f19533e38df20be12e56d059
+        version: github.com/mui/material-ui/f3cb496c999acbc8f19533e38df20be12e56d059
       '@mui/x-charts':
         specifier: 7.2.0
         version: 7.2.0(@mui/material@5.15.15)(react-dom@18.2.0)(react@18.2.0)
@@ -235,8 +235,8 @@ importers:
         specifier: ^5.15.11
         version: 5.15.11(@emotion/cache@11.11.0)(@emotion/server@11.11.0)(@mui/material@5.15.15)(next@14.2.1)(react@18.2.0)
       '@mui/monorepo':
-        specifier: github:mui/material-ui#9ef12dc81c54566eeceae16bcf026a75fbce504d
-        version: github.com/mui/material-ui/9ef12dc81c54566eeceae16bcf026a75fbce504d
+        specifier: github:mui/material-ui#f3cb496c999acbc8f19533e38df20be12e56d059
+        version: github.com/mui/material-ui/f3cb496c999acbc8f19533e38df20be12e56d059
       '@mui/styles':
         specifier: 5.15.15
         version: 5.15.15(react@18.2.0)
@@ -1565,7 +1565,7 @@ packages:
     resolution: {integrity: sha512-1DBaMmRDpuYQBPWD8Pf/WEwCrtgRHxsZnP4mIy9G/X+hFfbI47Q2G4t1Paakld84+qsk2fSsUPMKg71jkoOOaQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.24.4
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.0
@@ -1650,7 +1650,7 @@ packages:
   /@docsearch/react@3.6.0(@algolia/client-search@4.22.1)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.13.0):
     resolution: {integrity: sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==}
     peerDependencies:
-      '@types/react': '>= 16.8.0 < 19.0.0'
+      '@types/react': 18.2.55
       react: '>= 16.8.0 < 19.0.0'
       react-dom: '>= 16.8.0 < 19.0.0'
       search-insights: '>= 1 < 3'
@@ -14935,10 +14935,10 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/mui/material-ui/9ef12dc81c54566eeceae16bcf026a75fbce504d:
-    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/9ef12dc81c54566eeceae16bcf026a75fbce504d}
+  github.com/mui/material-ui/f3cb496c999acbc8f19533e38df20be12e56d059:
+    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/f3cb496c999acbc8f19533e38df20be12e56d059}
     name: '@mui/monorepo'
-    version: 6.0.0-alpha.2
+    version: 6.0.0-alpha.1
     requiresBuild: true
     dependencies:
       '@googleapis/sheets': 5.0.5


### PR DESCRIPTION
This regressed some of the icons:
![Screenshot 2024-04-15 at 12 01 53](https://github.com/mui/mui-toolpad/assets/2109932/89cf7ff8-b67e-4d14-96ba-ea238d0d0a46)
