### PR TITLE
[docs] upgrade monorepo

### DIFF
--- a/docs/data/toolpad/core/components/page-container/ActionsPageContainer.js
+++ b/docs/data/toolpad/core/components/page-container/ActionsPageContainer.js
@@ -9,7 +9,8 @@ import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import Button from '@mui/material/Button';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import dayjs from 'dayjs';
-import { Paper, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
 import PageContent from './PageContent';
 
 const NAVIGATION = [

--- a/docs/data/toolpad/core/components/page-container/ActionsPageContainer.tsx
+++ b/docs/data/toolpad/core/components/page-container/ActionsPageContainer.tsx
@@ -9,7 +9,8 @@ import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import Button from '@mui/material/Button';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import dayjs from 'dayjs';
-import { Paper, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
 import PageContent from './PageContent';
 
 const NAVIGATION = [

--- a/docs/data/toolpad/core/components/page-container/BasicPageContainer.js
+++ b/docs/data/toolpad/core/components/page-container/BasicPageContainer.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { useDemoRouter } from '@toolpad/core/internals';
-import { Paper, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
 
 const NAVIGATION = [
   { segment: '', title: 'Home' },

--- a/docs/data/toolpad/core/components/page-container/BasicPageContainer.tsx
+++ b/docs/data/toolpad/core/components/page-container/BasicPageContainer.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { useDemoRouter } from '@toolpad/core/internals';
-import { Paper, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
 
 const NAVIGATION = [
   { segment: '', title: 'Home' },

--- a/docs/data/toolpad/core/components/page-container/TitleBreadcrumbsPageContainer.js
+++ b/docs/data/toolpad/core/components/page-container/TitleBreadcrumbsPageContainer.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { useDemoRouter } from '@toolpad/core/internals';
-import { Paper, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
 
 const NAVIGATION = [
   {

--- a/docs/data/toolpad/core/components/page-container/TitleBreadcrumbsPageContainer.tsx
+++ b/docs/data/toolpad/core/components/page-container/TitleBreadcrumbsPageContainer.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
 import { AppProvider } from '@toolpad/core/AppProvider';
 import { useDemoRouter } from '@toolpad/core/internals';
-import { Paper, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
 
 const NAVIGATION = [
   {

--- a/docs/data/toolpad/core/components/use-notifications/ScopedNotification.js
+++ b/docs/data/toolpad/core/components/use-notifications/ScopedNotification.js
@@ -4,7 +4,9 @@ import {
   useNotifications,
 } from '@toolpad/core/useNotifications';
 import Button from '@mui/material/Button';
-import { Box, Snackbar, styled } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Snackbar from '@mui/material/Snackbar';
 
 const notificationsProviderSlots = {
   snackbar: styled(Snackbar)({ position: 'absolute' }),

--- a/docs/data/toolpad/core/components/use-notifications/ScopedNotification.tsx
+++ b/docs/data/toolpad/core/components/use-notifications/ScopedNotification.tsx
@@ -5,7 +5,9 @@ import {
   NotificationsProviderSlots,
 } from '@toolpad/core/useNotifications';
 import Button from '@mui/material/Button';
-import { Box, Snackbar, styled } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Snackbar from '@mui/material/Snackbar';
 
 const notificationsProviderSlots: NotificationsProviderSlots = {
   snackbar: styled(Snackbar)({ position: 'absolute' }),

--- a/docs/data/toolpad/core/introduction/TutorialPages.js
+++ b/docs/data/toolpad/core/introduction/TutorialPages.js
@@ -7,7 +7,7 @@ import { AppProvider } from '@toolpad/core/AppProvider';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import { useDemoRouter } from '@toolpad/core/internals';
 import { PageContainer } from '@toolpad/core/PageContainer';
-import { Typography } from '@mui/material';
+import Typography from '@mui/material/Typography';
 
 const NAVIGATION = [
   {

--- a/docs/data/toolpad/core/introduction/TutorialPages.tsx
+++ b/docs/data/toolpad/core/introduction/TutorialPages.tsx
@@ -6,7 +6,7 @@ import { AppProvider, Navigation } from '@toolpad/core/AppProvider';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import { useDemoRouter } from '@toolpad/core/internals';
 import { PageContainer } from '@toolpad/core/PageContainer';
-import { Typography } from '@mui/material';
+import Typography from '@mui/material/Typography';
 
 const NAVIGATION: Navigation = [
   {

--- a/docs/data/toolpad/core/introduction/tutorial.md
+++ b/docs/data/toolpad/core/introduction/tutorial.md
@@ -64,7 +64,7 @@ yarn && yarn dev
 1. To add a new page and make it appear in the sidebar navigation, create a new folder within the `(dashboard)` directory titled `page-2` and add the following content to `page.tsx` inside it:
 
 ```tsx title="./(dashboard)/page-2/page.tsx"
-import { Typography } from '@mui/material';
+import Typography from '@mui/material/Typography';
 
 export default function Home() {
   return (

--- a/docs/data/toolpad/studio/components/button/ButtonColor.js
+++ b/docs/data/toolpad/studio/components/button/ButtonColor.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@toolpad/studio-components';
-import { Stack } from '@mui/material';
+import Stack from '@mui/material/Stack';
 
 const TOOLPAD_PROPS1 = {
   color: 'primary',

--- a/docs/data/toolpad/studio/components/button/ButtonState.js
+++ b/docs/data/toolpad/studio/components/button/ButtonState.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@toolpad/studio-components';
-import { Stack } from '@mui/material';
+import Stack from '@mui/material/Stack';
 
 const TOOLPAD_PROPS1 = {
   content: 'Loading',

--- a/docs/data/toolpad/studio/components/button/ButtonVariant.js
+++ b/docs/data/toolpad/studio/components/button/ButtonVariant.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@toolpad/studio-components';
-import { Stack } from '@mui/material';
+import Stack from '@mui/material/Stack';
 
 const TOOLPAD_PROPS1 = {
   variant: 'contained',

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,3 +1,3 @@
-import MyDocument from '@mui/monorepo/docs/pages/_document';
+import MyDocument from 'docs/pages/_document';
 
 export default MyDocument;

--- a/docs/pages/toolpad/core/react-use-notifications/index.js
+++ b/docs/pages/toolpad/core/react-use-notifications/index.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docs-toolpad/data/toolpad/core/components/use-notifications/use-notifications.md?muiMarkdown';
 import { NotificationsProvider } from '@toolpad/core/useNotifications';
-import { Snackbar, createTheme, useTheme, ThemeProvider } from '@mui/material';
+import { createTheme, useTheme, ThemeProvider } from '@mui/material/styles';
+import Snackbar from '@mui/material/Snackbar';
 
 function DemoThemedSnackbar(props) {
   const outerTheme = useTheme();

--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
-import SvgToolpadLogo from 'docs/src/icons/SvgToolpadLogo';
+import SvgToolpadLogo from 'docs/src/icons/SvgToolpadStudioLogo';
 import Box from '@mui/material/Box';
 import GradientText from 'docs/src/components/typography/GradientText';
-import { Container } from '@mui/material';
+import Container from '@mui/material/Container';
 import GetStartedButtons from './GetStartedButtons';
 
 export default function Hero() {

--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
-import SvgToolpadLogo from 'docs/src/icons/SvgToolpadStudioLogo';
+import SvgToolpadLogo from 'docs/src/icons/SvgToolpadCoreLogo';
 import Box from '@mui/material/Box';
 import GradientText from 'docs/src/components/typography/GradientText';
 import Container from '@mui/material/Container';

--- a/docs/src/components/landing/ToolpadDashboardLayout.tsx
+++ b/docs/src/components/landing/ToolpadDashboardLayout.tsx
@@ -12,7 +12,7 @@ import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import { PageContainer, type Navigation } from '@toolpad/core';
 import DemoSandbox from 'docs/src/modules/components/DemoSandbox';
 import Grid from '@mui/material/Grid2';
-import { styled } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import Frame from '../../modules/components/Frame';
 
 const code = `

--- a/docs/src/modules/components/SchemaReference.tsx
+++ b/docs/src/modules/components/SchemaReference.tsx
@@ -4,15 +4,11 @@ import AppLayoutDocs from '@mui/monorepo/docs/src/modules/components/AppLayoutDo
 import Ad from '@mui/monorepo/docs/src/modules/components/Ad';
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import KeyboardArrowRightRoundedIcon from '@mui/icons-material/KeyboardArrowRightRounded';
-import {
-  ButtonBase,
-  Collapse,
-  Tooltip,
-  TooltipProps,
-  Typography,
-  styled,
-  tooltipClasses,
-} from '@mui/material';
+import ButtonBase from '@mui/material/ButtonBase';
+import Collapse from '@mui/material/Collapse';
+import Tooltip, { tooltipClasses, TooltipProps } from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
 import invariant from 'invariant';
 import clsx from 'clsx';
 import { SectionTitle } from '@mui/docs/SectionTitle';

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mui/internal-docs-utils": "1.0.9",
     "@mui/internal-markdown": "1.0.9",
     "@mui/internal-scripts": "1.0.15",
-    "@mui/monorepo": "github:mui/material-ui#85a3b55d22570881db6ac1b99181ef79c18fc58d",
+    "@mui/monorepo": "github:mui/material-ui#b9a041d089cb50067b853b18fe2b140b2e2f0810",
     "@mui/x-charts": "7.12.0",
     "@next/eslint-plugin-next": "14.2.5",
     "@playwright/test": "1.45.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: 1.0.15
         version: 1.0.15
       '@mui/monorepo':
-        specifier: github:mui/material-ui#85a3b55d22570881db6ac1b99181ef79c18fc58d
-        version: https://codeload.github.com/mui/material-ui/tar.gz/85a3b55d22570881db6ac1b99181ef79c18fc58d(encoding@0.1.13)
+        specifier: github:mui/material-ui#b9a041d089cb50067b853b18fe2b140b2e2f0810
+        version: https://codeload.github.com/mui/material-ui/tar.gz/b9a041d089cb50067b853b18fe2b140b2e2f0810(encoding@0.1.13)
       '@mui/x-charts':
         specifier: 7.12.0
         version: 7.12.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@mui/material@6.0.0-beta.5(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3015,10 +3015,10 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/85a3b55d22570881db6ac1b99181ef79c18fc58d':
-    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/85a3b55d22570881db6ac1b99181ef79c18fc58d}
-    version: 6.0.0-beta.4
-    engines: {pnpm: 9.5.0}
+  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/b9a041d089cb50067b853b18fe2b140b2e2f0810':
+    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/b9a041d089cb50067b853b18fe2b140b2e2f0810}
+    version: 6.0.0-beta.5
+    engines: {pnpm: 9.6.0}
 
   '@mui/private-theming@5.16.6':
     resolution: {integrity: sha512-rAk+Rh8Clg7Cd7shZhyt2HGTTE5wYKNSJ5sspf28Fqm/PZ69Er9o6KX25g03/FG2dfpg5GCwZh/xOojiTfm3hw==}
@@ -12192,7 +12192,7 @@ snapshots:
       '@emotion/styled': 11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)
       '@types/react': 18.3.3
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/85a3b55d22570881db6ac1b99181ef79c18fc58d(encoding@0.1.13)':
+  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/b9a041d089cb50067b853b18fe2b140b2e2f0810(encoding@0.1.13)':
     dependencies:
       '@googleapis/sheets': 8.0.0(encoding@0.1.13)
       '@netlify/functions': 2.8.1


### PR DESCRIPTION
This brings the latest menu changes to Toolpad docs

![Screenshot 2024-08-08 at 15 29 20](https://github.com/user-attachments/assets/79493943-946b-400f-aeef-8cb5dd5140b3)

[preview](https://deploy-preview-3911--mui-toolpad-docs.netlify.app/toolpad/)