### PR TITLE
Use url.pathToFileURL to correctly resolve functions paths on windows

### DIFF
--- a/packages/toolpad-studio/src/server/functionsRuntime.ts
+++ b/packages/toolpad-studio/src/server/functionsRuntime.ts
@@ -8,7 +8,6 @@ import * as crypto from 'crypto';
 
 async function loadExports(filePath: string): Promise<Map<string, unknown>> {
   const fullPath = url.pathToFileURL(path.resolve(filePath));
-  console.log(fullPath);
   const content = await fs.readFile(fullPath, 'utf-8');
   const hash = crypto.createHash('md5').update(content).digest('hex');
   const exports = await import(`${fullPath}?${hash}`);

--- a/packages/toolpad-studio/src/server/functionsRuntime.ts
+++ b/packages/toolpad-studio/src/server/functionsRuntime.ts
@@ -7,10 +7,11 @@ import { fromZodError } from 'zod-validation-error';
 import * as crypto from 'crypto';
 
 async function loadExports(filePath: string): Promise<Map<string, unknown>> {
-  const fullPath = url.pathToFileURL(path.resolve(filePath));
-  const content = await fs.readFile(fullPath, 'utf-8');
+  const importFileUrl = url.pathToFileURL(path.resolve(filePath));
+  const content = await fs.readFile(importFileUrl, 'utf-8');
   const hash = crypto.createHash('md5').update(content).digest('hex');
-  const exports = await import(`${fullPath}?${hash}`);
+  importFileUrl.searchParams.set('hash', hash);
+  const exports = await import(importFileUrl.href);
   return new Map(Object.entries(exports));
 }
 

--- a/packages/toolpad-studio/src/server/functionsRuntime.ts
+++ b/packages/toolpad-studio/src/server/functionsRuntime.ts
@@ -7,6 +7,7 @@ import { fromZodError } from 'zod-validation-error';
 import * as crypto from 'crypto';
 
 async function loadExports(filePath: string): Promise<Map<string, unknown>> {
+  // Need a valid file URL on Windows for the dynamic import()
   const importFileUrl = url.pathToFileURL(path.resolve(filePath));
   const content = await fs.readFile(importFileUrl, 'utf-8');
   const hash = crypto.createHash('md5').update(content).digest('hex');

--- a/packages/toolpad-studio/src/server/functionsRuntime.ts
+++ b/packages/toolpad-studio/src/server/functionsRuntime.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as url from 'url';
 import * as fs from 'fs/promises';
 import { TOOLPAD_DATA_PROVIDER_MARKER, ToolpadDataProvider } from '@toolpad/studio-runtime/server';
 import * as z from 'zod';
@@ -6,7 +7,8 @@ import { fromZodError } from 'zod-validation-error';
 import * as crypto from 'crypto';
 
 async function loadExports(filePath: string): Promise<Map<string, unknown>> {
-  const fullPath = path.resolve(filePath);
+  const fullPath = url.pathToFileURL(path.resolve(filePath));
+  console.log(fullPath);
   const content = await fs.readFile(fullPath, 'utf-8');
   const hash = crypto.createHash('md5').update(content).digest('hex');
   const exports = await import(`${fullPath}?${hash}`);


### PR DESCRIPTION
Fixes https://github.com/mui/mui-toolpad/issues/3405

Use `url.pathToFileURL` to correctly resolve paths on windows