### PR TITLE
[DataProvider] Support custom Id field

### DIFF
--- a/docs/data/toolpad/core/introduction/Tutorial1.js
+++ b/docs/data/toolpad/core/introduction/Tutorial1.js
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { createDataProvider } from '@toolpad/core/DataProvider';
+import { DataGrid } from '@toolpad/core/DataGrid';
+import Box from '@mui/material/Box';
+
+const npmData = createDataProvider({
+  async getMany() {
+    const res = await fetch('https://api.npmjs.org/downloads/range/last-year/react');
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+    }
+    const { downloads } = await res.json();
+    return { rows: downloads.map((point) => ({ ...point, id: point.day })) };
+  },
+  fields: {
+    id: {},
+    day: { type: 'date' },
+    downloads: { type: 'number' },
+  },
+});
+
+export default function Tutorial1() {
+  return (
+    <Box sx={{ height: 300, width: '100%' }}>
+      <DataGrid dataProvider={npmData} />
+    </Box>
+  );
+}

--- a/docs/data/toolpad/core/introduction/Tutorial1.js
+++ b/docs/data/toolpad/core/introduction/Tutorial1.js
@@ -10,10 +10,10 @@ const npmData = createDataProvider({
       throw new Error(`HTTP ${res.status}: ${res.statusText}`);
     }
     const { downloads } = await res.json();
-    return { rows: downloads.map((point) => ({ ...point, id: point.day })) };
+    return { rows: downloads };
   },
+  idField: 'day',
   fields: {
-    id: {},
     day: { type: 'date' },
     downloads: { type: 'number' },
   },

--- a/docs/data/toolpad/core/introduction/Tutorial1.tsx
+++ b/docs/data/toolpad/core/introduction/Tutorial1.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { createDataProvider } from '@toolpad/core/DataProvider';
+import { DataGrid } from '@toolpad/core/DataGrid';
+import Box from '@mui/material/Box';
+
+const npmData = createDataProvider({
+  async getMany() {
+    const res = await fetch('https://api.npmjs.org/downloads/range/last-year/react');
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+    }
+    const { downloads } = await res.json();
+    return { rows: downloads.map((point: any) => ({ ...point, id: point.day })) };
+  },
+  fields: {
+    id: {},
+    day: { type: 'date' },
+    downloads: { type: 'number' },
+  },
+});
+
+export default function Tutorial1() {
+  return (
+    <Box sx={{ height: 300, width: '100%' }}>
+      <DataGrid dataProvider={npmData} />
+    </Box>
+  );
+}

--- a/docs/data/toolpad/core/introduction/Tutorial1.tsx
+++ b/docs/data/toolpad/core/introduction/Tutorial1.tsx
@@ -10,10 +10,10 @@ const npmData = createDataProvider({
       throw new Error(`HTTP ${res.status}: ${res.statusText}`);
     }
     const { downloads } = await res.json();
-    return { rows: downloads.map((point: any) => ({ ...point, id: point.day })) };
+    return { rows: downloads };
   },
+  idField: 'day',
   fields: {
-    id: {},
     day: { type: 'date' },
     downloads: { type: 'number' },
   },

--- a/docs/data/toolpad/core/introduction/Tutorial1.tsx.preview
+++ b/docs/data/toolpad/core/introduction/Tutorial1.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid dataProvider={npmData} />

--- a/docs/data/toolpad/core/introduction/dashboard-tutorial.md
+++ b/docs/data/toolpad/core/introduction/dashboard-tutorial.md
@@ -12,21 +12,19 @@ Toolpad Core comes with the concept of data providers. At its core, a data provi
 ```js
 import { createDataProvider } from '@toolpad/core/DataProvider';
 
-const movieData = createDataProvider({
+const npmData = createDataProvider({
   async getMany() {
-    const res = await fetch(
-      'https://raw.githubusercontent.com/mui/mui-toolpad/master/public/movies.json',
-    );
-    if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-    const { movies } = await res.json();
-    return { rows: movies };
+    const res = await fetch('https://api.npmjs.org/downloads/range/last-year/react');
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+    }
+    const { downloads } = await res.json();
+    return { rows: downloads.map((point: any) => ({ ...point, id: point.day })) };
   },
+  idField: 'day',
   fields: {
-    id: {},
-    title: {},
-    year: {},
-    director: {},
-    runtime: {},
+    day: { type: 'date' },
+    downloads: { type: 'number' },
   },
 });
 ```
@@ -41,8 +39,8 @@ import { Box } from '@mui/material';
 
 export default function App() {
   return (
-    <Box sx={{ height: 400 }}>
-      <DataGrid dataProvider={movieData} />
+    <Box sx={{ height: 300, width: '100%' }}>
+      <DataGrid dataProvider={npmData} />
     </Box>
   );
 }
