### PR TITLE
[docs] Remove MarkdownElement import

### DIFF
--- a/docs/src/components/landing/CodeBlock.js
+++ b/docs/src/components/landing/CodeBlock.js
@@ -255,16 +255,19 @@ export default function CodeBlock({ appMode, fileIndex, setFrameIndex }) {
           </TabList>
         </Box>
         {filenames.map((file, index) => (
-          <TabPanel
-            value={index.toString()}
-            key={index}
-            sx={{ m: 0, p: 0, flex: 1, minHeight: 0, overflow: 'auto' }}
-          >
+          <TabPanel value={index.toString()} key={index} sx={{ m: 0, p: 0, flex: 1, minHeight: 0 }}>
             <HighlightedCode
               copyButtonHidden
               code={code[index]}
               language="tsx"
               sx={{
+                width: '100%',
+                height: '100%',
+                '& .MuiCode-root': {
+                  width: '100%',
+                  height: '100%',
+                  overflow: 'auto',
+                },
                 '& pre': {
                   m: 0,
                   border: 'none',

--- a/docs/src/components/landing/CodeBlock.js
+++ b/docs/src/components/landing/CodeBlock.js
@@ -7,7 +7,6 @@ import TabList from '@mui/lab/TabList';
 import TabPanel from '@mui/lab/TabPanel';
 import { alpha } from '@mui/material/styles';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
-import MarkdownElement from 'docs/src/components/markdown/MarkdownElement';
 
 const code = [
   `
@@ -176,8 +175,6 @@ export default function CodeBlock({ appMode, fileIndex, setFrameIndex }) {
         gridRowEnd: 2,
         minWidth: { xs: 'unset', sm: '50%', md: '200%', lg: 560 },
         maxHeight: { xs: 240, sm: 315, md: 420 },
-        overflowY: 'auto',
-        overflowX: 'inherit',
         position: { xs: 'relative', sm: 'absolute', md: 'relative' },
         bottom: { xs: 'unset', sm: 0, md: 'unset' },
         zIndex: 20,
@@ -187,6 +184,9 @@ export default function CodeBlock({ appMode, fileIndex, setFrameIndex }) {
         backgroundColor: '#0F1924',
         backfaceVisibility: 'hidden',
         transition: 'all 0.3s ease',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
         transform: appMode
           ? { xs: 'rotateY(180deg)', sm: 'unset', md: 'rotateY(180deg)' }
           : 'unset',
@@ -201,7 +201,6 @@ export default function CodeBlock({ appMode, fileIndex, setFrameIndex }) {
           sx={(theme) => ({
             display: 'flex',
             alignItems: 'center',
-            gap: 1,
             borderBottom: '1px solid',
             backgroundColor: (theme.vars || theme).palette.primaryDark[800],
             position: 'sticky',
@@ -259,25 +258,22 @@ export default function CodeBlock({ appMode, fileIndex, setFrameIndex }) {
           <TabPanel
             value={index.toString()}
             key={index}
-            sx={{
-              m: 0,
-              p: 0,
-              '& pre': {
-                backgroundColor: '#0F1924',
-              },
-            }}
+            sx={{ m: 0, p: 0, flex: 1, minHeight: 0, overflow: 'auto' }}
           >
             <HighlightedCode
               copyButtonHidden
-              component={MarkdownElement}
               code={code[index]}
               language="tsx"
               sx={{
-                p: 1.5,
-                fontSize: (theme) => ({
-                  xs: theme.typography.pxToRem(8.5),
-                  md: theme.typography.pxToRem(12),
-                }),
+                '& pre': {
+                  m: 0,
+                  border: 'none',
+                  maxHeight: 'fit-content',
+                  fontSize: (theme) => ({
+                    xs: theme.typography.pxToRem(8.5),
+                    md: theme.typography.pxToRem(12),
+                  }),
+                },
               }}
             />
           </TabPanel>

--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -121,7 +121,7 @@ export default function Hero() {
   const [frameIndex, setFrameIndex] = React.useState(0);
 
   const [pauseHeroAnimation, setPauseHeroAnimation] = React.useState(false);
-  /* 
+
   React.useEffect(() => {
     const loop = setInterval(() => {
       if (!pauseHeroAnimation) {
@@ -132,7 +132,7 @@ export default function Hero() {
       }
     }, FRAME_DELAY);
     return () => clearInterval(loop);
-  }, [pauseHeroAnimation, frameIndex, isLargerThanMd, isSmallerThanSm]); */
+  }, [pauseHeroAnimation, frameIndex, isLargerThanMd, isSmallerThanSm]);
 
   const fileIndex = React.useMemo(() => Math.floor(frameIndex / 2), [frameIndex]);
 

--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -121,7 +121,7 @@ export default function Hero() {
   const [frameIndex, setFrameIndex] = React.useState(0);
 
   const [pauseHeroAnimation, setPauseHeroAnimation] = React.useState(false);
-
+  /* 
   React.useEffect(() => {
     const loop = setInterval(() => {
       if (!pauseHeroAnimation) {
@@ -132,7 +132,7 @@ export default function Hero() {
       }
     }, FRAME_DELAY);
     return () => clearInterval(loop);
-  }, [pauseHeroAnimation, frameIndex, isLargerThanMd, isSmallerThanSm]);
+  }, [pauseHeroAnimation, frameIndex, isLargerThanMd, isSmallerThanSm]); */
 
   const fileIndex = React.useMemo(() => Math.floor(frameIndex / 2), [frameIndex]);
 


### PR DESCRIPTION
Fixes https://github.com/mui/mui-toolpad/issues/3442

Also fixes the scroll bar under the tab container, and clips the rounded corners correctly

Remove `MarkdownElement` import from `src/components/markdown/MarkdownElement`
See https://github.com/mui/material-ui/pull/41859#issuecomment-2074897388

Aside, `HighlightedCode` is a bit hard to use imo.

Intuitively I'd expect three levels of abstraction here, so that I can mix and match to my use case.
1. a highlighted code block, which auto sizes with the height, no border/corners
2. a code viewport, which provides the scroll behavior
3. a container which provides title/tabs and clips the corners

Preview: https://deploy-preview-3451--mui-toolpad-docs.netlify.app/toolpad/

before:

![Screenshot 2024-04-24 at 16 32 32](https://github.com/mui/mui-toolpad/assets/2109932/e5a5e311-1647-496d-a857-3483ac4e0cdf)

after:

![Screenshot 2024-04-24 at 16 32 39](https://github.com/mui/mui-toolpad/assets/2109932/c1354abe-08c6-4c71-9169-09dc32bf78d0)
