### PR TITLE
[docs] Add PageContainer content and make the theme follow the docs theme

### DIFF
--- a/docs/src/components/landing-core/ToolpadPageContainerDemo.tsx
+++ b/docs/src/components/landing-core/ToolpadPageContainerDemo.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 import Frame from 'docs/src/components/action/Frame';
 import Paper from '@mui/material/Paper';
+import DemoSandbox from 'docs/src/modules/components/DemoSandbox';
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { useDemoRouter } from '@toolpad/core/internals';
+import Grid from '@mui/material/Grid2';
+import { extendTheme, styled, useTheme } from '@mui/material/styles';
 
 const code = `
 <PageContainer>
@@ -17,16 +20,44 @@ const NAVIGATION = [
   { segment: 'orders', title: 'Orders' },
 ];
 
+const PlaceHolder = styled('div')<{ height: number }>(({ theme, height }) => ({
+  border: `1px solid ${theme.palette.divider}`,
+  height,
+  borderRadius: theme.shape.borderRadius,
+}));
+
 function PageContainerDemp() {
   const router = useDemoRouter('/orders');
+  const theme = useTheme();
+  const demoTheme = React.useMemo(
+    () =>
+      extendTheme({
+        colorSchemes: {
+          [theme.palette.mode === 'light' ? 'light' : 'dark']: true,
+        },
+      }),
+    [theme.palette.mode],
+  );
   return (
-    <AppProvider navigation={NAVIGATION} router={router}>
-      <Paper sx={{ width: '100%', height: { sm: 200, md: 400 } }}>
-        <PageContainer>Page content</PageContainer>
-      </Paper>
+    <AppProvider navigation={NAVIGATION} router={router} theme={demoTheme}>
+      <PageContainer>
+        <Grid container spacing={2}>
+          <Grid size={6}>
+            <PlaceHolder height={100} />
+          </Grid>
+          <Grid size={6}>
+            <PlaceHolder height={100} />
+          </Grid>
+          <Grid size={12}>
+            <PlaceHolder height={200} />
+          </Grid>
+        </Grid>
+      </PageContainer>
     </AppProvider>
   );
 }
+
+const NOOP = () => {};
 
 export default function ToolpadPageContainerDemo() {
   return (
@@ -47,7 +78,14 @@ export default function ToolpadPageContainerDemo() {
             }),
           })}
         >
-          <PageContainerDemp />
+          <DemoSandbox
+            iframe
+            name="DashboardLayout"
+            onResetDemoClick={NOOP}
+            productId="toolpad-core"
+          >
+            <PageContainerDemp />
+          </DemoSandbox>
         </Paper>
       </Frame.Demo>
       <Frame.Info data-mui-color-scheme="dark" sx={{ maxHeight: 600, overflow: 'auto' }}>


### PR DESCRIPTION
* Add some dummy content
* Make the theme color scheme follow the docs theme

[preview](https://deploy-preview-3895--mui-toolpad-docs.netlify.app/toolpad/core/)

![Screenshot 2024-08-05 at 16 04 16](https://github.com/user-attachments/assets/843a0414-6cfc-46e5-a9f9-973337113d09)
