### PR TITLE
[docs] Remove the list of upcoming features

### DIFF
--- a/docs/data/toolpad/core/introduction/overview.md
+++ b/docs/data/toolpad/core/introduction/overview.md
@@ -36,8 +36,3 @@ It follows the open-core model, with some features being available under the MIT
 :::info
 Visit the [roadmap](/toolpad/core/introduction/roadmap/) to see more details about upcoming features.
 :::
-
-- [Role-based Access Control](/)
-- [Audit Logs](/)
-- [Data Providers](/)
-- [Data Grid](/)


### PR DESCRIPTION
I thought it would be better to remove the mention of any upcoming features, instead just take users to the maintained roadmap.

