### PR TITLE
[core] Base typescript projects on the file location instead of on cwd

### DIFF
--- a/scripts/coreTypescriptProjects.js
+++ b/scripts/coreTypescriptProjects.js
@@ -1,12 +1,15 @@
 import path from 'path';
+import url from 'url';
+
+const currentDirectory = url.fileURLToPath(new URL('.', String(import.meta.url)));
 
 export default {
   'toolpad-core': {
-    rootPath: path.join(process.cwd(), 'packages/toolpad-core'),
+    rootPath: path.join(currentDirectory, '../packages/toolpad-core'),
     entryPointPath: 'src/index.ts',
   },
   docs: {
-    rootPath: path.join(process.cwd(), 'docs'),
+    rootPath: path.join(currentDirectory, '../docs'),
     tsConfigPath: 'tsconfig.json',
   },
 };


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-toolpad/pull/3558
Noticed that this script isn't portable while working on the demo formatter 
