### PR TITLE
[docs] Fix link icons for file reference section titles

### DIFF
--- a/docs/src/modules/components/SchemaReference.tsx
+++ b/docs/src/modules/components/SchemaReference.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import invariant from 'invariant';
 import clsx from 'clsx';
+import { SectionTitle } from '@mui/docs/SectionTitle';
 import { interleave } from '../utils/react';
 
 const EMPTY_OBJECT = {};
@@ -448,16 +449,7 @@ interface HeadingProps {
 }
 
 function Heading({ hash, level: Level, title }: HeadingProps) {
-  return (
-    <Level id={hash}>
-      {title}
-      <a aria-labelledby={hash} className="anchor-link" href={`#${hash}`} tabIndex={-1}>
-        <svg>
-          <use xlinkHref="#anchor-link-icon" />
-        </svg>
-      </a>
-    </Level>
-  );
+  return <SectionTitle title={title} id={hash} level={Level} />;
 }
 
 interface JsonSchemaDisplayProps {


### PR DESCRIPTION
Fix file reference [doc](https://mui.com/toolpad/studio/reference/file-schema/):

![Screenshot 2024-06-24 at 11 52 38](https://github.com/mui/mui-toolpad/assets/2109932/b4af031a-3119-4455-8cfe-21531a40f9c8)


[preview](https://deploy-preview-3709--mui-toolpad-docs.netlify.app/toolpad/studio/reference/file-schema/) of the fix.

The `SectionTitle` component is a step in the good direction, but it still requires a global setup in the consuming application. it needs the sprite present on the page:
```tsx
<svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">
  <symbol id="anchor-link-icon" viewBox="0 0 16 16">
    <path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z" />
  </symbol>
</svg>
```
Is there a good way to make this component fully self contained?