### PR TITLE
Revert using published @mui/docs

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -14,6 +14,9 @@ const { findPages } = require('./src/modules/utils/find');
 
 const WORKSPACE_ROOT = path.resolve(currentDirectory, '../');
 const MONOREPO_PATH = path.resolve(currentDirectory, '../node_modules/@mui/monorepo');
+const MONOREPO_PACKAGES = {
+  '@mui/docs': path.resolve(MONOREPO_PATH, './packages/mui-docs/src'),
+};
 
 export default withDocsInfra({
   experimental: {
@@ -40,6 +43,7 @@ export default withDocsInfra({
         alias: {
           ...config.resolve.alias,
           docs: path.resolve(MONOREPO_PATH, './docs'),
+          ...MONOREPO_PACKAGES,
           '@toolpad/studio-components': path.resolve(
             currentDirectory,
             '../packages/toolpad-studio-components/src',

--- a/eslintWebpackResolverConfig.js
+++ b/eslintWebpackResolverConfig.js
@@ -5,6 +5,7 @@ module.exports = {
   resolve: {
     modules: [__dirname, 'node_modules'],
     alias: {
+      '@mui/docs': path.resolve(__dirname, './node_modules/@mui/monorepo/packages/mui-docs/src'),
       '@toolpad/studio-components': path.resolve(
         __dirname,
         './packages/toolpad-studio-components/src',


### PR DESCRIPTION
Revert using the published `@mui/docs` and instead use the tip-of-the-tree variant that comes inside of the monorepo. The concept of the `@mui/docs` dependency keeps existing, we just circumvent npm installation of it until we can remove all aliasing.
