### PR TITLE
Fix performance regression

### DIFF
--- a/packages/toolpad-studio/src/canvas/ToolpadBridge.tsx
+++ b/packages/toolpad-studio/src/canvas/ToolpadBridge.tsx
@@ -1,6 +1,6 @@
 import { Emitter } from '@toolpad/utils/events';
 import type { RuntimeEvents } from '@toolpad/studio-runtime';
-import type { AppCanvasState, PageViewState } from '../types';
+import type { PageViewState } from '../types';
 
 const COMMAND_HANDLERS = Symbol('hidden property to hold the command handlers');
 
@@ -51,7 +51,6 @@ export interface ToolpadBridge {
   canvasEvents: Emitter<RuntimeEvents>;
   // Commands executed from the editor, ran in the canvas
   canvasCommands: Commands<{
-    update(updates: AppCanvasState): void;
     getViewCoordinates(clientX: number, clientY: number): { x: number; y: number } | null;
     getPageViewState(): PageViewState;
     isReady(): boolean;

--- a/packages/toolpad-studio/src/canvas/index.tsx
+++ b/packages/toolpad-studio/src/canvas/index.tsx
@@ -81,8 +81,7 @@ export interface AppCanvasProps {
   basename: string;
 }
 
-export default function AppCanvas({ basename, state: initialState }: AppCanvasProps) {
-  const [state, setState] = React.useState<AppCanvasState>(initialState);
+export default function AppCanvas({ basename, state }: AppCanvasProps) {
   const [readyBridge, setReadyBridge] = React.useState<ToolpadBridge | undefined>();
 
   const appRootRef = React.useRef<HTMLDivElement>();
@@ -164,19 +163,6 @@ export default function AppCanvas({ basename, state: initialState }: AppCanvasPr
         return { x: clientX - rect.x, y: clientY - rect.y };
       }
       return null;
-    });
-
-    setCommandHandler(bridge.canvasCommands, 'update', (newState) => {
-      // `update` will be called from the parent window. Since the canvas runs in an iframe, it's
-      // running in another javascript realm than the one this object was constructed in. This makes
-      // the MUI core `deepMerge` function fail. The `deepMerge` function uses `isPlainObject` which checks
-      // whether the object constructor property is the global `Object`.
-      // See https://github.com/mui/material-ui/blob/b935d3e8f48b5d54f6cd08154fe2f7aa035ab576/packages/mui-utils/src/deepmerge.ts#L2.
-      // Since different realms have different globals, this function erroneously marks it as not being a plain object.
-      // For now we've use structuredClone to make the `update` method behave as if it was built using
-      // `window.postMessage`, which we should probably move towards anyways at some point. structuredClone
-      // clones the object as if it was passed using `postMessage` and corrects the `constructor` property.
-      React.startTransition(() => setState(structuredClone(newState)));
     });
 
     setCommandHandler(bridge.canvasCommands, 'invalidateQueries', () => {

--- a/packages/toolpad-studio/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
+++ b/packages/toolpad-studio/src/toolpad/AppEditor/PageEditor/NodeAttributeEditor.tsx
@@ -43,16 +43,26 @@ export default function NodeAttributeEditor<P extends object>({
 }: NodeAttributeEditorProps<P>) {
   const domApi = useDomApi();
 
+  const initialPropValue = (node as any)[namespace]?.[name];
+  const [propValue, setPropValue] = React.useState<BindableAttrValue<unknown> | null>(
+    initialPropValue,
+  );
+
+  React.useEffect(() => {
+    setPropValue(initialPropValue);
+  }, [initialPropValue]);
+
   const handlePropChange = React.useCallback(
     (newValue: BindableAttrValue<unknown> | null) => {
-      domApi.update((draft) =>
-        appDom.setNodeNamespacedProp(draft, node, namespace as any, name, newValue),
-      );
+      setPropValue(newValue);
+      React.startTransition(() => {
+        domApi.update((draft) =>
+          appDom.setNodeNamespacedProp(draft, node, namespace as any, name, newValue),
+        );
+      });
     },
     [node, namespace, name, domApi],
   );
-
-  const propValue: BindableAttrValue<unknown> | null = (node as any)[namespace]?.[name] ?? null;
 
   const bindingId = `${node.id}${namespace ? `.${namespace}` : ''}.${name}`;
   const { vm } = usePageEditorState();


### PR DESCRIPTION
After we removed the second build process, the canvas content and the editor started running in the same React tree. The whole editor rendering now affects the responsiveness of the input components. 

This PR keeps the input state local and updates the editor state in a transition to make the rendering of these state updates through the editor interruptible.

Also removing some dead code