### PR TITLE
[core] Optimize studio production build

### DIFF
--- a/packages/toolpad-studio/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-studio/src/server/toolpadAppBuilder.ts
@@ -5,7 +5,6 @@ import type { InlineConfig, Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { indent } from '@toolpad/utils/strings';
 import * as appDom from '@toolpad/studio-runtime/appDom';
-import inspect from 'vite-plugin-inspect';
 import type { ComponentEntry, PagesManifest } from './localMode';
 import { INITIAL_STATE_WINDOW_PROPERTY } from '../constants';
 import viteVirtualPlugin, { VirtualFileContent, replaceFiles } from './viteVirtualPlugin';

--- a/packages/toolpad-studio/src/server/toolpadAppBuilder.ts
+++ b/packages/toolpad-studio/src/server/toolpadAppBuilder.ts
@@ -5,6 +5,7 @@ import type { InlineConfig, Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { indent } from '@toolpad/utils/strings';
 import * as appDom from '@toolpad/studio-runtime/appDom';
+import inspect from 'vite-plugin-inspect';
 import type { ComponentEntry, PagesManifest } from './localMode';
 import { INITIAL_STATE_WINDOW_PROPERTY } from '../constants';
 import viteVirtualPlugin, { VirtualFileContent, replaceFiles } from './viteVirtualPlugin';
@@ -122,36 +123,42 @@ import { init, setComponents } from '@toolpad/studio/entrypoint';
 import components from ${JSON.stringify(componentsId)};
 ${isEditor ? `import ToolpadEditor from '@toolpad/studio/editor'` : ''}
 
-// importing monaco to get around module ordering issues in esbuild
-import 'monaco-editor';
+${
+  isEditor
+    ? `
+      // importing monaco to get around module ordering issues in esbuild
+      import 'monaco-editor';
 
-window.MonacoEnvironment = {
-  getWorker: async (_, label) => {
-    // { type: 'module' } is supported in firefox but behind feature flag:
-    // you have to enable it manually via about:config and set dom.workers.modules.enabled to true.
-    if (label === 'typescript') {
-      const { default: TsWorker } = await import('monaco-editor/esm/vs/language/typescript/ts.worker?worker');
-      return new TsWorker();
-    }
-    if (label === 'json') {
-      const { default: JsonWorker } = await import('monaco-editor/esm/vs/language/json/json.worker?worker');
-      return new JsonWorker();
-    }
-    if (label === 'html') {
-      const { default: HtmlWorker } = await import('monaco-editor/esm/vs/language/html/html.worker?worker');
-      return new HtmlWorker();
-    }
-    if (label === 'css') {
-      const { default: CssWorker } = await import('monaco-editor/esm/vs/language/css/css.worker?worker');
-      return new CssWorker();
-    }
-    if (label === 'editorWorkerService') {
-      const { default: EditorWorker } = await import('monaco-editor/esm/vs/editor/editor.worker?worker');
-      return new EditorWorker();
-    }
-    throw new Error(\`Failed to resolve worker with label "\${label}"\`);
-  },
-} as monaco.Environment;
+      window.MonacoEnvironment = {
+        getWorker: async (_, label) => {
+          // { type: 'module' } is supported in firefox but behind feature flag:
+          // you have to enable it manually via about:config and set dom.workers.modules.enabled to true.
+          if (label === 'typescript') {
+            const { default: TsWorker } = await import('monaco-editor/esm/vs/language/typescript/ts.worker?worker');
+            return new TsWorker();
+          }
+          if (label === 'json') {
+            const { default: JsonWorker } = await import('monaco-editor/esm/vs/language/json/json.worker?worker');
+            return new JsonWorker();
+          }
+          if (label === 'html') {
+            const { default: HtmlWorker } = await import('monaco-editor/esm/vs/language/html/html.worker?worker');
+            return new HtmlWorker();
+          }
+          if (label === 'css') {
+            const { default: CssWorker } = await import('monaco-editor/esm/vs/language/css/css.worker?worker');
+            return new CssWorker();
+          }
+          if (label === 'editorWorkerService') {
+            const { default: EditorWorker } = await import('monaco-editor/esm/vs/editor/editor.worker?worker');
+            return new EditorWorker();
+          }
+          throw new Error(\`Failed to resolve worker with label "\${label}"\`);
+        },
+      } as monaco.Environment;
+      `
+    : ''
+}
 
 const initialState = window[${JSON.stringify(INITIAL_STATE_WINDOW_PROPERTY)}];
 


### PR DESCRIPTION
Last few weeks we started getting a lot of flaky integration tests. The CI takes much longer to complete since the move to the inline editor. It's timing out quite often trying to build production apps, which is the cause of the flakyness. I noticed we were bundling the monaco workers in production apps. This is unnecessary as the editor is not being used there. On my local this removed about 3/4 of the production build time. 

* Average runtime of our pipeline is now [~22m13s](https://app.circleci.com/insights/github/mui/mui-toolpad/workflows/pipeline/overview?branch=master&reporting-window=last-7-days)
* The runtime of this PR's CI: [~15m26s](https://app.circleci.com/pipelines/github/mui/mui-toolpad/15210/workflows/0e423c96-cdfc-4919-8ede-c23bfed1ee4f) ~30% reduction in total CI time


The main reason for this PR was to fix the flaky CI, but the effect on the bundle sizes of the production Toolpad application is also profound:

master:
![Screenshot 2024-07-04 at 15 31 52](https://github.com/mui/mui-toolpad/assets/2109932/3d946bbd-f3ee-458a-83a5-32ba1b442d84)


This PR:
![Screenshot 2024-07-04 at 15 30 17](https://github.com/mui/mui-toolpad/assets/2109932/eb5c5a8d-e3ce-4e16-a683-8dd6119f9e45)



Lighthouse:

Before:

![Screenshot 2024-07-04 at 16 28 26](https://github.com/mui/mui-toolpad/assets/2109932/547fc409-757d-42fc-9e37-abd2af88f056)


After:

![Screenshot 2024-07-04 at 16 23 21](https://github.com/mui/mui-toolpad/assets/2109932/53339b29-4a75-4534-8fd0-aacbccb984de)


I address a few more low-hanging fruits in a follow-up [PR](https://github.com/mui/mui-toolpad/pull/3756)