@@ -51,57 +49,3 @@ export default function App() {
 This results in the following output
 
 {{"demo": "Tutorial1.js", "hideToolbar": true}}
-
-## Sharing a datasource
-
-The data providers can be shared between different data components. For example, to also visualize this data in a chart you can add the BarChart component and connect the same data:
-
-```js
-import { DataGrid, BarChart } from '@toolpad/core';
-
-// ...
-
-export default function App() {
-  return (
-    <div>
-      <Box sx={{ height: 400 }}>
-        <DataGrid dataProvider={movieData} />
-      </Box>
-      <BarChart
-        dataProvider={movieData}
-        height={400}
-        groupBy="year"
-        aggregation="count"
-      />
-    </div>
-  );
-}
-```
-
-This results in the following Dashboard
-
-{{"demo": "Tutorial2.js", "hideToolbar": true}}
-
-## Filtering
-
-```js
-import { DataContext } from '@toolpad/core';
-
-export default function App() {
-  const [maxRuntime, setMaxRuntime] = React.useState(200);
-  return (
-    <div>
-      <Toolbar>
-        <TextField
-          label="Maximum Runtime"
-          value={maxRuntime}
-          onChange={(event) => setMaxRuntime(event.target.value)}
-        />
-      </Toolbar>
-      <DataContext filter={[[movieData, { runtime: { lt: maxRuntime } }]]}>
-        {/* ... */}
-      </DataContext>
-    </div>
-  );
-}
-```

--- a/docs/pages/toolpad/core/introduction/dashboard-tutorial.js
+++ b/docs/pages/toolpad/core/introduction/dashboard-tutorial.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from '../../../../data/toolpad/core/introduction/dashboard-tutorial.md?muiMarkdown';
+
+export default function Page() {
+  return <MarkdownDocs disableAd {...pageProps} />;
+}

--- a/packages/toolpad-core/src/DataGrid/DataGrid.tsx
+++ b/packages/toolpad-core/src/DataGrid/DataGrid.tsx
@@ -693,6 +693,7 @@ const DataGrid = function DataGrid<R extends Datum>(props: DataGridProps<R>) {
       inferredFields ?? dataProvider.fields,
       columnsProp,
     );
+    console.log(gridColumns, dataProvider.fields);
 
     gridColumns = updateColumnsWithDataProviderEditing(
       dataProvider,

--- a/packages/toolpad-core/src/DataGrid/DataGrid.tsx
+++ b/packages/toolpad-core/src/DataGrid/DataGrid.tsx
@@ -693,7 +693,6 @@ const DataGrid = function DataGrid<R extends Datum>(props: DataGridProps<R>) {
       inferredFields ?? dataProvider.fields,
       columnsProp,
     );
-    console.log(gridColumns, dataProvider.fields);
 
     gridColumns = updateColumnsWithDataProviderEditing(
       dataProvider,

--- a/packages/toolpad-core/src/DataGrid/NotificationSnackbar.tsx
+++ b/packages/toolpad-core/src/DataGrid/NotificationSnackbar.tsx
@@ -9,6 +9,7 @@ import { useNonNullableContext } from '@toolpad/utils/react';
 import CloseIcon from '@mui/icons-material/Close';
 
 export interface DataGridNotification {
+  key: string;
   severity: 'error' | 'success';
   message: React.ReactNode;
   showId?: GridRowId;
@@ -21,18 +22,20 @@ export const SetDataGridNotificationContext = React.createContext<React.Dispatch
 export interface NotificationSnackbarProps {
   notification: DataGridNotification | null;
   apiRef: React.MutableRefObject<GridApi>;
+  idField: string;
 }
 
 /**
  * @ignore - internal component.
  */
-export function NotificationSnackbar({ notification, apiRef }: NotificationSnackbarProps) {
+export function NotificationSnackbar({ notification, apiRef, idField }: NotificationSnackbarProps) {
   const latestNotification = useLatest(notification);
   const open = !!notification;
   const setNotification = useNonNullableContext(SetDataGridNotificationContext);
 
   return (
     <Snackbar
+      key={latestNotification?.key}
       sx={{ position: 'absolute', bottom: 0, left: 0, right: 0, m: 2 }}
       open={open}
       autoHideDuration={5000}
@@ -52,7 +55,7 @@ export function NotificationSnackbar({ notification, apiRef }: NotificationSnack
                   apiRef.current.setFilterModel({
                     items: [
                       {
-                        field: 'id',
+                        field: idField,
                         operator: 'equals',
                         value: String(latestNotification.showId),
                       },

--- a/packages/toolpad-core/src/DataProvider/DataProvider.tsx
+++ b/packages/toolpad-core/src/DataProvider/DataProvider.tsx
@@ -112,7 +112,7 @@ export function createDataProvider<R extends Datum>(
   const result = { ...input } as ResolvedDataProvider<R>;
   if (input.fields) {
     result.fields = {
-      id: { label: DEFAULT_ID_FIELD, type: 'string' },
+      [input.idField ?? DEFAULT_ID_FIELD]: { type: 'string' },
       ...Object.fromEntries(
         Object.entries(input.fields).map(([k, v]) => [k, { type: 'string', label: k, ...v }]),
       ),

--- a/packages/toolpad-core/src/DataProvider/DataProvider.tsx
+++ b/packages/toolpad-core/src/DataProvider/DataProvider.tsx
@@ -9,6 +9,9 @@ import { Filter, getKeyFromFilter, useAppliedFilter } from './filter';
  * Not a hook nor a component
  */
 
+export const DEFAULT_ID_FIELD = 'id';
+export type DefaultIdField = typeof DEFAULT_ID_FIELD;
+
 export type ValidId = string | number;
 export type ValidDatum = {
   id: ValidId;
@@ -16,24 +19,24 @@ export type ValidDatum = {
 };
 export type Datum<R extends ValidDatum = ValidDatum> = R;
 
-export type ValidProp<R extends Datum> = keyof R & string;
+export type FieldOf<R extends Datum> = keyof R & string;
 
 export type FieldType = 'string' | 'number' | 'boolean' | 'date';
 
-export interface ValueFormatter<R extends Datum, K extends ValidProp<R>> {
+export interface ValueFormatter<R extends Datum, K extends FieldOf<R>> {
   (value: R[K], field: K): string;
 }
 
-export interface FieldDef<R extends Datum, K extends ValidProp<R> = ValidProp<R>> {
+export interface FieldDef<R extends Datum, K extends FieldOf<R> = FieldOf<R>> {
   type?: FieldType;
   label?: string;
   valueFormatter?: ValueFormatter<R, K>;
 }
 
 export type FieldDefs<R extends Datum> = {
-  [K in Exclude<keyof R & string, 'id'>]: FieldDef<R, K>;
+  [K in Exclude<FieldOf<R>, DefaultIdField>]: FieldDef<R, K>;
 } & {
-  id?: FieldDef<R, 'id'>;
+  id?: FieldDef<R, DefaultIdField>;
 };
 
 export interface IndexPagination {
@@ -57,7 +60,7 @@ export interface GetManyMethod<R extends Datum> {
   (params: GetManyParams<R>): Promise<GetManyResult<R>>;
 }
 
-export interface ResolvedField<R extends Datum, K extends ValidProp<R> = ValidProp<R>> {
+export interface ResolvedField<R extends Datum, K extends FieldOf<R> = FieldOf<R>> {
   type: FieldType;
   label: string;
   valueFormatter?: ValueFormatter<R, K>;
@@ -85,11 +88,12 @@ export interface DataProviderDefinition<R extends Datum> {
   createOne?: CreateOneMethod<R>;
   updateOne?: UpdateOneMethod<R>;
   deleteOne?: DeleteOneMethod;
+  idField?: FieldOf<R>;
   fields?: FieldDefs<R>;
 }
 
 export type ResolvedFields<R extends Datum> = {
-  [K in keyof R & string]: ResolvedField<R, K>;
+  [K in FieldOf<R>]: ResolvedField<R, K>;
 };
 
 export interface ResolvedDataProvider<R extends Datum> {
@@ -98,6 +102,7 @@ export interface ResolvedDataProvider<R extends Datum> {
   createOne?: CreateOneMethod<R>;
   updateOne?: UpdateOneMethod<R>;
   deleteOne?: DeleteOneMethod;
+  idField?: FieldOf<R>;
   fields?: ResolvedFields<R>;
 }
 
@@ -107,7 +112,7 @@ export function createDataProvider<R extends Datum>(
   const result = { ...input } as ResolvedDataProvider<R>;
   if (input.fields) {
     result.fields = {
-      id: { label: 'id', type: 'string' },
+      id: { label: DEFAULT_ID_FIELD, type: 'string' },
       ...Object.fromEntries(
         Object.entries(input.fields).map(([k, v]) => [k, { type: 'string', label: k, ...v }]),
       ),


### PR DESCRIPTION
Realized while working on examples that many APIs use a different name than `id`. This PR makes it easier to define such data providers.  Added the initial start on a dashboard tutorial which calls npm API and uses the date as id. Continuation in https://github.com/mui/mui-toolpad/pull/3611

[temporary tutorial page](https://deploy-preview-3613--mui-toolpad-docs.netlify.app/toolpad/core/introduction/dashboard-tutorial/)