### PR TITLE
[docs] Support demo previews with comments

### DIFF
--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -89,7 +89,11 @@ async function transpileFile(tsxPath, project) {
       transformOptions.plugins = transformOptions.plugins.concat([
         [
           require.resolve('docs/src/modules/utils/babel-plugin-jsx-preview'),
-          { maxLines: 16, outputFilename: `${tsxPath}.preview` },
+          {
+            maxLines: 16,
+            outputFilename: `${tsxPath}.preview`,
+            wrapperTypes: ['div', 'Box', 'Stack'],
+          },
         ],
       ]);
     }


### PR DESCRIPTION
Allow for custom preview blocks in demos. The current solution focuses heavily on a single jsx element, not configurable. For Toolpad we're in need of more flexibility. This PR proposes the extraction of previews using `// preview-start` and `// preview-end` comment blocks. This allows for marking custom ranges as preview for demos, e.g.

```tsx
import { useMyHook } from '@lib'

export default function () {
  // preview-start
  const result = useMyHook()
  // preview-end

  return <div>{result}</div>
}
```
Will result in a preview of
```tsx
const result = useMyHook()
```

We can clean up the full demo in the markdownloader and remove the lines containing `// preview-start` and `// preview-end`. Additionally `{/* preview-start */}` and `{/* preview-end */}` are also supported to allow previewing specific JSX.

It's also possible to delineate multiple preview blocks. They will get joined in the preview by a `// ...`

Examples can be seen here: https://deploy-preview-3558--mui-toolpad-docs.netlify.app/toolpad/core/components/notifications/

tagging @mui/docs-infra wdyt?