### PR TITLE
[website] Fix brand copy

### DIFF
--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -67,7 +67,7 @@ export default function Hero() {
             color="text.secondary"
             sx={{ maxWidth: 620, mb: 3, textWrap: 'balance', textAlign: 'center' }}
           >
-            From the creators of MUI, Toolpad Core offers the components needed for your next admin
+            From the creators of Material UI, Toolpad Core offers the components needed for your next admin
             panel and internal tools project. Bootstrap from scratch in our CLI with well chosen
             defaults, or drop Toolpad Core into your existing Next.js or Vite* project.
           </Typography>

--- a/docs/src/components/landing/Hero.js
+++ b/docs/src/components/landing/Hero.js
@@ -67,9 +67,9 @@ export default function Hero() {
             color="text.secondary"
             sx={{ maxWidth: 620, mb: 3, textWrap: 'balance', textAlign: 'center' }}
           >
-            From the creators of Material UI, Toolpad Core offers the components needed for your next admin
-            panel and internal tools project. Bootstrap from scratch in our CLI with well chosen
-            defaults, or drop Toolpad Core into your existing Next.js or Vite* project.
+            From the creators of Material UI, Toolpad Core offers the components needed for your
+            next admin panel and internal tools project. Bootstrap from scratch in our CLI with well
+            chosen defaults, or drop Toolpad Core into your existing Next.js or Vite* project.
           </Typography>
         </Box>
         <Box


### PR DESCRIPTION
- "From the creators of MUI" -> "From the creators of Material UI"