### PR TITLE
[docs] Improve textfield docs and re-establish links to Material UI components

### DIFF
--- a/docs/data/toolpad/studio/components/text-field/TextFieldMinlength.js
+++ b/docs/data/toolpad/studio/components/text-field/TextFieldMinlength.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { TextField } from '@toolpad/studio-components';
+
+export default function TextFieldMinlength() {
+  return (
+    <TextField
+      label="Password"
+      size="small"
+      minLength="6"
+      placeholder="Enter password"
+      password
+      isRequired
+    />
+  );
+}

--- a/docs/data/toolpad/studio/components/text-field/text-field.md
+++ b/docs/data/toolpad/studio/components/text-field/text-field.md
@@ -75,7 +75,9 @@ isRequired is useful when the action can't be perfomed without a user provided t
 
 ### minLength
 
-A validation check on the minimum length of the input.
+A validation check on the minimum length of the input. The below demo showcases password, isRequired and minLength props. These props are available as configurations in the Toolpad Studio editor.
+
+{{"demo": "TextFieldMinlength.js", "hideToolbar": true}}
 
 ### maxLength
 

--- a/packages/toolpad-studio-components/src/Button.tsx
+++ b/packages/toolpad-studio-components/src/Button.tsx
@@ -13,7 +13,7 @@ function Button({ content, ...rest }: ButtonProps) {
 
 export default createBuiltin(Button, {
   helperText:
-    'The Material UI [Button](https://mui.com/toolpad/studio/components/button/) component.\n\nButtons allow users to take actions, and make choices, with a single tap.',
+    'The Material UI [Button](https://mui.com/material-ui/react-button/) component.\n\nButtons allow users to take actions, and make choices, with a single tap.',
   layoutDirection: 'both',
   argTypes: {
     onClick: {

--- a/packages/toolpad-studio-components/src/DataGrid.tsx
+++ b/packages/toolpad-studio-components/src/DataGrid.tsx
@@ -1370,7 +1370,7 @@ const DataGridComponent = React.forwardRef(function DataGridComponent(
 
 export default createBuiltin(DataGridComponent, {
   helperText:
-    'The [MUI X Data Grid](https://mui.com/toolpad/studio/components/data-grid/) component.\n\nThe datagrid lets users display tabular data in a flexible grid.',
+    'The [MUI X Data Grid](https://mui.com/x/react-data-grid/) component.\n\nThe datagrid lets users display tabular data in a flexible grid.',
   errorProp: 'error',
   loadingPropSource: ['rows', 'columns'],
   loadingProp: 'loading',

--- a/packages/toolpad-studio-components/src/DatePicker.tsx
+++ b/packages/toolpad-studio-components/src/DatePicker.tsx
@@ -159,7 +159,7 @@ const FormWrappedDatePicker = withComponentForm(DatePicker);
 
 export default createBuiltin(FormWrappedDatePicker, {
   helperText:
-    'The [MUI X Date Picker](https://mui.com/toolpad/studio/components/date-picker/) component.\n\nThe date picker lets the user select a date.',
+    'The [MUI X Date Picker](https://mui.com/x/react-date-pickers/date-picker/) component.\n\nThe date picker lets the user select a date.',
   argTypes: {
     value: {
       helperText: 'The currently selected date.',

--- a/packages/toolpad-studio-components/src/TextField.tsx
+++ b/packages/toolpad-studio-components/src/TextField.tsx
@@ -70,7 +70,7 @@ const FormWrappedTextField = withComponentForm(TextField);
 
 export default createBuiltin(FormWrappedTextField, {
   helperText:
-    'The Material UI [TextField](https://mui.com/toolpad/studio/components/text-field/) component lets you input a text value.',
+    'The Material UI [TextField](https://mui.com/material-ui/react-text-field/) component lets you input a text value.',
   layoutDirection: 'both',
   argTypes: {
     value: {

--- a/packages/toolpad-studio-components/src/constants.tsx
+++ b/packages/toolpad-studio-components/src/constants.tsx
@@ -1,2 +1,2 @@
 export const SX_PROP_HELPER_TEXT =
-  'The [`sx` prop](https://mui.com/toolpad/studio/concepts/theming/#overrides) is used for defining custom styles that have access to the theme. All MUI System properties are available via the `sx` prop. In addition, the `sx` prop allows you to specify any other CSS rules you may need.';
+  'The [`sx` prop](https://mui.com/system/getting-started/the-sx-prop/) is used for defining custom styles that have access to the theme. All MUI System properties are available via the `sx` prop. In addition, the `sx` prop allows you to specify any other CSS rules you may need.';


### PR DESCRIPTION
Address: https://github.com/mui/mui-toolpad/issues/3675#issuecomment-2178553160