### PR TITLE
[fix] Use the latest version for Toolpad Core

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -216,7 +216,7 @@ function AppWrapper(props) {
         productIdentifier = {
           metadata: '',
           name: 'Toolpad Core',
-          versions: [{ text: `v0.0.1`, current: true }],
+          versions: [{ text: `v${toolpadPkgJson.version}`, current: true }],
         };
         pages = toolpadCorePages;
       }
@@ -225,7 +225,7 @@ function AppWrapper(props) {
         productIdentifier = {
           metadata: '',
           name: 'Toolpad Core',
-          versions: [{ text: `v0.0.1`, current: true }],
+          versions: [{ text: `v${toolpadPkgJson.version}`, current: true }],
         };
         pages = toolpadCorePages;
       } else if (productId === 'toolpad-studio') {


### PR DESCRIPTION
- Closes #3833 
- Removes a hard coded version number
- Version numbers are in tandem across all packages, so using the same value is okay for now