### PR TITLE
[docs] Fix Core docs navigation sidebar links

### DIFF
--- a/docs/data/toolpad/core/pages.ts
+++ b/docs/data/toolpad/core/pages.ts
@@ -61,6 +61,12 @@ const pages: MuiPage[] = [
             pathname: '/toolpad/core/react-page-container',
             title: 'Page Container',
           },
+        ],
+      },
+      {
+        pathname: '/toolpad/core/authentication-group',
+        subheader: 'Authentication',
+        children: [
           {
             pathname: '/toolpad/core/react-sign-in-page',
             title: 'Sign-in Page',
@@ -97,24 +103,27 @@ const pages: MuiPage[] = [
     children: [
       {
         pathname: '/toolpad/core/api/components-group',
-        inSideNav: false,
         subheader: 'Components',
+        children: pagesApi,
+      },
+      {
+        pathname: '/toolpad/core/api/hooks-group',
+        subheader: 'Hooks',
         children: [
-          ...pagesApi,
           {
-            pathname: '/toolpad/core/react-use-notifications/api/',
+            pathname: '/toolpad/core/react-use-notifications/api',
             title: 'useNotifications',
           },
           {
-            pathname: '/toolpad/core/react-use-dialogs/api/',
+            pathname: '/toolpad/core/react-use-dialogs/api',
             title: 'useDialogs',
           },
           {
-            pathname: '/toolpad/core/react-persistent-state/use-local-storage-state-api/',
+            pathname: '/toolpad/core/react-persistent-state/use-local-storage-state-api',
             title: 'useLocalStorageState',
           },
           {
-            pathname: '/toolpad/core/react-persistent-state/use-session-storage-state-api/',
+            pathname: '/toolpad/core/react-persistent-state/use-session-storage-state-api',
             title: 'useSessionStorageState',
           },
         ],


### PR DESCRIPTION
- Closes #3985 
- Adds an "Authentication" sub-header for the "Components" menu
- Adds a "Hooks" sub-header for the "APIs" menu
- Fixes incorrect paths on the hooks API pages causing the sidebar item to not be focused while on its page

[preview](https://deploy-preview-3986--mui-toolpad-docs.netlify.app/toolpad/core/introduction/)