### PR TITLE
[core] Export `@mui/toolpad/internals`

### DIFF
--- a/docs/data/toolpad/core/components/page-container/ActionsPageContainer.js
+++ b/docs/data/toolpad/core/components/page-container/ActionsPageContainer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 import { PageContainer, PageContainerToolbar } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { LocalizationProvider } from '@mui/x-date-pickers-pro/LocalizationProvider';

--- a/docs/data/toolpad/core/components/page-container/ActionsPageContainer.tsx
+++ b/docs/data/toolpad/core/components/page-container/ActionsPageContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 import { PageContainer, PageContainerToolbar } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { LocalizationProvider } from '@mui/x-date-pickers-pro/LocalizationProvider';

--- a/docs/data/toolpad/core/components/page-container/BasicPageContainer.js
+++ b/docs/data/toolpad/core/components/page-container/BasicPageContainer.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 import { Paper, useTheme } from '@mui/material';
 
 const NAVIGATION = [

--- a/docs/data/toolpad/core/components/page-container/BasicPageContainer.tsx
+++ b/docs/data/toolpad/core/components/page-container/BasicPageContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 import { Paper, useTheme } from '@mui/material';
 
 const NAVIGATION = [

--- a/docs/data/toolpad/core/components/page-container/TitleBreadcrumbsPageContainer.js
+++ b/docs/data/toolpad/core/components/page-container/TitleBreadcrumbsPageContainer.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 import { Paper, useTheme } from '@mui/material';
 
 const NAVIGATION = [

--- a/docs/data/toolpad/core/components/page-container/TitleBreadcrumbsPageContainer.tsx
+++ b/docs/data/toolpad/core/components/page-container/TitleBreadcrumbsPageContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 import { Paper, useTheme } from '@mui/material';
 
 const NAVIGATION = [

--- a/docs/data/toolpad/core/introduction/TutorialDefault.js
+++ b/docs/data/toolpad/core/introduction/TutorialDefault.js
@@ -5,7 +5,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import { PageContainer } from '@toolpad/core/PageContainer';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 
 const NAVIGATION = [
   {

--- a/docs/data/toolpad/core/introduction/TutorialDefault.tsx
+++ b/docs/data/toolpad/core/introduction/TutorialDefault.tsx
@@ -4,7 +4,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import { AppProvider, Navigation } from '@toolpad/core/AppProvider';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import { PageContainer } from '@toolpad/core/PageContainer';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 
 const NAVIGATION: Navigation = [
   {

--- a/docs/data/toolpad/core/introduction/TutorialPages.js
+++ b/docs/data/toolpad/core/introduction/TutorialPages.js
@@ -5,7 +5,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { Typography } from '@mui/material';
 

--- a/docs/data/toolpad/core/introduction/TutorialPages.tsx
+++ b/docs/data/toolpad/core/introduction/TutorialPages.tsx
@@ -4,7 +4,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import { AppProvider, Navigation } from '@toolpad/core/AppProvider';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { Typography } from '@mui/material';
 

--- a/docs/src/components/landing-core/ToolpadPageContainerDemo.tsx
+++ b/docs/src/components/landing-core/ToolpadPageContainerDemo.tsx
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper';
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { PageContainer } from '@toolpad/core/PageContainer';
-import { useDemoRouter } from '@toolpad/core/internals/demo';
+import { useDemoRouter } from '@toolpad/core/internals';
 
 const code = `
 <PageContainer>

--- a/packages/toolpad-core/src/internals/index.tsx
+++ b/packages/toolpad-core/src/internals/index.tsx
@@ -1,0 +1,1 @@
+export * from './demo';


### PR DESCRIPTION
Make `@mui/toolpad/internals` a top-level export. This is analog to `@mui/x-data-grid`. This export was always the intention, `@mui/tooplad/internals/core` just got auto imported by accident.