### PR TITLE
[core] Remove lib dom from create-toolpad-app

### DIFF
--- a/packages/create-toolpad-app/src/examples.ts
+++ b/packages/create-toolpad-app/src/examples.ts
@@ -22,8 +22,6 @@ async function downloadTar(url: string) {
   invariant(response.body, 'Missing response body');
 
   let current = 0;
-  // @ts-expect-error - @types/node ReadableStream clashing with lib.dom ReadableStream
-  // https://github.com/microsoft/TypeScript/issues/29867
   const readable = Readable.fromWeb(response.body);
   readable.on('data', (chunk) => {
     process.stdout.write(

--- a/packages/create-toolpad-app/tsconfig.json
+++ b/packages/create-toolpad-app/tsconfig.json
@@ -5,10 +5,7 @@
     "target": "es2020",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "lib": [
-      "esnext",
-      "dom" // For the global fetch, remove when https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60924 is resolved
-    ],
+    "lib": ["esnext"],
     "isolatedModules": true,
     "strict": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Remove hack that is obsolete now. `fetch` is properly in the node typings now. The types now follow correctly the runtime again.