### PR TITLE
[examples] Fix Dependabot warning in Next.js example with passkey

### DIFF
--- a/examples/core/auth-nextjs-passkey/package.json
+++ b/examples/core/auth-nextjs-passkey/package.json
@@ -26,7 +26,7 @@
     "@types/node": "22.5.1",
     "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
-    "eslint-config-next": "^14",    
+    "eslint-config-next": "^14",
     "prisma": "5.19.1"
   }
 }


### PR DESCRIPTION
Should fix https://github.com/mui/toolpad/security/dependabot/90