### PR TITLE
Update README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable-next-line -->
 <p align="center">
-  <a href="https://mui.com/" rel="noopener" target="_blank"><img width="150" src="https://mui.com/static/logo.svg" alt="Toolpad Studio logo"></a>
+  <a href="https://mui.com/toolpad/" rel="noopener" target="_blank"><img width="150" src="https://mui.com/static/branding/product-toolpad-light.svg" alt="Toolpad Studio logo"></a>
 </p>
 
 <h1 align="center">Toolpad Studio</h1>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <div align="center">
 
-Quickly build internal tools. Toolpad Studio is a self-hosted low-code internal tools builder designed to extend the [MUI](https://mui.com/) React components. It's designed for developers of all trades who want to save time building internal applications.
+Toolpad Studio is a self-hosted low-code admin builder designed to extend the [MUI](https://mui.com/) React components. It's for developers of all trades who want to save time building internal applications. Drag-and-drop from a catalogue of pre-built components, connect to any data source and build apps quickly.
 
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/mui/material-ui/blob/HEAD/LICENSE)
 
@@ -18,7 +18,7 @@ Quickly build internal tools. Toolpad Studio is a self-hosted low-code internal 
 -->
 
 [![CircleCI](https://circleci.com/gh/mui/mui-toolpad/tree/master.svg?style=shield)](https://app.circleci.com/pipelines/github/mui/mui-toolpad?branch=master)
-[![Follow on Twitter](https://img.shields.io/twitter/follow/MUI_hq.svg?label=follow+MUI)](https://twitter.com/MUI_hq)
+[![Follow on Twitter](https://img.shields.io/twitter/follow/Toolpad_.svg?label=follow+Toolpad)](https://twitter.com/Toolpad_)
 [![Renovate status](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://github.com/mui/mui-toolpad/issues/8)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/mui/mui-toolpad.svg)](https://isitmaintained.com/project/mui/mui-toolpad 'Average time to resolve an issue')
 [![Open Collective backers and sponsors](https://img.shields.io/opencollective/all/mui-org)](https://opencollective.com/mui-org)
@@ -55,7 +55,8 @@ Check out our [documentation](https://mui.com/toolpad/studio/getting-started/).
 
 ## Examples
 
-Check out our [mui-public](https://github.com/mui/mui-public) repo to see how a Toolpad Studio app looks in production.
+Check out our [mui-public](https://tools-public.onrender.com/prod/pages/OverviewPage) app to see how a Toolpad Studio app looks in production.
+Our documentation contains more [examples](https://mui.com/toolpad/studio/examples/) to help you get started.
 
 ## Contributing
 

--- a/packages/toolpad-studio/README.md
+++ b/packages/toolpad-studio/README.md
@@ -5,14 +5,18 @@
 
 <h1 align="center">Toolpad Studio</h1>
 
-This package is the GUI based, low-code admin builder offering from MUI. Drag-and-drop pre-built MUI components, connect to any datasource and build functional React apps quickly.
+Toolpad Studio is a self-hosted low-code admin builder designed to extend the [MUI](https://mui.com/) React components. It's for developers of all trades who want to save time building internal applications. Drag-and-drop from a catalogue of pre-built components, connect to any data source and build apps quickly.
 
 ## Installation
 
 Install the package in your project directory with:
 
 ```bash
-npm install @toolpad/studio
+npx create-toolpad-app@latest my-toolpad-studio-app
+# or
+yarn create toolpad-app my-toolpad-studio-app
+# or
+pnpm create toolpad-app my-toolpad-studio-app
 ```
 
 ## Documentation
@@ -21,7 +25,8 @@ Visit [https://mui.com/toolpad/studio/getting-started/](https://mui.com/toolpad/
 
 ## Examples
 
-Check out some [examples built using Toolpad Studio](https://mui.com/toolpad/studio/examples/).
+Check out our [mui-public](https://tools-public.onrender.com/prod/pages/OverviewPage) app to see how a Toolpad Studio app looks in production.
+Our documentation contains more [examples](https://mui.com/toolpad/studio/examples/) to help you get started.
 
 ## Changelog
 

--- a/packages/toolpad-studio/README.md
+++ b/packages/toolpad-studio/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable-next-line -->
 <p align="center">
-  <a href="https://mui.com/toolpad/" rel="noopener" target="_blank"><img width="150" src="https://mui.com/static/logo.svg" alt="Toolpad Studio logo"></a>
+  <a href="https://mui.com/toolpad/" rel="noopener" target="_blank"><img width="150" src="https://mui.com/static/branding/product-toolpad-light.svg" alt="Toolpad Studio logo"></a>
 </p>
 
 <h1 align="center">Toolpad Studio</h1>

--- a/packages/toolpad-studio/README.md
+++ b/packages/toolpad-studio/README.md
@@ -1,6 +1,11 @@
-# @toolpad/studio
+<!-- markdownlint-disable-next-line -->
+<p align="center">
+  <a href="https://mui.com/toolpad/" rel="noopener" target="_blank"><img width="150" src="https://mui.com/static/logo.svg" alt="Toolpad Studio logo"></a>
+</p>
 
-Low-code tool, powered by MUI
+<h1 align="center">Toolpad Studio</h1>
+
+This package is the GUI based, low-code admin builder offering from MUI. Drag-and-drop pre-built MUI components, connect to any datasource and build functional React apps quickly.
 
 ## Installation
 
@@ -12,4 +17,16 @@ npm install @toolpad/studio
 
 ## Documentation
 
-[The documentation](./docs)
+Visit [https://mui.com/toolpad/studio/getting-started/](https://mui.com/toolpad/studio/getting-started/) to view the full documentation.
+
+## Examples
+
+Check out some [examples built using Toolpad Studio](https://mui.com/toolpad/studio/examples/).
+
+## Changelog
+
+The [changelog](https://github.com/mui/mui-toolpad/releases) is regularly updated to reflect what's changed in each new release.
+
+## Roadmap
+
+Future plans and high-priority features and enhancements can be found in the [roadmap](https://mui.com/toolpad/studio/getting-started/roadmap/).


### PR DESCRIPTION
Currently, the light theme logo is being picked. In the dark theme of GitHub it looks like: 

<img width="957" alt="Screenshot 2024-04-27 at 1 53 34 AM" src="https://github.com/mui/mui-toolpad/assets/92228082/b9bc29a0-01e4-4034-aee2-118b8950c707">




Later on, update https://www.npmjs.com/package/@toolpad/studio with the homepage, GitHub repo, and keywords.
