### PR TITLE
feat: pass `renderPageItem` to sub navigation items

### DIFF
--- a/packages/toolpad-core/src/DashboardLayout/DashboardSidebarSubNavigation.tsx
+++ b/packages/toolpad-core/src/DashboardLayout/DashboardSidebarSubNavigation.tsx
@@ -78,6 +78,7 @@ function DashboardSidebarSubNavigationPageItem({
           onLinkClick={onLinkClick}
           isPopover={isMini}
           sidebarExpandedWidth={sidebarExpandedWidth}
+          renderPageItem={renderPageItem}
         />
       ),
     }),


### PR DESCRIPTION
- [x] I've read and followed the [contributing guide](https://github.com/mui/toolpad/blob/master/CONTRIBUTING.md#sending-a-pull-request) on how to create great pull requests.
- [x] I've updated the relevant documentation for any new or updated feature.
- [x] I've linked relevant GitHub issue with "Closes #4581 ".
- [ ] I've added a visual demonstration in the form of a screenshot or video.

## Summary

This PR adds support for customising the render of `DashboardSidebarPageItem` for child items., addressing #4581 

## Changes

Passed the `renderPageItem` function prop to `DashboardSidebarSubNavigation` in the `renderNestedNavigation` of the `pageItemContextProps`.

## API Usage

Exactly as stated in the (docs)[https://mui.com/toolpad/core/react-dashboard-layout/#custom-page-items] but now child `DashboardSidebarPageItem` can now be customized. Given, the example in the documentation, to customise Sub-Item 1 and 2, a developer would do the following:

```tsx
const renderPageItem = React.useCallback(
    (item: NavigationPageItem, { mini }: { mini: boolean }) => {
      ...
      if (item.title === 'Custom Item') {
        return <CustomPageItem item={item} mini={mini} />;
      }
      if  (item.segment === 'sub-item-1' {
        return <CustomPageItem item={item} mini={mini} />;
      }
      if  (item.segment === 'sub-item-2' {
        return <CustomPageItem item={item} mini={mini} />;
      }
      return <DashboardSidebarPageItem item={item} />;
    },
    [],
  );
  ```
  
  It might be better to have the full path rather than the segment.
  
  ## Documentation
  
  No documentation required as the current documentation implies that this is already possible.
  
  Close #4581  