### PR TITLE
[docs] Add tabs example

### DIFF
--- a/examples/tabs/README.md
+++ b/examples/tabs/README.md
@@ -27,7 +27,7 @@ or:
 This app demonstrates the following capabilities of Toolpad:
 
 1. How to use the Tabs component
-2. How to use the COntainer component
+2. How to use the Container component
 
 ## The source
 

--- a/examples/tabs/README.md
+++ b/examples/tabs/README.md
@@ -1,0 +1,34 @@
+# Basic Tabs example
+
+<p class="description">A basic application to showcase how you can build tab switching in Toolpad Studio.</p>
+
+## How to run
+
+Use `create-toolpad-app` to bootstrap the example:
+
+```bash
+npx create-toolpad-app@latest --example tabs
+```
+
+```bash
+yarn create toolpad-app --example tabs
+```
+
+```bash
+pnpm create toolpad-app --example tabs
+```
+
+or:
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/mui/mui-toolpad/tree/master/examples/tabs)
+
+## What's inside
+
+This app demonstrates the following capabilities of Toolpad:
+
+1. How to use the Tabs component
+2. How to use the COntainer component
+
+## The source
+
+[Check out the source code](https://github.com/mui/mui-toolpad/tree/master/examples/tabs)

--- a/examples/tabs/package.json
+++ b/examples/tabs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tabs",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "toolpad-studio dev",
+    "build": "toolpad-studio build",
+    "start": "toolpad-studio start"
+  },
+  "dependencies": {
+    "@toolpad/studio": "0.3.1"
+  }
+}

--- a/examples/tabs/toolpad/.gitignore
+++ b/examples/tabs/toolpad/.gitignore
@@ -1,0 +1,1 @@
+.generated

--- a/examples/tabs/toolpad/application.yml
+++ b/examples/tabs/toolpad/application.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/mui/mui-toolpad/v0.3.1/docs/schemas/v1/definitions.json#properties/Application
+
+apiVersion: v1
+kind: application
+spec: { authentication: {}, authorization: {} }

--- a/examples/tabs/toolpad/pages/Tabs/page.yml
+++ b/examples/tabs/toolpad/pages/Tabs/page.yml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/mui/mui-toolpad/v0.3.1/docs/schemas/v1/definitions.json#properties/Page
+
+apiVersion: v1
+kind: page
+spec:
+  title: Tabs demo
+  content:
+    - component: Tabs
+      name: tabs
+      props:
+        tabs:
+          - title: Products
+            name: products
+          - title: Orders
+            name: orders
+          - title: Invoices
+            name: invoices
+        defaultValue: products
+
+    - component: Container
+      name: container2
+      children:
+        - component: Text
+          name: text
+          props:
+            variant: h2
+            value: Products page
+      props:
+        visible:
+          $$jsExpression: tabs.value === 'products'
+    - component: Container
+      name: container1
+      children:
+        - component: Text
+          name: text1
+          props:
+            value: Orders page
+            variant: h2
+      props:
+        visible:
+          $$jsExpression: tabs.value === 'orders'
+    - component: Container
+      name: container
+      children:
+        - component: Text
+          name: text2
+          props:
+            value: Invoices page
+            variant: h2
+      props:
+        visible:
+          $$jsExpression: tabs.value === 'invoices'

--- a/packages/toolpad-studio/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-studio/src/runtime/ToolpadApp.tsx
@@ -1208,6 +1208,9 @@ function RenderedNodeContent({
             justifyContent: boundLayoutProps.horizontalAlign,
             height: node.layout?.height ?? componentConfig.defaultLayoutHeight,
             minHeight: '100%',
+            '&:empty': {
+              display: 'none',
+            },
           }}
           ref={nodeRef}
           data-toolpad-node-id={nodeId}
@@ -1229,7 +1232,7 @@ const PageRoot = React.forwardRef<HTMLDivElement, PageRootProps>(function PageRo
   ref,
 ) {
   const containerMaxWidth =
-    maxWidth === 'none' ? false : maxWidth ?? appDom.DEFAULT_CONTAINER_WIDTH;
+    maxWidth === 'none' ? false : (maxWidth ?? appDom.DEFAULT_CONTAINER_WIDTH);
   return (
     <Container ref={ref} maxWidth={containerMaxWidth}>
       <Stack data-testid="page-root" direction="column" sx={{ my: 2, gap: 1 }} {...props}>

--- a/packages/toolpad-studio/src/runtime/ToolpadApp.tsx
+++ b/packages/toolpad-studio/src/runtime/ToolpadApp.tsx
@@ -1232,7 +1232,7 @@ const PageRoot = React.forwardRef<HTMLDivElement, PageRootProps>(function PageRo
   ref,
 ) {
   const containerMaxWidth =
-    maxWidth === 'none' ? false : (maxWidth ?? appDom.DEFAULT_CONTAINER_WIDTH);
+    maxWidth === 'none' ? false : maxWidth ?? appDom.DEFAULT_CONTAINER_WIDTH;
   return (
     <Container ref={ref} maxWidth={containerMaxWidth}>
       <Stack data-testid="page-root" direction="column" sx={{ my: 2, gap: 1 }} {...props}>


### PR DESCRIPTION
Following up on https://github.com/mui/mui-toolpad/discussions/3802

* Add an example that demonstrates the method as outlined in https://github.com/mui/mui-toolpad/pull/1549
* Small fix to hide container elements when they're not visible. This avoids the gap from appearing between containers
