### PR TITLE
fix: Support `require`

### DIFF
--- a/packages/toolpad-core/package.json
+++ b/packages/toolpad-core/package.json
@@ -8,11 +8,13 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./build/index.d.ts",
-      "default": "./build/index.js"
+      "import": "./build/index.js",
+      "require": "./build/node/index.js"
     },
     "./*": {
       "types": "./build/*/index.d.ts",
-      "default": "./build/*/index.js"
+      "import": "./build/*/index.js",
+      "require": "./build/node/*/index.js"
     }
   },
   "keywords": [


### PR DESCRIPTION
- Extracting some fixes from https://github.com/mui/mui-toolpad/pull/3906/