### PR TITLE
[core] Add Italian and Spanish locale translations

### DIFF
--- a/packages/toolpad-core/src/locales/esES.tsx
+++ b/packages/toolpad-core/src/locales/esES.tsx
@@ -1,0 +1,58 @@
+import type { LocaleText } from '../AppProvider';
+import { getLocalization } from './getLocalization';
+
+const esLabels: LocaleText = {
+  // Account
+  accountSignInLabel: 'Iniciar sesión',
+  accountSignOutLabel: 'Cerrar sesión',
+
+  // AccountPreview
+  accountPreviewTitle: 'Cuenta',
+  accountPreviewIconButtonLabel: 'Usuario actual',
+
+  // SignInPage
+  signInTitle: (brandingTitle?: string) =>
+    brandingTitle ? `Iniciar sesión en ${brandingTitle}` : 'Iniciar sesión',
+  signInSubtitle: 'Bienvenido usuario, por favor inicie sesión para continuar',
+  signInRememberMe: 'Recordarme',
+  providerSignInTitle: (provider: string) => `Iniciar sesión con ${provider}`,
+
+  // Common authentication labels
+  email: 'Correo electrónico',
+  password: 'Contraseña',
+  username: 'Nombre de usuario',
+  passkey: 'Clave de acceso',
+
+  // Common action labels
+  save: 'Guardar',
+  cancel: 'Cancelar',
+  ok: 'Aceptar',
+  or: 'O',
+  to: 'A',
+  with: 'Con',
+  close: 'Cerrar',
+  delete: 'Eliminar',
+  alert: 'Alerta',
+  confirm: 'Confirmar',
+  loading: 'Cargando...',
+
+  // CRUD
+  createNewButtonLabel: 'Crear nuevo',
+  reloadButtonLabel: 'Recargar datos',
+  createLabel: 'Crear',
+  createSuccessMessage: 'Elemento creado exitosamente.',
+  createErrorMessage: 'Error al crear el elemento. Razón:',
+  editLabel: 'Editar',
+  editSuccessMessage: 'Elemento editado exitosamente.',
+  editErrorMessage: 'Error al editar el elemento. Razón:',
+  deleteLabel: 'Eliminar',
+  deleteConfirmTitle: '¿Eliminar elemento?',
+  deleteConfirmMessage: '¿Desea eliminar este elemento?',
+  deleteConfirmLabel: 'Eliminar',
+  deleteCancelLabel: 'Cancelar',
+  deleteSuccessMessage: 'Elemento eliminado exitosamente.',
+  deleteErrorMessage: 'Error al eliminar el elemento. Razón:',
+  deletedItemMessage: 'Este elemento ha sido eliminado.',
+};
+
+export default getLocalization(esLabels);

--- a/packages/toolpad-core/src/locales/index.tsx
+++ b/packages/toolpad-core/src/locales/index.tsx
@@ -1,2 +1,6 @@
-export { default as hiIN } from './hiIN';
 export { default as en } from './en';
+export { default as esES } from './esES';
+export { default as hiIN } from './hiIN';
+export { default as itIT } from './itIT';
+export { default as jaJP } from './jaJP';
+export { default as skSK } from './skSK';

--- a/packages/toolpad-core/src/locales/itIT.tsx
+++ b/packages/toolpad-core/src/locales/itIT.tsx
@@ -1,0 +1,58 @@
+import type { LocaleText } from '../AppProvider';
+import { getLocalization } from './getLocalization';
+
+const itLabels: LocaleText = {
+  // Account
+  accountSignInLabel: 'Accedi',
+  accountSignOutLabel: 'Esci',
+
+  // AccountPreview
+  accountPreviewTitle: 'Account',
+  accountPreviewIconButtonLabel: 'Utente corrente',
+
+  // SignInPage
+  signInTitle: (brandingTitle?: string) =>
+    brandingTitle ? `Accedi a ${brandingTitle}` : 'Accedi',
+  signInSubtitle: 'Benvenuto, effettua l\'accesso per continuare',
+  signInRememberMe: 'Ricordami',
+  providerSignInTitle: (provider: string) => `Accedi con ${provider}`,
+
+  // Common authentication labels
+  email: 'Email',
+  password: 'Password',
+  username: 'Nome utente',
+  passkey: 'Passkey',
+
+  // Common action labels
+  save: 'Salva',
+  cancel: 'Annulla',
+  ok: 'OK',
+  or: 'O',
+  to: 'A',
+  with: 'Con',
+  close: 'Chiudi',
+  delete: 'Elimina',
+  alert: 'Avviso',
+  confirm: 'Conferma',
+  loading: 'Caricamento...',
+
+  // CRUD
+  createNewButtonLabel: 'Crea nuovo',
+  reloadButtonLabel: 'Ricarica dati',
+  createLabel: 'Crea',
+  createSuccessMessage: 'Elemento creato con successo.',
+  createErrorMessage: 'Errore durante la creazione dell\'elemento. Motivo:',
+  editLabel: 'Modifica',
+  editSuccessMessage: 'Elemento modificato con successo.',
+  editErrorMessage: 'Errore durante la modifica dell\'elemento. Motivo:',
+  deleteLabel: 'Elimina',
+  deleteConfirmTitle: 'Eliminare l\'elemento?',
+  deleteConfirmMessage: 'Vuoi eliminare questo elemento?',
+  deleteConfirmLabel: 'Elimina',
+  deleteCancelLabel: 'Annulla',
+  deleteSuccessMessage: 'Elemento eliminato con successo.',
+  deleteErrorMessage: 'Errore durante l\'eliminazione dell\'elemento. Motivo:',
+  deletedItemMessage: 'Questo elemento è stato eliminato.',
+};
+
+export default getLocalization(itLabels);


### PR DESCRIPTION
## Summary
- Add Italian (itIT) locale translations
- Add Spanish (esES) locale translations
- Sort locale exports alphabetically in index.tsx

## Test plan
- [ ] Verify translations display correctly in the app
- [ ] Check TypeScript types are satisfied