### PR TITLE
Fix environment binding preview

### DIFF
--- a/packages/toolpad-studio/src/server/EnvManager.ts
+++ b/packages/toolpad-studio/src/server/EnvManager.ts
@@ -96,8 +96,8 @@ export default class EnvManager {
     this.watcher.on('change', handleChange);
   }
 
-  async getDeclaredValues(): Promise<Record<string, string>> {
-    return this.values;
+  async getDeclaredKeys(): Promise<string[]> {
+    return Object.keys(this.values);
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/toolpad-studio/src/toolpad/AppEditor/PageEditor/BindableEditor.tsx
+++ b/packages/toolpad-studio/src/toolpad/AppEditor/PageEditor/BindableEditor.tsx
@@ -37,7 +37,8 @@ export interface BindableEditorProps<V> extends WithControlledProp<BindableAttrV
   liveBinding?: LiveBinding;
   globalScope?: Record<string, unknown>;
   globalScopeMeta: ScopeMeta;
-  env?: Record<string, string>;
+  env?: Record<string, string | undefined>;
+  declaredEnvKeys?: string[];
   sx?: SxProps;
 }
 
@@ -54,6 +55,7 @@ export default function BindableEditor<V>({
   globalScope = {},
   globalScopeMeta = {},
   env,
+  declaredEnvKeys,
   sx,
 }: BindableEditorProps<V>) {
   const propTypeControls = usePropControlsContext();
@@ -120,6 +122,7 @@ export default function BindableEditor<V>({
           hidden={!bindable}
           liveBinding={liveBinding}
           env={env}
+          declaredEnvKeys={declaredEnvKeys}
         />
       </React.Fragment>
     </Stack>

--- a/packages/toolpad-studio/src/toolpad/AppEditor/PageEditor/ParametersEditor.tsx
+++ b/packages/toolpad-studio/src/toolpad/AppEditor/PageEditor/ParametersEditor.tsx
@@ -16,7 +16,8 @@ export interface StringRecordEntriesEditorProps
   autoFocus?: boolean;
   sx?: SxProps;
   jsRuntime: JsRuntime;
-  env?: Record<string, string>;
+  env?: Record<string, string | undefined>;
+  declaredEnvKeys?: string[];
   disabled?: boolean;
 }
 
@@ -34,6 +35,7 @@ export default function ParametersEditor({
   disabled,
   globalScopeMeta,
   env,
+  declaredEnvKeys,
 }: StringRecordEntriesEditorProps) {
   const fieldInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -94,6 +96,7 @@ export default function ParametersEditor({
               }
               disabled={disabled}
               env={env}
+              declaredEnvKeys={declaredEnvKeys}
             />
 
             <IconButton

--- a/packages/toolpad-studio/src/toolpadDataSources/rest/client.tsx
+++ b/packages/toolpad-studio/src/toolpadDataSources/rest/client.tsx
@@ -311,7 +311,11 @@ function QueryEditor({
     [appStateApi],
   );
 
-  const env = React.useMemo(() => introspection?.data?.env, [introspection]);
+  const env = React.useMemo(() => introspection?.data?.env ?? {}, [introspection?.data?.env]);
+  const declaredEnvKeys = React.useMemo(
+    () => introspection?.data?.declaredEnvKeys ?? [],
+    [introspection?.data?.declaredEnvKeys],
+  );
   const handleParamsChange = React.useCallback(
     (newParams: [string, BindableAttrValue<string>][]) => {
       appStateApi.updateQueryDraft((draft) => ({
@@ -650,6 +654,7 @@ function QueryEditor({
                     liveValue={paramsEditorLiveValue}
                     jsRuntime={jsServerRuntime}
                     env={env}
+                    declaredEnvKeys={declaredEnvKeys}
                   />
                 </TabPanel>
               </TabContext>

--- a/packages/toolpad-studio/src/toolpadDataSources/rest/server.ts
+++ b/packages/toolpad-studio/src/toolpadDataSources/rest/server.ts
@@ -21,14 +21,11 @@ import {
   RawBody,
   RestConnectionParams,
   UrlEncodedBody,
+  IntrospectionResult,
 } from './types';
 import applyTransform from '../applyTransform';
 import { HTTP_NO_BODY, getAuthenticationHeaders, parseBaseUrl } from './shared';
 import type { IToolpadProject } from '../server';
-
-async function loadEnvFile(project: IToolpadProject) {
-  return project.envManager.getDeclaredValues();
-}
 
 function resolveBindable<T>(
   jsRuntime: JsRuntime,
@@ -229,8 +226,10 @@ export default function createDatasource(
     async execPrivate(connection: Maybe<RestConnectionParams>, query: FetchPrivateQuery) {
       switch (query.kind) {
         case 'introspection': {
-          const env = await loadEnvFile(project);
-          return { env };
+          return {
+            env: process.env,
+            declaredEnvKeys: await project.envManager.getDeclaredKeys(),
+          } satisfies IntrospectionResult;
         }
         case 'debugExec':
           return execBase(project, connection, query.query, query.params);

--- a/packages/toolpad-studio/src/toolpadDataSources/rest/types.ts
+++ b/packages/toolpad-studio/src/toolpadDataSources/rest/types.ts
@@ -125,5 +125,6 @@ export interface FetchResult extends ExecFetchResult<any> {
 }
 
 export type IntrospectionResult = {
-  env: Record<string, string>;
+  env: Record<string, string | undefined>;
+  declaredEnvKeys: string[];
 };


### PR DESCRIPTION
Fixes https://github.com/mui/mui-toolpad/issues/3410

The env var file is only a subset of the available vars.

* Use the env var file keys for the warning message
* Use the actual env for evaluation of preview
* Show a preview of the actual value
* Fix issues with the tab switching to expression when you empty the env value

![Screenshot 2024-04-17 at 18 40 39](https://github.com/mui/mui-toolpad/assets/2109932/87cbdc5b-3057-4272-9812-9cbf7ecee2df)
