### PR TITLE
[core] Refix mobile menu closing when link is clicked

### DIFF
--- a/docs/src/components/landing/ToolpadDashboardLayout.tsx
+++ b/docs/src/components/landing/ToolpadDashboardLayout.tsx
@@ -65,7 +65,7 @@ const NAVIGATION: Navigation = [
 function DashboardLayoutBasic(props: DemoProps) {
   const { window } = props;
 
-  const [pathname, setPathname] = React.useState('/page');
+  const [pathname, setPathname] = React.useState('/dashboard');
 
   const router = React.useMemo<Router>(() => {
     return {
@@ -159,7 +159,7 @@ const PlaceHolder = styled('div')<{ height: number }>(({ theme, height }) => ({
 function DashboardLayoutBasic(props: DemoProps) {
   const { window } = props;
 
-  const [pathname, setPathname] = React.useState('/page');
+  const [pathname, setPathname] = React.useState('/dashboard');
 
   const router = React.useMemo<Router>(() => {
     return {

--- a/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx
@@ -183,7 +183,7 @@ function DashboardSidebarSubNavigation({
     initialExpandedSidebarItemIds,
   );
 
-  const handleNavigationLinkClick = React.useCallback(
+  const handleLinkClick = React.useCallback(
     (item: NavigationPageItem) => () => {
       if (onSidebarLinkClick) {
         onSidebarLinkClick(item);
@@ -262,7 +262,7 @@ function DashboardSidebarSubNavigation({
                 : {
                     LinkComponent: Link,
                     href: navigationItemFullPath,
-                    onClick: handleNavigationLinkClick(navigationItem),
+                    onClick: handleLinkClick(navigationItem),
                   })}
             >
               {navigationItem.icon ? (

--- a/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx
@@ -148,7 +148,7 @@ interface DashboardSidebarSubNavigationProps {
   subNavigation: Navigation;
   basePath?: string;
   depth?: number;
-  onSidebarItemClick?: (item: NavigationPageItem) => void;
+  onSidebarLinkClick?: (item: NavigationPageItem) => void;
   validatedItemIds: Set<string>;
   uniqueItemPaths: Set<string>;
 }
@@ -157,7 +157,7 @@ function DashboardSidebarSubNavigation({
   subNavigation,
   basePath = '',
   depth = 0,
-  onSidebarItemClick,
+  onSidebarLinkClick,
   validatedItemIds,
   uniqueItemPaths,
 }: DashboardSidebarSubNavigationProps) {
@@ -181,6 +181,15 @@ function DashboardSidebarSubNavigation({
 
   const [expandedSidebarItemIds, setExpandedSidebarItemIds] = React.useState(
     initialExpandedSidebarItemIds,
+  );
+
+  const handleNavigationLinkClick = React.useCallback(
+    (item: NavigationPageItem) => () => {
+      if (onSidebarLinkClick) {
+        onSidebarLinkClick(item);
+      }
+    },
+    [onSidebarLinkClick],
   );
 
   const handleOpenFolderClick = React.useCallback(
@@ -253,6 +262,7 @@ function DashboardSidebarSubNavigation({
                 : {
                     LinkComponent: Link,
                     href: navigationItemFullPath,
+                    onClick: handleNavigationLinkClick(navigationItem),
                   })}
             >
               {navigationItem.icon ? (
@@ -298,7 +308,7 @@ function DashboardSidebarSubNavigation({
                   subNavigation={navigationItem.children}
                   basePath={navigationItemFullPath}
                   depth={depth + 1}
-                  onSidebarItemClick={onSidebarItemClick}
+                  onSidebarLinkClick={onSidebarLinkClick}
                   validatedItemIds={validatedItemIds}
                   uniqueItemPaths={uniqueItemPaths}
                 />
@@ -371,7 +381,7 @@ function DashboardLayout(props: DashboardLayoutProps) {
       <Box component="nav" sx={{ overflow: 'auto', pt: navigation[0]?.kind === 'header' ? 0 : 2 }}>
         <DashboardSidebarSubNavigation
           subNavigation={navigation}
-          onSidebarItemClick={handleNavigationItemClick}
+          onSidebarLinkClick={handleNavigationItemClick}
           validatedItemIds={validatedItemIdsRef.current}
           uniqueItemPaths={uniqueItemPathsRef.current}
         />


### PR DESCRIPTION
Not sure if this had been removed intentionally though.

https://github.com/user-attachments/assets/c90be287-9989-48e8-a005-5564dc4678bd

https://deploy-preview-3915--mui-toolpad-docs.netlify.app/toolpad

Also fix initial page in home page example as I noticed it wasn't correct.
